### PR TITLE
Ability to use Virtual Thread for async scheduler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
     java
     `maven-publish`
-    id("com.github.johnrengelman.shadow") version "8.1.1" apply false
+    id("com.github.johnrengelman.shadow") version "8.1.1" apply false // paperweight required this original shadow
+    id("io.github.goooler.shadow") version "8.1.7" apply false
     id("io.papermc.paperweight.patcher") version "1.5.12-SNAPSHOT"
 }
 
@@ -26,13 +27,13 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(21))
         }
     }
 
     tasks.withType<JavaCompile> {
         options.encoding = Charsets.UTF_8.name()
-        options.release.set(17)
+        options.release.set(21)
     }
     tasks.withType<Javadoc> {
         options.encoding = Charsets.UTF_8.name()

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ galeCommit = 377da10d2e1fdd3d1bbba68813dd1996dcdbfd09
 org.gradle.caching = true
 org.gradle.parallel = true
 org.gradle.vfs.watch = false
-org.gradle.jvmargs = -Xmx4G
+org.gradle.jvmargs = -Xmx4G -Dfile.encoding=UTF8

--- a/patches/server/0073-Ability-to-use-Virtual-Thread-for-async-scheduler.patch
+++ b/patches/server/0073-Ability-to-use-Virtual-Thread-for-async-scheduler.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nostalfinals <yuu8583@proton.me>
+Date: Tue, 12 Mar 2024 00:36:29 +0800
+Subject: [PATCH] Ability to use Virtual Thread for async scheduler
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
+index 9c1aff17aabd062640e3f451a2ef8c50a7c62f10..234a92d643059e7178eeb0b4dc255bccef656851 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
++++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncScheduler.java
+@@ -26,6 +26,7 @@ package org.bukkit.craftbukkit.scheduler;
+ import com.destroystokyo.paper.ServerSchedulerReportingWrapper;
+ import com.google.common.util.concurrent.ThreadFactoryBuilder;
+ import org.bukkit.plugin.Plugin;
++import org.dreeam.leaf.config.modules.opt.VT4BukkitScheduler;
+ 
+ import java.util.ArrayList;
+ import java.util.Iterator;
+@@ -38,17 +39,30 @@ import java.util.concurrent.TimeUnit;
+ 
+ public class CraftAsyncScheduler extends CraftScheduler {
+ 
+-    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(
+-            4, Integer.MAX_VALUE,30L, TimeUnit.SECONDS, new SynchronousQueue<>(),
+-            new ThreadFactoryBuilder().setNameFormat("Craft Scheduler Thread - %1$d").setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER)).build()); // Paper
++    private final Executor executor; // Leaf - use super class
+     private final Executor management = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+             .setNameFormat("Craft Async Scheduler Management Thread").setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER)).build()); // Paper
+     private final List<CraftTask> temp = new ArrayList<>();
+ 
+     CraftAsyncScheduler() {
+         super(true);
+-        executor.allowCoreThreadTimeOut(true);
+-        executor.prestartAllCoreThreads();
++
++        // Leaf start - Ability to use Virtual Thread for async scheduler
++        if (!VT4BukkitScheduler.enabled) {
++            executor = new ThreadPoolExecutor(
++                    4, Integer.MAX_VALUE,30L, TimeUnit.SECONDS, new SynchronousQueue<>(),
++                    new ThreadFactoryBuilder().setNameFormat("Craft Scheduler Thread - %1$d").setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER)).build());
++
++            var threadPoolExecutor = (ThreadPoolExecutor) executor;
++
++            threadPoolExecutor.allowCoreThreadTimeOut(true);
++            threadPoolExecutor.prestartAllCoreThreads();
++
++            return;
++        }
++
++        executor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("Craft Scheduler Thread - %1$d").factory());
++        // Leaf end
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/dreeam/leaf/config/modules/opt/VT4BukkitScheduler.java b/src/main/java/org/dreeam/leaf/config/modules/opt/VT4BukkitScheduler.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9add2256eea4de354f7e4ada10b4d0ccb32a60a1
+--- /dev/null
++++ b/src/main/java/org/dreeam/leaf/config/modules/opt/VT4BukkitScheduler.java
+@@ -0,0 +1,29 @@
++package org.dreeam.leaf.config.modules.opt;
++
++import com.electronwill.nightconfig.core.file.CommentedFileConfig;
++import org.dreeam.leaf.config.ConfigInfo;
++import org.dreeam.leaf.config.EnumConfigCategory;
++import org.dreeam.leaf.config.IConfigModule;
++
++public class VT4BukkitScheduler implements IConfigModule {
++
++    @Override
++    public EnumConfigCategory getCategory() {
++        return EnumConfigCategory.PERFORMANCE;
++    }
++
++    @Override
++    public String getBaseName() {
++        return "use_virtual_thread_for_async_scheduler";
++    }
++
++    @ConfigInfo(baseName = "enabled")
++    public static boolean enabled = false;
++
++    @Override
++    public void onLoaded(CommentedFileConfig config) {
++        config.setComment("performance.use_virtual_thread_for_async_scheduler", """
++                 Use the new Virtual Thread introduced in JDK 21 for CraftAsyncScheduler.
++                """);
++    }
++}

--- a/patches/server/0074-Use-a-shadow-fork-that-supports-Java-21.patch
+++ b/patches/server/0074-Use-a-shadow-fork-that-supports-Java-21.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nostalfinals <yuu8583@proton.me>
+Date: Tue, 12 Mar 2024 01:10:54 +0800
+Subject: [PATCH] Use a shadow fork that supports Java 21
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 9d7cc530187263c6a4ed99df2c79d66d76749cc6..6497e2ce6720afb583dbfac5be2b7a14f8f2b632 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -3,7 +3,7 @@ import io.papermc.paperweight.util.*
+ plugins {
+     java
+     `maven-publish`
+-    id("com.github.johnrengelman.shadow")
++    id("io.github.goooler.shadow") // Leaf - use a shadow fork that supports Java 21
+ }
+ 
+ val log4jPlugins = sourceSets.create("log4jPlugins")


### PR DESCRIPTION
This patch add a option (`performance.use_virtual_thread_for_async_scheduler`) to use the new Virtual Thread introduced in JDK 21 for `CraftAsyncScheduler`.
The server jar need to be compiled using JDK 21, and at least Java 21 to run.
This feature will be disabled by default.

## TODO

- [x] Fix compiling issue while shadow plugin doesn't support Java 21 for now -> Fixed by using a shadow fork.
- [x] Test plugins which are using `BukkitScheduler` on this.
- [x] Fix `An expected class  org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftScheduler$4 was not found for preloading: org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftScheduler$4` issue by editing Spigot's preloading code. 