### PR TITLE
Async locator & Virtual thread for chat executor

### DIFF
--- a/patches/server/0090-Reduce-worldgen-allocations.patch
+++ b/patches/server/0090-Reduce-worldgen-allocations.patch
@@ -31,7 +31,7 @@ index 5e89428321d91edb893826b0eb0b9050d327d310..2bee2988b5019d81da25784ef60feb35
  
      private DensityFunction wrapNew(DensityFunction function) {
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/SurfaceRules.java b/src/main/java/net/minecraft/world/level/levelgen/SurfaceRules.java
-index 9df053ddff459d4aab478106c6e66a5fc3cda8f6..7a9b36b93032fbbfd439b8d95c82c7515616cbbd 100644
+index 9df053ddff459d4aab478106c6e66a5fc3cda8f6..24ba023c0789984dd173e982030c29406c110428 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/SurfaceRules.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/SurfaceRules.java
 @@ -314,8 +314,14 @@ public class SurfaceRules {
@@ -42,7 +42,7 @@ index 9df053ddff459d4aab478106c6e66a5fc3cda8f6..7a9b36b93032fbbfd439b8d95c82c751
 -            this.biome = Suppliers.memoize(() -> this.biomeGetter.apply(this.pos.set(blockX, blockY, blockZ)));
 +            // Leaf start - Reuse supplier object instead of creating new ones every time
 +            ++this.lastUpdateY;
-+            var getter = this.biome;
++            Supplier<Holder<Biome>> getter = this.biome;
 +            if (getter == null) {
 +                this.biome = getter = new org.dreeam.leaf.util.biome.PositionalBiomeGetter(this.biomeGetter, this.pos);
 +            }
@@ -95,7 +95,7 @@ index afdbc74a3012fa717f59ecef613567338d285b7b..b219a5c1a489f337ceb96a80246fa8c8
  }
 diff --git a/src/main/java/org/dreeam/leaf/util/biome/PositionalBiomeGetter.java b/src/main/java/org/dreeam/leaf/util/biome/PositionalBiomeGetter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2385f09404274aa650d082e2928deab847b570a0
+index 0000000000000000000000000000000000000000..3683c61ebc673cf5d2f8197fffdf44270f1287f4
 --- /dev/null
 +++ b/src/main/java/org/dreeam/leaf/util/biome/PositionalBiomeGetter.java
 @@ -0,0 +1,36 @@
@@ -128,8 +128,8 @@ index 0000000000000000000000000000000000000000..2385f09404274aa650d082e2928deab8
 +
 +    @Override
 +    public Holder<Biome> get() {
-+        var biome = curBiome;
-+        if(biome == null) {
++        Holder<Biome> biome = curBiome;
++        if (biome == null) {
 +            curBiome = biome = biomeGetter.apply(pos.set(nextX, nextY, nextZ));
 +        }
 +        return biome;

--- a/patches/server/0107-Multithreaded-Tracker.patch
+++ b/patches/server/0107-Multithreaded-Tracker.patch
@@ -40,7 +40,7 @@ index e42677bb004201efe1702779a78cc8d0ca05e80f..6676be8304e9415099ed423d3315180c
          }
          // Leaves start - skip photographer
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 6985da233e41a62bea04277260f81b3ba200a415..965c147a5d9c300be19418d56736e5719dd10ad4 100644
+index 6985da233e41a62bea04277260f81b3ba200a415..58e79417e3722ce73cbbc1f9c74cbc73178f762d 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -234,6 +234,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -106,20 +106,22 @@ index 6985da233e41a62bea04277260f81b3ba200a415..965c147a5d9c300be19418d56736e571
  
          // Paper start - optimise entity tracker
          private long lastChunkUpdate = -1L;
-@@ -1182,6 +1215,37 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1181,7 +1214,39 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+             this.lastTrackedChunk = chunk;
  
              final ServerPlayer[] playersRaw = players.getRawDataUnchecked();
- 
++            final int playersLen = players.size(); // Ensure length won't change in the future tasks
++
 +            // Leaf start - Multithreaded tracker
 +            if (org.dreeam.leaf.config.modules.async.MultithreadedTracker.enabled && org.dreeam.leaf.config.modules.async.MultithreadedTracker.compatModeEnabled) {
 +                final boolean isServerPlayer = this.entity instanceof ServerPlayer;
 +                final boolean isRealPlayer = isServerPlayer && ((ca.spottedleaf.moonrise.patches.chunk_system.player.ChunkSystemServerPlayer) this.entity).moonrise$isRealPlayer();
 +                Runnable updatePlayerTasks = () -> {
-+                    for (int i = 0, len = players.size(); i < len; ++i) {
++                    for (int i = 0; i < playersLen; ++i) {
 +                        final ServerPlayer player = playersRaw[i];
 +                        this.updatePlayer(player);
 +                    }
-+
+ 
 +                    if (lastChunkUpdate != currChunkUpdate || lastTrackedChunk != chunk) {
 +                        // need to purge any players possible not in the chunk list
 +                        for (final ServerPlayerConnection conn : new java.util.ArrayList<>(this.seenBy)) {
@@ -144,7 +146,7 @@ index 6985da233e41a62bea04277260f81b3ba200a415..965c147a5d9c300be19418d56736e571
              for (int i = 0, len = players.size(); i < len; ++i) {
                  final ServerPlayer player = playersRaw[i];
                  this.updatePlayer(player);
-@@ -1196,6 +1260,8 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1196,6 +1261,8 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                      }
                  }
              }
@@ -153,7 +155,7 @@ index 6985da233e41a62bea04277260f81b3ba200a415..965c147a5d9c300be19418d56736e571
          }
  
          @Override
-@@ -1250,14 +1316,11 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1250,14 +1317,11 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          }
  
          public void broadcast(Packet<?> packet) {
@@ -171,7 +173,7 @@ index 6985da233e41a62bea04277260f81b3ba200a415..965c147a5d9c300be19418d56736e571
          }
  
          public void broadcastAndSend(Packet<?> packet) {
-@@ -1269,18 +1332,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1269,18 +1333,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          }
  
          public void broadcastRemoved() {
@@ -194,7 +196,7 @@ index 6985da233e41a62bea04277260f81b3ba200a415..965c147a5d9c300be19418d56736e571
              if (this.seenBy.remove(player.connection)) {
                  this.serverEntity.removePairing(player);
              }
-@@ -1288,8 +1348,9 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1288,8 +1349,9 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          }
  
          public void updatePlayer(ServerPlayer player) {

--- a/patches/server/0115-Fix-MC-177381.patch
+++ b/patches/server/0115-Fix-MC-177381.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Wed, 23 Oct 2024 20:20:16 +0800
+Subject: [PATCH] Fix MC-177381
+
+Related MC issue: https://bugs.mojang.com/browse/MC-177381
+
+diff --git a/src/main/java/net/minecraft/server/commands/LocateCommand.java b/src/main/java/net/minecraft/server/commands/LocateCommand.java
+index 74a00a9b636b7457c54f9e76f60432de1701239b..39f5deea47d8f573c3cfec5df431216ee806c32c 100644
+--- a/src/main/java/net/minecraft/server/commands/LocateCommand.java
++++ b/src/main/java/net/minecraft/server/commands/LocateCommand.java
+@@ -197,8 +197,10 @@ public class LocateCommand {
+     }
+ 
+     private static float dist(int x1, int y1, int x2, int y2) {
+-        int i = x2 - x1;
+-        int j = y2 - y1;
+-        return Mth.sqrt((float)(i * i + j * j));
++        // Leaf start - Fix distance overflow MC-177381
++        double i = x2 - x1;
++        double j = y2 - y1;
++        return (float) Math.hypot(i, j);
++        // Leaf end - Fix distance overflow MC-177381
+     }
+ }

--- a/patches/server/0116-Asynchronous-locator.patch
+++ b/patches/server/0116-Asynchronous-locator.patch
@@ -1,0 +1,335 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Wed, 23 Oct 2024 23:54:00 +0800
+Subject: [PATCH] Asynchronous locator
+
+
+diff --git a/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java b/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java
+index 11b7f15755dde766140c29bedca456c80d53293f..0b9a2448999826eef362589078688d6f5f69e4e6 100644
+--- a/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java
++++ b/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java
+@@ -90,6 +90,13 @@ public class TickThread extends Thread {
+     }
+ 
+     public static boolean isTickThread() {
++        // Leaf start - Async locator
++        if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled) {
++            Thread currentThread = Thread.currentThread();
++            return currentThread instanceof TickThread ||
++                    currentThread instanceof org.dreeam.leaf.async.locate.AsyncLocator.AsyncLocatorThread;
++        }
++        // Leaf end - Async locator
+         return Thread.currentThread() instanceof TickThread;
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/commands/LocateCommand.java b/src/main/java/net/minecraft/server/commands/LocateCommand.java
+index 39f5deea47d8f573c3cfec5df431216ee806c32c..51994f272737f8754aac41dc0c55f43f45617519 100644
+--- a/src/main/java/net/minecraft/server/commands/LocateCommand.java
++++ b/src/main/java/net/minecraft/server/commands/LocateCommand.java
+@@ -106,6 +106,37 @@ public class LocateCommand {
+         BlockPos blockPos = BlockPos.containing(source.getPosition());
+         ServerLevel serverLevel = source.getLevel();
+         Stopwatch stopwatch = Stopwatch.createStarted(Util.TICKER);
++        // Leaf start - Async locator
++        if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled) {
++            net.minecraft.commands.CommandSource locatorSource = source.source;
++            if (locatorSource instanceof net.minecraft.server.level.ServerPlayer ||
++                locatorSource instanceof net.minecraft.server.MinecraftServer) {
++                BlockPos originPos = BlockPos.containing(source.getPosition());
++                org.dreeam.leaf.async.locate.AsyncLocator.locate(source.getLevel(), holderSet, originPos, 100, false)
++                        .thenOnServerThread(pair -> {
++                            stopwatch.stop();
++                            if (pair != null) {
++                                showLocateResult(
++                                        source,
++                                        predicate,
++                                        originPos,
++                                        pair,
++                                        "commands.locate.structure.success",
++                                        false,
++                                        stopwatch.elapsed()
++                                );
++                            } else {
++                                source.sendFailure(
++                                        Component.literal(
++                                                ERROR_STRUCTURE_NOT_FOUND.create(predicate.asPrintable()).getMessage()
++                                        )
++                                );
++                            }
++                        });
++                return 0;
++            }
++        }
++        // Leaf end - Async locator
+         Pair<BlockPos, Holder<Structure>> pair = serverLevel.getChunkSource()
+             .getGenerator()
+             .findNearestMapStructure(serverLevel, holderSet, blockPos, 100, false);
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Dolphin.java b/src/main/java/net/minecraft/world/entity/animal/Dolphin.java
+index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..3646810c21641559ee81084da8ac290c720bd411 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Dolphin.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Dolphin.java
+@@ -466,6 +466,8 @@ public class Dolphin extends WaterAnimal {
+ 
+         private final Dolphin dolphin;
+         private boolean stuck;
++        @Nullable
++        private org.dreeam.leaf.async.locate.AsyncLocator.LocateTask locateTask;
+ 
+         DolphinSwimToTreasureGoal(Dolphin dolphin) {
+             this.dolphin = dolphin;
+@@ -485,6 +487,11 @@ public class Dolphin extends WaterAnimal {
+ 
+         @Override
+         public boolean canContinueToUse() {
++            // Leaf start - Async locator
++            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.locateTask != null) {
++                return true;
++            }
++            // Leaf end - Async locator
+             BlockPos blockposition = this.dolphin.getTreasurePos();
+ 
+             return !BlockPos.containing((double) blockposition.getX(), this.dolphin.getY(), (double) blockposition.getZ()).closerToCenterThan(this.dolphin.position(), 4.0D) && !this.stuck && this.dolphin.getAirSupply() >= 100;
+@@ -498,6 +505,20 @@ public class Dolphin extends WaterAnimal {
+                 this.stuck = false;
+                 this.dolphin.getNavigation().stop();
+                 BlockPos blockposition = this.dolphin.blockPosition();
++                // Leaf start - Async locator
++                if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled) {
++                    locateTask = org.dreeam.leaf.async.locate.AsyncLocator.locate(worldserver, StructureTags.DOLPHIN_LOCATED, blockposition, 50, false)
++                            .thenOnServerThread(pos -> {
++                                if (pos != null) {
++                                    this.dolphin.setTreasurePos(pos);
++                                    worldserver.broadcastEntityEvent(this.dolphin, (byte) 38);
++                                } else {
++                                    this.stuck = true;
++                                }
++                            });
++                    return;
++                }
++                // Leaf end - Async locator
+                 BlockPos blockposition1 = worldserver.findNearestMapStructure(StructureTags.DOLPHIN_LOCATED, blockposition, 50, false);
+ 
+                 if (blockposition1 != null) {
+@@ -511,6 +532,12 @@ public class Dolphin extends WaterAnimal {
+ 
+         @Override
+         public void stop() {
++            // Leaf start - Async locator
++            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.locateTask != null) {
++                this.locateTask.cancel();
++                this.locateTask = null;
++            }
++            // Leaf end - Async locator
+             BlockPos blockposition = this.dolphin.getTreasurePos();
+ 
+             if (BlockPos.containing((double) blockposition.getX(), this.dolphin.getY(), (double) blockposition.getZ()).closerToCenterThan(this.dolphin.position(), 4.0D) || this.stuck) {
+@@ -521,6 +548,11 @@ public class Dolphin extends WaterAnimal {
+ 
+         @Override
+         public void tick() {
++            // Leaf start - Async locator
++            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.locateTask != null) {
++                return;
++            }
++            // Leaf end - Async locator
+             Level world = this.dolphin.level();
+ 
+             if (this.dolphin.closeToNextPos() || this.dolphin.getNavigation().isDone()) {
+diff --git a/src/main/java/org/dreeam/leaf/async/locate/AsyncLocator.java b/src/main/java/org/dreeam/leaf/async/locate/AsyncLocator.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ab6fd96bb5a8fdbebf0d9a252fa4d17c6c37964e
+--- /dev/null
++++ b/src/main/java/org/dreeam/leaf/async/locate/AsyncLocator.java
+@@ -0,0 +1,150 @@
++package org.dreeam.leaf.async.locate;
++
++import com.google.common.util.concurrent.ThreadFactoryBuilder;
++import com.mojang.datafixers.util.Pair;
++import net.minecraft.core.BlockPos;
++import net.minecraft.core.Holder;
++import net.minecraft.core.HolderSet;
++import net.minecraft.server.MinecraftServer;
++import net.minecraft.server.level.ServerLevel;
++import net.minecraft.tags.TagKey;
++import net.minecraft.world.level.chunk.ChunkGenerator;
++import net.minecraft.world.level.levelgen.structure.Structure;
++
++import java.util.concurrent.*;
++import java.util.function.Consumer;
++
++// Original project: https://github.com/thebrightspark/AsyncLocator
++public class AsyncLocator {
++    private static final ExecutorService LOCATING_EXECUTOR_SERVICE;
++
++    private AsyncLocator() {}
++
++    public static class AsyncLocatorThread extends Thread {
++    }
++
++    static {
++        int threads = org.dreeam.leaf.config.modules.async.AsyncLocator.asyncLocatorThreads;
++        LOCATING_EXECUTOR_SERVICE = Executors.newFixedThreadPool(
++                threads,
++                new ThreadFactoryBuilder()
++                        .setNameFormat("Leaf Async Locator Thread - %d")
++                        .setThreadFactory(
++                                r -> new AsyncLocatorThread() {
++                                    @Override
++                                    public void run() {
++                                        r.run();
++                                    }
++                                }
++                        )
++                        .setPriority(Thread.NORM_PRIORITY - 2)
++                        .build()
++        );
++    }
++
++    public static void shutdownExecutorService() {
++        if (LOCATING_EXECUTOR_SERVICE != null) {
++            LOCATING_EXECUTOR_SERVICE.shutdown();
++        }
++    }
++
++    /**
++     * Queues a task to locate a feature using {@link ServerLevel#findNearestMapStructure(TagKey, BlockPos, int, boolean)}
++     * and returns a {@link LocateTask} with the futures for it.
++     */
++    public static LocateTask<BlockPos> locate(
++            ServerLevel level,
++            TagKey<Structure> structureTag,
++            BlockPos pos,
++            int searchRadius,
++            boolean skipKnownStructures
++    ) {
++        CompletableFuture<BlockPos> completableFuture = new CompletableFuture<>();
++        Future<?> future = LOCATING_EXECUTOR_SERVICE.submit(
++                () -> doLocateLevel(completableFuture, level, structureTag, pos, searchRadius, skipKnownStructures)
++        );
++        return new LocateTask<>(level.getServer(), completableFuture, future);
++    }
++
++    /**
++     * Queues a task to locate a feature using
++     * {@link ChunkGenerator#findNearestMapStructure(ServerLevel, HolderSet, BlockPos, int, boolean)} and returns a
++     * {@link LocateTask} with the futures for it.
++     */
++    public static LocateTask<Pair<BlockPos, Holder<Structure>>> locate(
++            ServerLevel level,
++            HolderSet<Structure> structureSet,
++            BlockPos pos,
++            int searchRadius,
++            boolean skipKnownStructures
++    ) {
++        CompletableFuture<Pair<BlockPos, Holder<Structure>>> completableFuture = new CompletableFuture<>();
++        Future<?> future = LOCATING_EXECUTOR_SERVICE.submit(
++                () -> doLocateChunkGenerator(completableFuture, level, structureSet, pos, searchRadius, skipKnownStructures)
++        );
++        return new LocateTask<>(level.getServer(), completableFuture, future);
++    }
++
++    private static void doLocateLevel(
++            CompletableFuture<BlockPos> completableFuture,
++            ServerLevel level,
++            TagKey<Structure> structureTag,
++            BlockPos pos,
++            int searchRadius,
++            boolean skipExistingChunks
++    ) {
++        BlockPos foundPos = level.findNearestMapStructure(structureTag, pos, searchRadius, skipExistingChunks);
++        completableFuture.complete(foundPos);
++    }
++
++    private static void doLocateChunkGenerator(
++            CompletableFuture<Pair<BlockPos, Holder<Structure>>> completableFuture,
++            ServerLevel level,
++            HolderSet<Structure> structureSet,
++            BlockPos pos,
++            int searchRadius,
++            boolean skipExistingChunks
++    ) {
++        long start = System.nanoTime();
++        Pair<BlockPos, Holder<Structure>> foundPair = level.getChunkSource().getGenerator()
++                .findNearestMapStructure(level, structureSet, pos, searchRadius, skipExistingChunks);
++        completableFuture.complete(foundPair);
++    }
++
++    /**
++     * Holder of the futures for an async locate task as well as providing some helper functions.
++     * The completableFuture will be completed once the call to
++     * {@link ServerLevel#findNearestMapStructure(TagKey, BlockPos, int, boolean)} has completed, and will hold the
++     * result of it.
++     * The taskFuture is the future for the {@link Runnable} itself in the executor service.
++     */
++    public record LocateTask<T>(MinecraftServer server, CompletableFuture<T> completableFuture, Future<?> taskFuture) {
++        /**
++         * Helper function that calls {@link CompletableFuture#thenAccept(Consumer)} with the given action.
++         * Bear in mind that the action will be executed from the task's thread. If you intend to change any game data,
++         * it's strongly advised you use {@link #thenOnServerThread(Consumer)} instead so that it's queued and executed
++         * on the main server thread instead.
++         */
++        public LocateTask<T> then(Consumer<T> action) {
++            completableFuture.thenAccept(action);
++            return this;
++        }
++
++        /**
++         * Helper function that calls {@link CompletableFuture#thenAccept(Consumer)} with the given action on the server
++         * thread.
++         */
++        public LocateTask<T> thenOnServerThread(Consumer<T> action) {
++            completableFuture.thenAccept(pos -> server.submit(() -> action.accept(pos)));
++            return this;
++        }
++
++        /**
++         * Helper function that cancels both completableFuture and taskFuture.
++         */
++        public void cancel() {
++            taskFuture.cancel(true);
++            completableFuture.cancel(false);
++        }
++    }
++}
+\ No newline at end of file
+diff --git a/src/main/java/org/dreeam/leaf/config/modules/async/AsyncLocator.java b/src/main/java/org/dreeam/leaf/config/modules/async/AsyncLocator.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9c02fab33892ba0711b1cf7d63e343591173bdfd
+--- /dev/null
++++ b/src/main/java/org/dreeam/leaf/config/modules/async/AsyncLocator.java
+@@ -0,0 +1,35 @@
++package org.dreeam.leaf.config.modules.async;
++
++import org.dreeam.leaf.config.ConfigModules;
++import org.dreeam.leaf.config.EnumConfigCategory;
++import org.dreeam.leaf.config.LeafConfig;
++
++public class AsyncLocator extends ConfigModules {
++
++    public String getBasePath() {
++        return EnumConfigCategory.ASYNC.getBaseKeyName() + ".async-locator";
++    }
++
++    public static boolean enabled = false;
++    public static int asyncLocatorThreads = 0;
++
++    @Override
++    public void onLoaded() {
++        config.addComment(getBasePath(), """
++                ***Experimental feature, report any bugs you encountered!***
++                Whether or not asynchronous locator should be enabled.
++                This offloads structure locating to other threads.
++                Only for locate command and dolphin treasure finding currently.""");
++        enabled = config.getBoolean(getBasePath() + ".enabled", enabled);
++        asyncLocatorThreads = config.getInt(getBasePath() + ".threads", asyncLocatorThreads);
++
++        if (asyncLocatorThreads < 0)
++            asyncLocatorThreads = Math.max(Runtime.getRuntime().availableProcessors() + asyncLocatorThreads, 1);
++        else if (asyncLocatorThreads == 0)
++            asyncLocatorThreads = Math.max(Runtime.getRuntime().availableProcessors() / 4, 1);
++        if (!enabled)
++            asyncLocatorThreads = 0;
++        else
++            LeafConfig.LOGGER.info("Using {} threads for Async Locator", asyncLocatorThreads);
++    }
++}

--- a/patches/server/0116-Asynchronous-locator.patch
+++ b/patches/server/0116-Asynchronous-locator.patch
@@ -6,23 +6,18 @@ Subject: [PATCH] Asynchronous locator
 This patch was ported from project: https://github.com/thebrightspark/AsyncLocator
 
 diff --git a/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java b/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java
-index 11b7f15755dde766140c29bedca456c80d53293f..0b9a2448999826eef362589078688d6f5f69e4e6 100644
+index 11b7f15755dde766140c29bedca456c80d53293f..749d00449ac3f3c79bfc73a5517ea3a07675e447 100644
 --- a/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java
 +++ b/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java
-@@ -90,6 +90,13 @@ public class TickThread extends Thread {
+@@ -80,7 +80,7 @@ public class TickThread extends Thread {
+         this(run, name, ID_GENERATOR.incrementAndGet());
      }
  
-     public static boolean isTickThread() {
-+        // Leaf start - Async locator
-+        if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled) {
-+            Thread currentThread = Thread.currentThread();
-+            return currentThread instanceof TickThread ||
-+                    currentThread instanceof org.dreeam.leaf.async.locate.AsyncLocator.AsyncLocatorThread;
-+        }
-+        // Leaf end - Async locator
-         return Thread.currentThread() instanceof TickThread;
+-    private TickThread(final Runnable run, final String name, final int id) {
++    protected TickThread(final Runnable run, final String name, final int id) { // Leaf - private -> protected
+         super(run, name);
+         this.id = id;
      }
- 
 diff --git a/src/main/java/net/minecraft/server/commands/LocateCommand.java b/src/main/java/net/minecraft/server/commands/LocateCommand.java
 index 39f5deea47d8f573c3cfec5df431216ee806c32c..51994f272737f8754aac41dc0c55f43f45617519 100644
 --- a/src/main/java/net/minecraft/server/commands/LocateCommand.java
@@ -138,12 +133,13 @@ index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..3646810c21641559ee81084da8ac290c
              if (this.dolphin.closeToNextPos() || this.dolphin.getNavigation().isDone()) {
 diff --git a/src/main/java/org/dreeam/leaf/async/locate/AsyncLocator.java b/src/main/java/org/dreeam/leaf/async/locate/AsyncLocator.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ab6fd96bb5a8fdbebf0d9a252fa4d17c6c37964e
+index 0000000000000000000000000000000000000000..7f2c97ab9cb53c312d021e16eded6ea0b48115c8
 --- /dev/null
 +++ b/src/main/java/org/dreeam/leaf/async/locate/AsyncLocator.java
-@@ -0,0 +1,150 @@
+@@ -0,0 +1,160 @@
 +package org.dreeam.leaf.async.locate;
 +
++import ca.spottedleaf.moonrise.common.util.TickThread;
 +import com.google.common.util.concurrent.ThreadFactoryBuilder;
 +import com.mojang.datafixers.util.Pair;
 +import net.minecraft.core.BlockPos;
@@ -156,6 +152,7 @@ index 0000000000000000000000000000000000000000..ab6fd96bb5a8fdbebf0d9a252fa4d17c
 +import net.minecraft.world.level.levelgen.structure.Structure;
 +
 +import java.util.concurrent.*;
++import java.util.concurrent.atomic.AtomicInteger;
 +import java.util.function.Consumer;
 +
 +// Original project: https://github.com/thebrightspark/AsyncLocator
@@ -164,7 +161,16 @@ index 0000000000000000000000000000000000000000..ab6fd96bb5a8fdbebf0d9a252fa4d17c
 +
 +    private AsyncLocator() {}
 +
-+    public static class AsyncLocatorThread extends Thread {
++    public static class AsyncLocatorThread extends TickThread {
++        private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(0);
++        public AsyncLocatorThread(Runnable run, String name) {
++            super(run, name, THREAD_COUNTER.incrementAndGet());
++        }
++
++        @Override
++        public void run() {
++            super.run();
++        }
 +    }
 +
 +    static {
@@ -172,15 +178,15 @@ index 0000000000000000000000000000000000000000..ab6fd96bb5a8fdbebf0d9a252fa4d17c
 +        LOCATING_EXECUTOR_SERVICE = Executors.newFixedThreadPool(
 +                threads,
 +                new ThreadFactoryBuilder()
-+                        .setNameFormat("Leaf Async Locator Thread - %d")
 +                        .setThreadFactory(
-+                                r -> new AsyncLocatorThread() {
++                                r -> new AsyncLocatorThread(r, "Leaf Async Locator Thread") {
 +                                    @Override
 +                                    public void run() {
 +                                        r.run();
 +                                    }
 +                                }
 +                        )
++                        .setNameFormat("Leaf Async Locator Thread - %d")
 +                        .setPriority(Thread.NORM_PRIORITY - 2)
 +                        .build()
 +        );
@@ -249,7 +255,6 @@ index 0000000000000000000000000000000000000000..ab6fd96bb5a8fdbebf0d9a252fa4d17c
 +            int searchRadius,
 +            boolean skipExistingChunks
 +    ) {
-+        long start = System.nanoTime();
 +        Pair<BlockPos, Holder<Structure>> foundPair = level.getChunkSource().getGenerator()
 +                .findNearestMapStructure(level, structureSet, pos, searchRadius, skipExistingChunks);
 +        completableFuture.complete(foundPair);

--- a/patches/server/0116-Asynchronous-locator.patch
+++ b/patches/server/0116-Asynchronous-locator.patch
@@ -132,7 +132,7 @@ index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..3646810c21641559ee81084da8ac290c
  
              if (this.dolphin.closeToNextPos() || this.dolphin.getNavigation().isDone()) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-index 00ed0d5ad535faa36111ab28bb0cf1317eb067ec..b5a2a384c4113dff49507eb686dd21292a6a1321 100644
+index 00ed0d5ad535faa36111ab28bb0cf1317eb067ec..477aa4f069ab18de2c764f74dc26db52a95d6206 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 @@ -132,12 +132,35 @@ public abstract class ChunkGenerator {
@@ -147,7 +147,7 @@ index 00ed0d5ad535faa36111ab28bb0cf1317eb067ec..b5a2a384c4113dff49507eb686dd2129
 +            // Leaf start - Async locator - Ensure event is called on server thread
 +            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled &&
 +                    Thread.currentThread() instanceof org.dreeam.leaf.async.locate.AsyncLocator.AsyncLocatorThread) {
-+                final java.util.concurrent.atomic.AtomicBoolean shouldReturn = new java.util.concurrent.atomic.AtomicBoolean(true);
++                final java.util.concurrent.atomic.AtomicBoolean shouldReturn = new java.util.concurrent.atomic.AtomicBoolean(false);
 +                CompletableFuture<Pair<BlockPos, Holder<Structure>>> futureEvent = net.minecraft.server.MinecraftServer.getServer().submit(() -> {
 +                    if (!event.callEvent()) {
 +                        shouldReturn.set(true);

--- a/patches/server/0116-Asynchronous-locator.patch
+++ b/patches/server/0116-Asynchronous-locator.patch
@@ -3,6 +3,7 @@ From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 Date: Wed, 23 Oct 2024 23:54:00 +0800
 Subject: [PATCH] Asynchronous locator
 
+This patch was ported from project: https://github.com/thebrightspark/AsyncLocator
 
 diff --git a/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java b/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java
 index 11b7f15755dde766140c29bedca456c80d53293f..0b9a2448999826eef362589078688d6f5f69e4e6 100644

--- a/patches/server/0116-Asynchronous-locator.patch
+++ b/patches/server/0116-Asynchronous-locator.patch
@@ -131,6 +131,105 @@ index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..3646810c21641559ee81084da8ac290c
              Level world = this.dolphin.level();
  
              if (this.dolphin.closeToNextPos() || this.dolphin.getNavigation().isDone()) {
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/EyeOfEnder.java b/src/main/java/net/minecraft/world/entity/projectile/EyeOfEnder.java
+index fca3786d0a3f99a3e61e7a4b2251361276eff9d7..cb4ff1e98418c651ef21f04f3c74cac7065031ae 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/EyeOfEnder.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/EyeOfEnder.java
+@@ -27,6 +27,7 @@ public class EyeOfEnder extends Entity implements ItemSupplier {
+     public double tz;
+     public int life;
+     public boolean surviveAfterDeath;
++    public boolean asyncLocator$locateTaskOngoing = false; // Leaf - Async locator
+ 
+     public EyeOfEnder(EntityType<? extends EyeOfEnder> type, Level world) {
+         super(type, world);
+@@ -114,6 +115,11 @@ public class EyeOfEnder extends Entity implements ItemSupplier {
+     @Override
+     public void tick() {
+         super.tick();
++        // Leaf start - Async locator
++        if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.asyncLocator$locateTaskOngoing) {
++            return;
++        }
++        // Leaf end - Async locator
+         Vec3 vec3d = this.getDeltaMovement();
+         double d0 = this.getX() + vec3d.x;
+         double d1 = this.getY() + vec3d.y;
+diff --git a/src/main/java/net/minecraft/world/item/EnderEyeItem.java b/src/main/java/net/minecraft/world/item/EnderEyeItem.java
+index d8ce44a180f848f4c9c04967470c4359af979b2f..500c4a86500dd193d9b4f0b33c1cd53e42874876 100644
+--- a/src/main/java/net/minecraft/world/item/EnderEyeItem.java
++++ b/src/main/java/net/minecraft/world/item/EnderEyeItem.java
+@@ -113,20 +113,53 @@ public class EnderEyeItem extends Item {
+             user.startUsingItem(hand);
+             if (world instanceof ServerLevel) {
+                 ServerLevel worldserver = (ServerLevel) world;
+-                BlockPos blockposition = worldserver.findNearestMapStructure(StructureTags.EYE_OF_ENDER_LOCATED, user.blockPosition(), 100, false);
++                // Leaf start - Async locator
++                BlockPos blockposition;
++                if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled) {
++                    blockposition = BlockPos.ZERO;
++                } else {
++                    blockposition = worldserver.findNearestMapStructure(StructureTags.EYE_OF_ENDER_LOCATED, user.blockPosition(), 100, false);
++                }
++                // Leaf end - Async locator
+ 
+                 if (blockposition != null) {
+                     EyeOfEnder entityendersignal = new EyeOfEnder(world, user.getX(), user.getY(0.5D), user.getZ());
+-
++                    // Leaf start - Async locator
++                    final boolean isAsyncLocatorEnabled = org.dreeam.leaf.config.modules.async.AsyncLocator.enabled;
++                    if (isAsyncLocatorEnabled) {
++                        org.dreeam.leaf.async.locate.AsyncLocator.locate(
++                                worldserver,
++                                StructureTags.EYE_OF_ENDER_LOCATED,
++                                user.blockPosition(),
++                                100,
++                                false
++                        ).thenOnServerThread(pos -> {
++                            entityendersignal.asyncLocator$locateTaskOngoing = false;
++                            if (pos != null) {
++                                entityendersignal.signalTo(pos);
++                                CriteriaTriggers.USED_ENDER_EYE.trigger((ServerPlayer) user, pos);
++                                user.awardStat(Stats.ITEM_USED.get(this));
++                            } else {
++                                // Set the entity's life to long enough that it dies
++                                entityendersignal.life = Integer.MAX_VALUE - 100;
++                            }
++                        });
++                        entityendersignal.asyncLocator$locateTaskOngoing = true;
++                    }
++                    // Leaf end - Async locator
+                     entityendersignal.setItem(itemstack);
+-                    entityendersignal.signalTo(blockposition);
++                    // Leaf start - Async locator
++                    if (!isAsyncLocatorEnabled) {
++                        entityendersignal.signalTo(blockposition);
++                    }
++                    // Leaf end - Async locator
+                     world.gameEvent((Holder) GameEvent.PROJECTILE_SHOOT, entityendersignal.position(), GameEvent.Context.of((Entity) user));
+                     // CraftBukkit start
+                     if (!world.addFreshEntity(entityendersignal)) {
+                         return new InteractionResultHolder(InteractionResult.FAIL, itemstack);
+                     }
+                     // CraftBukkit end
+-                    if (user instanceof ServerPlayer) {
++                    if (!isAsyncLocatorEnabled && user instanceof ServerPlayer) { // Leaf - Async locator
+                         ServerPlayer entityplayer = (ServerPlayer) user;
+ 
+                         CriteriaTriggers.USED_ENDER_EYE.trigger(entityplayer, blockposition);
+@@ -136,7 +169,11 @@ public class EnderEyeItem extends Item {
+ 
+                     world.playSound((Player) null, user.getX(), user.getY(), user.getZ(), SoundEvents.ENDER_EYE_LAUNCH, SoundSource.NEUTRAL, 1.0F, f);
+                     itemstack.consume(1, user);
+-                    user.awardStat(Stats.ITEM_USED.get(this));
++                    // Leaf start - Async locator
++                    if (!isAsyncLocatorEnabled) {
++                        user.awardStat(Stats.ITEM_USED.get(this));
++                    }
++                    // Leaf end - Async locator
+                     user.swing(hand, true);
+                     return InteractionResultHolder.success(itemstack);
+                 }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 index 00ed0d5ad535faa36111ab28bb0cf1317eb067ec..477aa4f069ab18de2c764f74dc26db52a95d6206 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
@@ -346,7 +445,7 @@ index 0000000000000000000000000000000000000000..b03c908d1e630d08ba91279886d24497
 \ No newline at end of file
 diff --git a/src/main/java/org/dreeam/leaf/config/modules/async/AsyncLocator.java b/src/main/java/org/dreeam/leaf/config/modules/async/AsyncLocator.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9c02fab33892ba0711b1cf7d63e343591173bdfd
+index 0000000000000000000000000000000000000000..33bf0155cac0776457f124f7815b7e9ecc2ef8da
 --- /dev/null
 +++ b/src/main/java/org/dreeam/leaf/config/modules/async/AsyncLocator.java
 @@ -0,0 +1,35 @@
@@ -368,10 +467,10 @@ index 0000000000000000000000000000000000000000..9c02fab33892ba0711b1cf7d63e34359
 +    @Override
 +    public void onLoaded() {
 +        config.addComment(getBasePath(), """
-+                ***Experimental feature, report any bugs you encountered!***
++                ***Experimental feature, report any bugs you encounter!***
 +                Whether or not asynchronous locator should be enabled.
 +                This offloads structure locating to other threads.
-+                Only for locate command and dolphin treasure finding currently.""");
++                Only for locate command, dolphin treasure finding and eye of ender currently.""");
 +        enabled = config.getBoolean(getBasePath() + ".enabled", enabled);
 +        asyncLocatorThreads = config.getInt(getBasePath() + ".threads", asyncLocatorThreads);
 +

--- a/patches/server/0116-Asynchronous-locator.patch
+++ b/patches/server/0116-Asynchronous-locator.patch
@@ -131,12 +131,57 @@ index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..3646810c21641559ee81084da8ac290c
              Level world = this.dolphin.level();
  
              if (this.dolphin.closeToNextPos() || this.dolphin.getNavigation().isDone()) {
+diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
+index 00ed0d5ad535faa36111ab28bb0cf1317eb067ec..b5a2a384c4113dff49507eb686dd21292a6a1321 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
++++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
+@@ -132,12 +132,35 @@ public abstract class ChunkGenerator {
+         final List<org.bukkit.generator.structure.Structure> apiStructures = structures.stream().map(Holder::value).map(nms -> org.bukkit.craftbukkit.generator.structure.CraftStructure.minecraftToBukkit(nms)).toList();
+         if (!apiStructures.isEmpty()) {
+             final io.papermc.paper.event.world.StructuresLocateEvent event = new io.papermc.paper.event.world.StructuresLocateEvent(bukkitWorld, origin, apiStructures, radius, skipReferencedStructures);
+-            if (!event.callEvent()) {
+-                return null;
+-            }
+-            if (event.getResult() != null) {
+-                return Pair.of(io.papermc.paper.util.MCUtil.toBlockPos(event.getResult().pos()), world.registryAccess().registryOrThrow(Registries.STRUCTURE).wrapAsHolder(org.bukkit.craftbukkit.generator.structure.CraftStructure.bukkitToMinecraft(event.getResult().structure())));
++            // Leaf start - Async locator - Ensure event is called on server thread
++            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled &&
++                    Thread.currentThread() instanceof org.dreeam.leaf.async.locate.AsyncLocator.AsyncLocatorThread) {
++                final java.util.concurrent.atomic.AtomicBoolean shouldReturn = new java.util.concurrent.atomic.AtomicBoolean(true);
++                CompletableFuture<Pair<BlockPos, Holder<Structure>>> futureEvent = net.minecraft.server.MinecraftServer.getServer().submit(() -> {
++                    if (!event.callEvent()) {
++                        shouldReturn.set(true);
++                        return null;
++                    }
++                    if (event.getResult() != null) {
++                        shouldReturn.set(true);
++                        return Pair.of(io.papermc.paper.util.MCUtil.toBlockPos(event.getResult().pos()), world.registryAccess().registryOrThrow(Registries.STRUCTURE).wrapAsHolder(org.bukkit.craftbukkit.generator.structure.CraftStructure.bukkitToMinecraft(event.getResult().structure())));
++                    }
++                    shouldReturn.set(false);
++                    return null;
++                });
++                Pair<BlockPos, Holder<Structure>> result = futureEvent.join();
++                if (shouldReturn.get()) {
++                    return result;
++                }
++            } else {
++                if (!event.callEvent()) {
++                    return null;
++                }
++                if (event.getResult() != null) {
++                    return Pair.of(io.papermc.paper.util.MCUtil.toBlockPos(event.getResult().pos()), world.registryAccess().registryOrThrow(Registries.STRUCTURE).wrapAsHolder(org.bukkit.craftbukkit.generator.structure.CraftStructure.bukkitToMinecraft(event.getResult().structure())));
++                }
+             }
++            // Leaf end - Async locator - Ensure event is called on server thread
+             center = io.papermc.paper.util.MCUtil.toBlockPosition(event.getOrigin());
+             radius = event.getRadius();
+             skipReferencedStructures = event.shouldFindUnexplored();
 diff --git a/src/main/java/org/dreeam/leaf/async/locate/AsyncLocator.java b/src/main/java/org/dreeam/leaf/async/locate/AsyncLocator.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7f2c97ab9cb53c312d021e16eded6ea0b48115c8
+index 0000000000000000000000000000000000000000..b03c908d1e630d08ba91279886d244977e9de4b6
 --- /dev/null
 +++ b/src/main/java/org/dreeam/leaf/async/locate/AsyncLocator.java
-@@ -0,0 +1,160 @@
+@@ -0,0 +1,161 @@
 +package org.dreeam.leaf.async.locate;
 +
 +import ca.spottedleaf.moonrise.common.util.TickThread;
@@ -284,6 +329,7 @@ index 0000000000000000000000000000000000000000..7f2c97ab9cb53c312d021e16eded6ea0
 +         * thread.
 +         */
 +        public LocateTask<T> thenOnServerThread(Consumer<T> action) {
++            // noinspection ResultOfMethodCallIgnored
 +            completableFuture.thenAccept(pos -> server.submit(() -> action.accept(pos)));
 +            return this;
 +        }

--- a/patches/server/0116-Asynchronous-locator.patch
+++ b/patches/server/0116-Asynchronous-locator.patch
@@ -156,10 +156,10 @@ index fca3786d0a3f99a3e61e7a4b2251361276eff9d7..cb4ff1e98418c651ef21f04f3c74cac7
          double d0 = this.getX() + vec3d.x;
          double d1 = this.getY() + vec3d.y;
 diff --git a/src/main/java/net/minecraft/world/item/EnderEyeItem.java b/src/main/java/net/minecraft/world/item/EnderEyeItem.java
-index d8ce44a180f848f4c9c04967470c4359af979b2f..500c4a86500dd193d9b4f0b33c1cd53e42874876 100644
+index d8ce44a180f848f4c9c04967470c4359af979b2f..2a6ec59672bafe885e6d09ed75bb315f2d33078d 100644
 --- a/src/main/java/net/minecraft/world/item/EnderEyeItem.java
 +++ b/src/main/java/net/minecraft/world/item/EnderEyeItem.java
-@@ -113,20 +113,53 @@ public class EnderEyeItem extends Item {
+@@ -113,20 +113,54 @@ public class EnderEyeItem extends Item {
              user.startUsingItem(hand);
              if (world instanceof ServerLevel) {
                  ServerLevel worldserver = (ServerLevel) world;
@@ -175,7 +175,7 @@ index d8ce44a180f848f4c9c04967470c4359af979b2f..500c4a86500dd193d9b4f0b33c1cd53e
  
                  if (blockposition != null) {
                      EyeOfEnder entityendersignal = new EyeOfEnder(world, user.getX(), user.getY(0.5D), user.getZ());
--
+ 
 +                    // Leaf start - Async locator
 +                    final boolean isAsyncLocatorEnabled = org.dreeam.leaf.config.modules.async.AsyncLocator.enabled;
 +                    if (isAsyncLocatorEnabled) {
@@ -217,7 +217,7 @@ index d8ce44a180f848f4c9c04967470c4359af979b2f..500c4a86500dd193d9b4f0b33c1cd53e
                          ServerPlayer entityplayer = (ServerPlayer) user;
  
                          CriteriaTriggers.USED_ENDER_EYE.trigger(entityplayer, blockposition);
-@@ -136,7 +169,11 @@ public class EnderEyeItem extends Item {
+@@ -136,7 +170,11 @@ public class EnderEyeItem extends Item {
  
                      world.playSound((Player) null, user.getX(), user.getY(), user.getZ(), SoundEvents.ENDER_EYE_LAUNCH, SoundSource.NEUTRAL, 1.0F, f);
                      itemstack.consume(1, user);

--- a/patches/server/0116-Asynchronous-locator.patch
+++ b/patches/server/0116-Asynchronous-locator.patch
@@ -157,7 +157,7 @@ index fca3786d0a3f99a3e61e7a4b2251361276eff9d7..cb4ff1e98418c651ef21f04f3c74cac7
          double d0 = this.getX() + vec3d.x;
          double d1 = this.getY() + vec3d.y;
 diff --git a/src/main/java/net/minecraft/world/item/EnderEyeItem.java b/src/main/java/net/minecraft/world/item/EnderEyeItem.java
-index d8ce44a180f848f4c9c04967470c4359af979b2f..2a6ec59672bafe885e6d09ed75bb315f2d33078d 100644
+index d8ce44a180f848f4c9c04967470c4359af979b2f..90abb83a6baa60bbcbedc7d818c3bc9f4317f04f 100644
 --- a/src/main/java/net/minecraft/world/item/EnderEyeItem.java
 +++ b/src/main/java/net/minecraft/world/item/EnderEyeItem.java
 @@ -113,20 +113,54 @@ public class EnderEyeItem extends Item {
@@ -180,6 +180,7 @@ index d8ce44a180f848f4c9c04967470c4359af979b2f..2a6ec59672bafe885e6d09ed75bb315f
 +                    // Leaf start - Async locator
 +                    final boolean isAsyncLocatorEnabled = org.dreeam.leaf.config.modules.async.AsyncLocator.enabled;
 +                    if (isAsyncLocatorEnabled) {
++                        entityendersignal.asyncLocator$locateTaskOngoing = true;
 +                        org.dreeam.leaf.async.locate.AsyncLocator.locate(
 +                                worldserver,
 +                                StructureTags.EYE_OF_ENDER_LOCATED,
@@ -197,7 +198,6 @@ index d8ce44a180f848f4c9c04967470c4359af979b2f..2a6ec59672bafe885e6d09ed75bb315f
 +                                entityendersignal.life = Integer.MAX_VALUE - 100;
 +                            }
 +                        });
-+                        entityendersignal.asyncLocator$locateTaskOngoing = true;
 +                    }
 +                    // Leaf end - Async locator
                      entityendersignal.setItem(itemstack);

--- a/patches/server/0116-Asynchronous-locator.patch
+++ b/patches/server/0116-Asynchronous-locator.patch
@@ -61,7 +61,7 @@ index 39f5deea47d8f573c3cfec5df431216ee806c32c..51994f272737f8754aac41dc0c55f43f
              .getGenerator()
              .findNearestMapStructure(serverLevel, holderSet, blockPos, 100, false);
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Dolphin.java b/src/main/java/net/minecraft/world/entity/animal/Dolphin.java
-index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..3646810c21641559ee81084da8ac290c720bd411 100644
+index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..061d020c08b722b92187ba9042ab4084ecd72b06 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Dolphin.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Dolphin.java
 @@ -466,6 +466,8 @@ public class Dolphin extends WaterAnimal {
@@ -69,7 +69,7 @@ index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..3646810c21641559ee81084da8ac290c
          private final Dolphin dolphin;
          private boolean stuck;
 +        @Nullable
-+        private org.dreeam.leaf.async.locate.AsyncLocator.LocateTask locateTask;
++        private org.dreeam.leaf.async.locate.AsyncLocator.LocateTask<?> asyncLocator$locateTask;
  
          DolphinSwimToTreasureGoal(Dolphin dolphin) {
              this.dolphin = dolphin;
@@ -78,21 +78,22 @@ index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..3646810c21641559ee81084da8ac290c
          @Override
          public boolean canContinueToUse() {
 +            // Leaf start - Async locator
-+            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.locateTask != null) {
++            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.asyncLocator$locateTask != null) {
 +                return true;
 +            }
 +            // Leaf end - Async locator
              BlockPos blockposition = this.dolphin.getTreasurePos();
  
              return !BlockPos.containing((double) blockposition.getX(), this.dolphin.getY(), (double) blockposition.getZ()).closerToCenterThan(this.dolphin.position(), 4.0D) && !this.stuck && this.dolphin.getAirSupply() >= 100;
-@@ -498,6 +505,20 @@ public class Dolphin extends WaterAnimal {
+@@ -498,6 +505,21 @@ public class Dolphin extends WaterAnimal {
                  this.stuck = false;
                  this.dolphin.getNavigation().stop();
                  BlockPos blockposition = this.dolphin.blockPosition();
 +                // Leaf start - Async locator
 +                if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled) {
-+                    locateTask = org.dreeam.leaf.async.locate.AsyncLocator.locate(worldserver, StructureTags.DOLPHIN_LOCATED, blockposition, 50, false)
++                    asyncLocator$locateTask = org.dreeam.leaf.async.locate.AsyncLocator.locate(worldserver, StructureTags.DOLPHIN_LOCATED, blockposition, 50, false)
 +                            .thenOnServerThread(pos -> {
++                                asyncLocator$locateTask = null;
 +                                if (pos != null) {
 +                                    this.dolphin.setTreasurePos(pos);
 +                                    worldserver.broadcastEntityEvent(this.dolphin, (byte) 38);
@@ -106,25 +107,25 @@ index ef0124ceb7cafd58c01c7f0b4b542f38a383ab88..3646810c21641559ee81084da8ac290c
                  BlockPos blockposition1 = worldserver.findNearestMapStructure(StructureTags.DOLPHIN_LOCATED, blockposition, 50, false);
  
                  if (blockposition1 != null) {
-@@ -511,6 +532,12 @@ public class Dolphin extends WaterAnimal {
+@@ -511,6 +533,12 @@ public class Dolphin extends WaterAnimal {
  
          @Override
          public void stop() {
 +            // Leaf start - Async locator
-+            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.locateTask != null) {
-+                this.locateTask.cancel();
-+                this.locateTask = null;
++            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.asyncLocator$locateTask != null) {
++                this.asyncLocator$locateTask.cancel();
++                this.asyncLocator$locateTask = null;
 +            }
 +            // Leaf end - Async locator
              BlockPos blockposition = this.dolphin.getTreasurePos();
  
              if (BlockPos.containing((double) blockposition.getX(), this.dolphin.getY(), (double) blockposition.getZ()).closerToCenterThan(this.dolphin.position(), 4.0D) || this.stuck) {
-@@ -521,6 +548,11 @@ public class Dolphin extends WaterAnimal {
+@@ -521,6 +549,11 @@ public class Dolphin extends WaterAnimal {
  
          @Override
          public void tick() {
 +            // Leaf start - Async locator
-+            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.locateTask != null) {
++            if (org.dreeam.leaf.config.modules.async.AsyncLocator.enabled && this.asyncLocator$locateTask != null) {
 +                return;
 +            }
 +            // Leaf end - Async locator

--- a/patches/server/0117-Virtual-thread-for-chat-executor.patch
+++ b/patches/server/0117-Virtual-thread-for-chat-executor.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Fri, 25 Oct 2024 02:27:21 +0800
+Subject: [PATCH] Virtual thread for chat executor
+
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 37c377761b45eefab39164a7e714e585a02a4447..cca3945ef31b9696950f08164d8bbacaeaa36b4e 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -43,6 +43,7 @@ import java.util.Set;
+ import java.util.UUID;
+ import java.util.concurrent.CompletableFuture;
+ import java.util.concurrent.Executor;
++import java.util.concurrent.Executors;
+ import java.util.concurrent.atomic.AtomicReference;
+ import java.util.function.BooleanSupplier;
+ import java.util.function.Consumer;
+@@ -2894,7 +2895,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+     }
+ 
+     public final java.util.concurrent.ExecutorService chatExecutor = java.util.concurrent.Executors.newCachedThreadPool(
+-            new com.google.common.util.concurrent.ThreadFactoryBuilder().setDaemon(true).setNameFormat("Async Chat Thread - #%d").setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER)).build()); // Paper
++            new com.google.common.util.concurrent.ThreadFactoryBuilder().setDaemon(true).setNameFormat("Async Chat Thread - #%d").setThreadFactory(org.dreeam.leaf.config.modules.opt.VT4ChatExecutor.enabled ? Thread.ofVirtual().factory() : Executors.defaultThreadFactory()).setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER)).build()); // Paper // Leaf - Virtual thread for chatExecutor
+ 
+     public final ChatDecorator improvedChatDecorator = new io.papermc.paper.adventure.ImprovedChatDecorator(this); // Paper - adventure
+     public ChatDecorator getChatDecorator() {
+diff --git a/src/main/java/org/dreeam/leaf/config/modules/opt/VT4ChatExecutor.java b/src/main/java/org/dreeam/leaf/config/modules/opt/VT4ChatExecutor.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a00f559076f5efbaf72217c4a889f246fc5f60d4
+--- /dev/null
++++ b/src/main/java/org/dreeam/leaf/config/modules/opt/VT4ChatExecutor.java
+@@ -0,0 +1,19 @@
++package org.dreeam.leaf.config.modules.opt;
++
++import org.dreeam.leaf.config.ConfigModules;
++import org.dreeam.leaf.config.EnumConfigCategory;
++
++public class VT4ChatExecutor extends ConfigModules {
++
++    public String getBasePath() {
++        return EnumConfigCategory.PERF.getBaseKeyName();
++    }
++
++    public static boolean enabled = true;
++
++    @Override
++    public void onLoaded() {
++        enabled = config.getBoolean(getBasePath() + ".use-virtual-thread-for-async-chat-executor", enabled,
++                "Use the new Virtual Thread introduced in JDK 21 for Async Chat Executor.");
++    }
++}

--- a/patches/server/0117-Virtual-thread-for-chat-executor.patch
+++ b/patches/server/0117-Virtual-thread-for-chat-executor.patch
@@ -5,23 +5,15 @@ Subject: [PATCH] Virtual thread for chat executor
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 37c377761b45eefab39164a7e714e585a02a4447..cca3945ef31b9696950f08164d8bbacaeaa36b4e 100644
+index 37c377761b45eefab39164a7e714e585a02a4447..09e55f62b4cea5b058e04356252f4f56957646b8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -43,6 +43,7 @@ import java.util.Set;
- import java.util.UUID;
- import java.util.concurrent.CompletableFuture;
- import java.util.concurrent.Executor;
-+import java.util.concurrent.Executors;
- import java.util.concurrent.atomic.AtomicReference;
- import java.util.function.BooleanSupplier;
- import java.util.function.Consumer;
-@@ -2894,7 +2895,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2894,7 +2894,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      }
  
      public final java.util.concurrent.ExecutorService chatExecutor = java.util.concurrent.Executors.newCachedThreadPool(
 -            new com.google.common.util.concurrent.ThreadFactoryBuilder().setDaemon(true).setNameFormat("Async Chat Thread - #%d").setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER)).build()); // Paper
-+            new com.google.common.util.concurrent.ThreadFactoryBuilder().setDaemon(true).setNameFormat("Async Chat Thread - #%d").setThreadFactory(org.dreeam.leaf.config.modules.opt.VT4ChatExecutor.enabled ? Thread.ofVirtual().factory() : Executors.defaultThreadFactory()).setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER)).build()); // Paper // Leaf - Virtual thread for chatExecutor
++            new com.google.common.util.concurrent.ThreadFactoryBuilder().setDaemon(true).setNameFormat("Async Chat Thread - #%d").setThreadFactory(org.dreeam.leaf.config.modules.opt.VT4ChatExecutor.enabled ? Thread.ofVirtual().factory() : java.util.concurrent.Executors.defaultThreadFactory()).setUncaughtExceptionHandler(new net.minecraft.DefaultUncaughtExceptionHandlerWithName(net.minecraft.server.MinecraftServer.LOGGER)).build()); // Paper // Leaf - Virtual thread for chatExecutor
  
      public final ChatDecorator improvedChatDecorator = new io.papermc.paper.adventure.ImprovedChatDecorator(this); // Paper - adventure
      public ChatDecorator getChatDecorator() {


### PR DESCRIPTION
This pull request includes following changes:

1. Fix [MC-177381](https://bugs.mojang.com/browse/MC-177381), which causes locate command distance overflow.
2. Asynchronous locator for /locate command, EyeOfEnder, dolphin treasure finding
3. Able to use virtual thread for chat executor, which could improve performance and reduce resource consumption on high player throughput servers
4. Fix potential ArrayIndexOutOfBoundsException when using MultithreadedTracker with compat mode on ([Logs](https://mclo.gs/bntV6qx))