### PR TITLE
Fix the sprint glitch which results in inconsistent health.

### DIFF
--- a/patches/server/0041-Fix-sprint-glitch.patch
+++ b/patches/server/0041-Fix-sprint-glitch.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: pixelNightly <pixelnightly@proton.me>
+Date: Mon, 4 Dec 2023 16:11:36 +0200
+Subject: [PATCH] Fix sprint glitch
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 23197384963b7f67e096eff18bf1809d36611923..57e6609368bf402ece1ca28b46fd1ef5813c7159 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1422,7 +1422,8 @@ public abstract class LivingEntity extends Entity implements Attackable {
+                 player.setRealHealth(health);
+             }
+
+-            player.updateScaledHealth(false);
++                       this.entityData.set(LivingEntity.DATA_HEALTH_ID, player.getScaledHealth()); // Sprint glitch Fix by pafias
++            // player.updateScaledHealth(false); // Commented out to fix sprint glitch
+             return;
+         }
+         // CraftBukkit end


### PR DESCRIPTION
This bug has been in the game since 1.16.4 and has been annoying several of my customers. I would rather not have to make a fork of this every time I need to provision a new server.