### PR TITLE
Add dontEnableIfInWater option to DAB

### DIFF
--- a/patches/server/0008-Pufferfish-Dynamic-Activation-of-Brain.patch
+++ b/patches/server/0008-Pufferfish-Dynamic-Activation-of-Brain.patch
@@ -371,18 +371,10 @@ index 0000000000000000000000000000000000000000..a2e60c43074df560eb01f150bf52b8d0
 +    }
 +}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 0b2f2fbe462ed628ef3d640824d4162e79279089..dce90b9c38ed5734bc3259c4de4387fa862b9c9f 100644
+index 0b2f2fbe462ed628ef3d640824d4162e79279089..e469b2782932275caa4bb760eefff82916c47d3a 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -3,6 +3,7 @@ package org.spigotmc;
- import net.minecraft.core.BlockPos;
- import net.minecraft.server.MinecraftServer;
- import net.minecraft.server.level.ServerChunkCache;
-+import net.minecraft.tags.EntityTypeTags;
- import net.minecraft.world.entity.Entity;
- import net.minecraft.world.entity.ExperienceOrb;
- import net.minecraft.world.entity.FlyingMob;
-@@ -38,7 +39,6 @@ import co.aikar.timings.MinecraftTimings;
+@@ -38,7 +38,6 @@ import co.aikar.timings.MinecraftTimings;
  import net.minecraft.world.entity.schedule.Activity;
  import net.minecraft.world.level.Level;
  import net.minecraft.world.phys.AABB;
@@ -390,14 +382,14 @@ index 0b2f2fbe462ed628ef3d640824d4162e79279089..dce90b9c38ed5734bc3259c4de4387fa
  import org.galemc.gale.configuration.GaleWorldConfiguration;
  
  public class ActivationRange
-@@ -238,6 +238,26 @@ public class ActivationRange
+@@ -238,6 +237,26 @@ public class ActivationRange
                  }
                  // Paper end - Configurable marker ticking
                  ActivationRange.activateEntity(entity);
 +
 +                // Pufferfish start
 +                if (org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.enabled && entity.getType().dabEnabled &&
-+                        (!org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.dontEnableIfInWater || entity.getType().is(EntityTypeTags.CAN_BREATHE_UNDER_WATER) || !entity.isInWaterOrBubble())) { // Leaf - Option for dontEnableIfInWater
++                        (!org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.dontEnableIfInWater || entity.getType().is(net.minecraft.tags.EntityTypeTags.CAN_BREATHE_UNDER_WATER) || !entity.isInWaterOrBubble())) { // Leaf - Option for dontEnableIfInWater
 +                    if (!entity.activatedPriorityReset) {
 +                        entity.activatedPriorityReset = true;
 +                        entity.activatedPriority = org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.maximumActivationPrio;
@@ -417,7 +409,7 @@ index 0b2f2fbe462ed628ef3d640824d4162e79279089..dce90b9c38ed5734bc3259c4de4387fa
              }
              // Paper end
          }
-@@ -254,12 +274,12 @@ public class ActivationRange
+@@ -254,12 +273,12 @@ public class ActivationRange
          if ( MinecraftServer.currentTick > entity.activatedTick )
          {
              if ( entity.defaultActivationState )

--- a/patches/server/0008-Pufferfish-Dynamic-Activation-of-Brain.patch
+++ b/patches/server/0008-Pufferfish-Dynamic-Activation-of-Brain.patch
@@ -371,10 +371,18 @@ index 0000000000000000000000000000000000000000..a2e60c43074df560eb01f150bf52b8d0
 +    }
 +}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 0b2f2fbe462ed628ef3d640824d4162e79279089..fe1d053a703b6652485b24ba487d8ebfcbabf28b 100644
+index 0b2f2fbe462ed628ef3d640824d4162e79279089..dce90b9c38ed5734bc3259c4de4387fa862b9c9f 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -38,7 +38,6 @@ import co.aikar.timings.MinecraftTimings;
+@@ -3,6 +3,7 @@ package org.spigotmc;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.server.MinecraftServer;
+ import net.minecraft.server.level.ServerChunkCache;
++import net.minecraft.tags.EntityTypeTags;
+ import net.minecraft.world.entity.Entity;
+ import net.minecraft.world.entity.ExperienceOrb;
+ import net.minecraft.world.entity.FlyingMob;
+@@ -38,7 +39,6 @@ import co.aikar.timings.MinecraftTimings;
  import net.minecraft.world.entity.schedule.Activity;
  import net.minecraft.world.level.Level;
  import net.minecraft.world.phys.AABB;
@@ -382,14 +390,14 @@ index 0b2f2fbe462ed628ef3d640824d4162e79279089..fe1d053a703b6652485b24ba487d8ebf
  import org.galemc.gale.configuration.GaleWorldConfiguration;
  
  public class ActivationRange
-@@ -238,6 +237,26 @@ public class ActivationRange
+@@ -238,6 +238,26 @@ public class ActivationRange
                  }
                  // Paper end - Configurable marker ticking
                  ActivationRange.activateEntity(entity);
 +
 +                // Pufferfish start
 +                if (org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.enabled && entity.getType().dabEnabled &&
-+                        (!org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.dontEnableIfInWater || entity.getType().is(net.minecraft.tags.EntityTypeTags.AQUATIC) || entity.getType().is(net.minecraft.tags.EntityTypeTags.UNDEAD) || !entity.isInWaterOrBubble())) { // Leaf - Option for dontEnableIfInWater
++                        (!org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.dontEnableIfInWater || entity.getType().is(EntityTypeTags.CAN_BREATHE_UNDER_WATER) || !entity.isInWaterOrBubble())) { // Leaf - Option for dontEnableIfInWater
 +                    if (!entity.activatedPriorityReset) {
 +                        entity.activatedPriorityReset = true;
 +                        entity.activatedPriority = org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.maximumActivationPrio;
@@ -409,7 +417,7 @@ index 0b2f2fbe462ed628ef3d640824d4162e79279089..fe1d053a703b6652485b24ba487d8ebf
              }
              // Paper end
          }
-@@ -254,12 +273,12 @@ public class ActivationRange
+@@ -254,12 +274,12 @@ public class ActivationRange
          if ( MinecraftServer.currentTick > entity.activatedTick )
          {
              if ( entity.defaultActivationState )

--- a/patches/server/0008-Pufferfish-Dynamic-Activation-of-Brain.patch
+++ b/patches/server/0008-Pufferfish-Dynamic-Activation-of-Brain.patch
@@ -295,10 +295,10 @@ index 71a3eadd2f1e00fa066dbfe9918d749d43435a18..03513d3b6118ac5d0a58788462dcbc98
          }
 diff --git a/src/main/java/org/dreeam/leaf/config/modules/opt/DynamicActivationofBrain.java b/src/main/java/org/dreeam/leaf/config/modules/opt/DynamicActivationofBrain.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ed8496e344284f79ff66c1d216090a218d95c311
+index 0000000000000000000000000000000000000000..a2e60c43074df560eb01f150bf52b8d0f5af9b54
 --- /dev/null
 +++ b/src/main/java/org/dreeam/leaf/config/modules/opt/DynamicActivationofBrain.java
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,71 @@
 +package org.dreeam.leaf.config.modules.opt;
 +
 +import net.minecraft.core.registries.BuiltInRegistries;
@@ -322,6 +322,7 @@ index 0000000000000000000000000000000000000000..ed8496e344284f79ff66c1d216090a21
 +    public static int startDistanceSquared;
 +    public static int maximumActivationPrio = 20;
 +    public static int activationDistanceMod = 8;
++    public static boolean dontEnableIfInWater = false;
 +    public static List<String> blackedEntities = new ArrayList<>();
 +
 +    @Override
@@ -331,6 +332,9 @@ index 0000000000000000000000000000000000000000..ed8496e344284f79ff66c1d216090a21
 +                they're far away from the player""");
 +
 +        enabled = config.getBoolean(getBasePath() + ".enabled", enabled);
++        dontEnableIfInWater = config.getBoolean(getBasePath() + ".dont-enable-if-in-water", dontEnableIfInWater, """
++                After enabling this, non-aquatic entities in the water will not be affected by DAB.
++                This could fix entities suffocate in the water.""");
 +        startDistance = config.getInt(getBasePath() + ".start-distance", startDistance, """
 +                This value determines how far away an entity has to be
 +                from the player to start being effected by DEAR.""");
@@ -367,16 +371,24 @@ index 0000000000000000000000000000000000000000..ed8496e344284f79ff66c1d216090a21
 +    }
 +}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 0b2f2fbe462ed628ef3d640824d4162e79279089..456f64fcae7a12ca141d8061f69797e58efa1899 100644
+index 0b2f2fbe462ed628ef3d640824d4162e79279089..e4c0092179e702ecc8dc6aa345b7fb4cc4ea6ebf 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -238,6 +238,25 @@ public class ActivationRange
+@@ -38,7 +38,6 @@ import co.aikar.timings.MinecraftTimings;
+ import net.minecraft.world.entity.schedule.Activity;
+ import net.minecraft.world.level.Level;
+ import net.minecraft.world.phys.AABB;
+-import org.galemc.gale.configuration.GaleGlobalConfiguration;
+ import org.galemc.gale.configuration.GaleWorldConfiguration;
+ 
+ public class ActivationRange
+@@ -238,6 +237,25 @@ public class ActivationRange
                  }
                  // Paper end - Configurable marker ticking
                  ActivationRange.activateEntity(entity);
 +
 +                // Pufferfish start
-+                if (org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.enabled && entity.getType().dabEnabled) {
++                if (org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.enabled && entity.getType().dabEnabled && (!org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.dontEnableIfInWater || entity instanceof WaterAnimal || !entity.isInWaterOrBubble())) { // Leaf - Option for dontEnableIfInWater
 +                    if (!entity.activatedPriorityReset) {
 +                        entity.activatedPriorityReset = true;
 +                        entity.activatedPriority = org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.maximumActivationPrio;
@@ -396,7 +408,7 @@ index 0b2f2fbe462ed628ef3d640824d4162e79279089..456f64fcae7a12ca141d8061f69797e5
              }
              // Paper end
          }
-@@ -254,12 +273,12 @@ public class ActivationRange
+@@ -254,12 +272,12 @@ public class ActivationRange
          if ( MinecraftServer.currentTick > entity.activatedTick )
          {
              if ( entity.defaultActivationState )

--- a/patches/server/0008-Pufferfish-Dynamic-Activation-of-Brain.patch
+++ b/patches/server/0008-Pufferfish-Dynamic-Activation-of-Brain.patch
@@ -371,7 +371,7 @@ index 0000000000000000000000000000000000000000..a2e60c43074df560eb01f150bf52b8d0
 +    }
 +}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 0b2f2fbe462ed628ef3d640824d4162e79279089..e4c0092179e702ecc8dc6aa345b7fb4cc4ea6ebf 100644
+index 0b2f2fbe462ed628ef3d640824d4162e79279089..fe1d053a703b6652485b24ba487d8ebfcbabf28b 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -38,7 +38,6 @@ import co.aikar.timings.MinecraftTimings;
@@ -382,13 +382,14 @@ index 0b2f2fbe462ed628ef3d640824d4162e79279089..e4c0092179e702ecc8dc6aa345b7fb4c
  import org.galemc.gale.configuration.GaleWorldConfiguration;
  
  public class ActivationRange
-@@ -238,6 +237,25 @@ public class ActivationRange
+@@ -238,6 +237,26 @@ public class ActivationRange
                  }
                  // Paper end - Configurable marker ticking
                  ActivationRange.activateEntity(entity);
 +
 +                // Pufferfish start
-+                if (org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.enabled && entity.getType().dabEnabled && (!org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.dontEnableIfInWater || entity instanceof WaterAnimal || !entity.isInWaterOrBubble())) { // Leaf - Option for dontEnableIfInWater
++                if (org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.enabled && entity.getType().dabEnabled &&
++                        (!org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.dontEnableIfInWater || entity.getType().is(net.minecraft.tags.EntityTypeTags.AQUATIC) || entity.getType().is(net.minecraft.tags.EntityTypeTags.UNDEAD) || !entity.isInWaterOrBubble())) { // Leaf - Option for dontEnableIfInWater
 +                    if (!entity.activatedPriorityReset) {
 +                        entity.activatedPriorityReset = true;
 +                        entity.activatedPriority = org.dreeam.leaf.config.modules.opt.DynamicActivationofBrain.maximumActivationPrio;
@@ -408,7 +409,7 @@ index 0b2f2fbe462ed628ef3d640824d4162e79279089..e4c0092179e702ecc8dc6aa345b7fb4c
              }
              // Paper end
          }
-@@ -254,12 +272,12 @@ public class ActivationRange
+@@ -254,12 +273,12 @@ public class ActivationRange
          if ( MinecraftServer.currentTick > entity.activatedTick )
          {
              if ( entity.defaultActivationState )

--- a/patches/server/0011-Purpur-Server-Changes.patch
+++ b/patches/server/0011-Purpur-Server-Changes.patch
@@ -24824,10 +24824,10 @@ index 0000000000000000000000000000000000000000..129acb8ad139decc6b1c023cb10bc32d
 +    // Paper end - lifecycle events
 +}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index fe1d053a703b6652485b24ba487d8ebfcbabf28b..b16970195d560dba9d0b3a258961857008b3550c 100644
+index dce90b9c38ed5734bc3259c4de4387fa862b9c9f..103571f5aa880b0118e1b946e166c86b1e7bf5b5 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -215,6 +215,8 @@ public class ActivationRange
+@@ -216,6 +216,8 @@ public class ActivationRange
                  continue;
              }
  
@@ -24836,7 +24836,7 @@ index fe1d053a703b6652485b24ba487d8ebfcbabf28b..b16970195d560dba9d0b3a2589618570
              // Paper start
              int worldHeight = world.getHeight();
              ActivationRange.maxBB = player.getBoundingBox().inflate( maxRange, worldHeight, maxRange );
-@@ -413,6 +415,7 @@ public class ActivationRange
+@@ -414,6 +416,7 @@ public class ActivationRange
       */
      public static boolean checkIfActive(Entity entity)
      {

--- a/patches/server/0011-Purpur-Server-Changes.patch
+++ b/patches/server/0011-Purpur-Server-Changes.patch
@@ -24824,7 +24824,7 @@ index 0000000000000000000000000000000000000000..129acb8ad139decc6b1c023cb10bc32d
 +    // Paper end - lifecycle events
 +}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index e4c0092179e702ecc8dc6aa345b7fb4cc4ea6ebf..ab22da71bcd4bd52eb49f92999459684fb29875e 100644
+index fe1d053a703b6652485b24ba487d8ebfcbabf28b..b16970195d560dba9d0b3a258961857008b3550c 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -215,6 +215,8 @@ public class ActivationRange
@@ -24836,7 +24836,7 @@ index e4c0092179e702ecc8dc6aa345b7fb4cc4ea6ebf..ab22da71bcd4bd52eb49f92999459684
              // Paper start
              int worldHeight = world.getHeight();
              ActivationRange.maxBB = player.getBoundingBox().inflate( maxRange, worldHeight, maxRange );
-@@ -412,6 +414,7 @@ public class ActivationRange
+@@ -413,6 +415,7 @@ public class ActivationRange
       */
      public static boolean checkIfActive(Entity entity)
      {

--- a/patches/server/0011-Purpur-Server-Changes.patch
+++ b/patches/server/0011-Purpur-Server-Changes.patch
@@ -24824,10 +24824,10 @@ index 0000000000000000000000000000000000000000..129acb8ad139decc6b1c023cb10bc32d
 +    // Paper end - lifecycle events
 +}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 456f64fcae7a12ca141d8061f69797e58efa1899..530c5d656b6b362d0df85a897d7e8d0497250680 100644
+index e4c0092179e702ecc8dc6aa345b7fb4cc4ea6ebf..ab22da71bcd4bd52eb49f92999459684fb29875e 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -216,6 +216,8 @@ public class ActivationRange
+@@ -215,6 +215,8 @@ public class ActivationRange
                  continue;
              }
  
@@ -24836,7 +24836,7 @@ index 456f64fcae7a12ca141d8061f69797e58efa1899..530c5d656b6b362d0df85a897d7e8d04
              // Paper start
              int worldHeight = world.getHeight();
              ActivationRange.maxBB = player.getBoundingBox().inflate( maxRange, worldHeight, maxRange );
-@@ -413,6 +415,7 @@ public class ActivationRange
+@@ -412,6 +414,7 @@ public class ActivationRange
       */
      public static boolean checkIfActive(Entity entity)
      {

--- a/patches/server/0011-Purpur-Server-Changes.patch
+++ b/patches/server/0011-Purpur-Server-Changes.patch
@@ -24824,10 +24824,10 @@ index 0000000000000000000000000000000000000000..129acb8ad139decc6b1c023cb10bc32d
 +    // Paper end - lifecycle events
 +}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index dce90b9c38ed5734bc3259c4de4387fa862b9c9f..103571f5aa880b0118e1b946e166c86b1e7bf5b5 100644
+index e469b2782932275caa4bb760eefff82916c47d3a..92a8d0a44a3e8b955807fc6b94564b6660bd94ad 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -216,6 +216,8 @@ public class ActivationRange
+@@ -215,6 +215,8 @@ public class ActivationRange
                  continue;
              }
  
@@ -24836,7 +24836,7 @@ index dce90b9c38ed5734bc3259c4de4387fa862b9c9f..103571f5aa880b0118e1b946e166c86b
              // Paper start
              int worldHeight = world.getHeight();
              ActivationRange.maxBB = player.getBoundingBox().inflate( maxRange, worldHeight, maxRange );
-@@ -414,6 +416,7 @@ public class ActivationRange
+@@ -413,6 +415,7 @@ public class ActivationRange
       */
      public static boolean checkIfActive(Entity entity)
      {

--- a/patches/server/0015-Remove-Timings.patch
+++ b/patches/server/0015-Remove-Timings.patch
@@ -1838,7 +1838,7 @@ index 579c2e69d8f6ce8398eb1297d1d1ead98c9068a5..00000000000000000000000000000000
 -
 -}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index ab22da71bcd4bd52eb49f92999459684fb29875e..e4731087598dca93d55e7ccb65bf440561ad8a96 100644
+index b16970195d560dba9d0b3a258961857008b3550c..0f8987d1fe6a9e4d8e9d984d242797215993a269 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -34,7 +34,6 @@ import net.minecraft.world.entity.projectile.FireworkRocketEntity;
@@ -1857,7 +1857,7 @@ index ab22da71bcd4bd52eb49f92999459684fb29875e..e4731087598dca93d55e7ccb65bf4405
          final int miscActivationRange = world.spigotConfig.miscActivationRange;
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
-@@ -261,7 +259,6 @@ public class ActivationRange
+@@ -262,7 +260,6 @@ public class ActivationRange
              }
              // Paper end
          }

--- a/patches/server/0015-Remove-Timings.patch
+++ b/patches/server/0015-Remove-Timings.patch
@@ -1838,10 +1838,10 @@ index 579c2e69d8f6ce8398eb1297d1d1ead98c9068a5..00000000000000000000000000000000
 -
 -}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 103571f5aa880b0118e1b946e166c86b1e7bf5b5..7182d1e8746d094b5fb1e4aaa5ce3b3cb85ab1b5 100644
+index 92a8d0a44a3e8b955807fc6b94564b6660bd94ad..dae16e2c3cc0f154dbe3a62e3050548fb649c3c2 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -35,7 +35,6 @@ import net.minecraft.world.entity.projectile.FireworkRocketEntity;
+@@ -34,7 +34,6 @@ import net.minecraft.world.entity.projectile.FireworkRocketEntity;
  import net.minecraft.world.entity.projectile.ThrowableProjectile;
  import net.minecraft.world.entity.projectile.ThrownTrident;
  import net.minecraft.world.entity.raid.Raider;
@@ -1849,7 +1849,7 @@ index 103571f5aa880b0118e1b946e166c86b1e7bf5b5..7182d1e8746d094b5fb1e4aaa5ce3b3c
  import net.minecraft.world.entity.schedule.Activity;
  import net.minecraft.world.level.Level;
  import net.minecraft.world.phys.AABB;
-@@ -182,7 +181,6 @@ public class ActivationRange
+@@ -181,7 +180,6 @@ public class ActivationRange
       */
      public static void activateEntities(Level world)
      {
@@ -1857,7 +1857,7 @@ index 103571f5aa880b0118e1b946e166c86b1e7bf5b5..7182d1e8746d094b5fb1e4aaa5ce3b3c
          final int miscActivationRange = world.spigotConfig.miscActivationRange;
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
-@@ -263,7 +261,6 @@ public class ActivationRange
+@@ -262,7 +260,6 @@ public class ActivationRange
              }
              // Paper end
          }

--- a/patches/server/0015-Remove-Timings.patch
+++ b/patches/server/0015-Remove-Timings.patch
@@ -1838,7 +1838,7 @@ index 579c2e69d8f6ce8398eb1297d1d1ead98c9068a5..00000000000000000000000000000000
 -
 -}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 530c5d656b6b362d0df85a897d7e8d0497250680..7fd2a463e9208635bd2d9f0b1a4291d60c5dedf2 100644
+index ab22da71bcd4bd52eb49f92999459684fb29875e..e4731087598dca93d55e7ccb65bf440561ad8a96 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -34,7 +34,6 @@ import net.minecraft.world.entity.projectile.FireworkRocketEntity;
@@ -1849,7 +1849,7 @@ index 530c5d656b6b362d0df85a897d7e8d0497250680..7fd2a463e9208635bd2d9f0b1a4291d6
  import net.minecraft.world.entity.schedule.Activity;
  import net.minecraft.world.level.Level;
  import net.minecraft.world.phys.AABB;
-@@ -182,7 +181,6 @@ public class ActivationRange
+@@ -181,7 +180,6 @@ public class ActivationRange
       */
      public static void activateEntities(Level world)
      {
@@ -1857,7 +1857,7 @@ index 530c5d656b6b362d0df85a897d7e8d0497250680..7fd2a463e9208635bd2d9f0b1a4291d6
          final int miscActivationRange = world.spigotConfig.miscActivationRange;
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
-@@ -262,7 +260,6 @@ public class ActivationRange
+@@ -261,7 +259,6 @@ public class ActivationRange
              }
              // Paper end
          }

--- a/patches/server/0015-Remove-Timings.patch
+++ b/patches/server/0015-Remove-Timings.patch
@@ -1838,10 +1838,10 @@ index 579c2e69d8f6ce8398eb1297d1d1ead98c9068a5..00000000000000000000000000000000
 -
 -}
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index b16970195d560dba9d0b3a258961857008b3550c..0f8987d1fe6a9e4d8e9d984d242797215993a269 100644
+index 103571f5aa880b0118e1b946e166c86b1e7bf5b5..7182d1e8746d094b5fb1e4aaa5ce3b3cb85ab1b5 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -34,7 +34,6 @@ import net.minecraft.world.entity.projectile.FireworkRocketEntity;
+@@ -35,7 +35,6 @@ import net.minecraft.world.entity.projectile.FireworkRocketEntity;
  import net.minecraft.world.entity.projectile.ThrowableProjectile;
  import net.minecraft.world.entity.projectile.ThrownTrident;
  import net.minecraft.world.entity.raid.Raider;
@@ -1849,7 +1849,7 @@ index b16970195d560dba9d0b3a258961857008b3550c..0f8987d1fe6a9e4d8e9d984d24279721
  import net.minecraft.world.entity.schedule.Activity;
  import net.minecraft.world.level.Level;
  import net.minecraft.world.phys.AABB;
-@@ -181,7 +180,6 @@ public class ActivationRange
+@@ -182,7 +181,6 @@ public class ActivationRange
       */
      public static void activateEntities(Level world)
      {
@@ -1857,7 +1857,7 @@ index b16970195d560dba9d0b3a258961857008b3550c..0f8987d1fe6a9e4d8e9d984d24279721
          final int miscActivationRange = world.spigotConfig.miscActivationRange;
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
-@@ -262,7 +260,6 @@ public class ActivationRange
+@@ -263,7 +261,6 @@ public class ActivationRange
              }
              // Paper end
          }

--- a/patches/server/0113-Multithreaded-Tracker.patch
+++ b/patches/server/0113-Multithreaded-Tracker.patch
@@ -352,14 +352,15 @@ index 14ceb3308474e76220bd64b0254df3f2925d4206..6cd45791b19df76e367d2693bce349c6
      private final net.minecraft.world.entity.LivingEntity entity; // Purpur
 diff --git a/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java b/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1fc19cc2945eff7bd5d3d3da826f4f973e5a7eb8
+index 0000000000000000000000000000000000000000..587c2c5b75dedfd8e218a8e26284ef83f56a0d51
 --- /dev/null
 +++ b/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
-@@ -0,0 +1,168 @@
+@@ -0,0 +1,189 @@
 +package org.dreeam.leaf.async.tracker;
 +
 +import ca.spottedleaf.moonrise.common.list.ReferenceList;
 +import ca.spottedleaf.moonrise.common.misc.NearbyPlayers;
++import ca.spottedleaf.moonrise.common.util.TickThread;
 +import ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemServerLevel;
 +import ca.spottedleaf.moonrise.patches.chunk_system.level.entity.server.ServerEntityLookup;
 +import ca.spottedleaf.moonrise.patches.entity_tracker.EntityTrackerEntity;
@@ -376,16 +377,36 @@ index 0000000000000000000000000000000000000000..1fc19cc2945eff7bd5d3d3da826f4f97
 +import java.util.concurrent.LinkedBlockingQueue;
 +import java.util.concurrent.ThreadPoolExecutor;
 +import java.util.concurrent.TimeUnit;
++import java.util.concurrent.atomic.AtomicInteger;
 +
 +public class MultithreadedTracker {
 +
 +    private static final Logger LOGGER = LogManager.getLogger("MultithreadedTracker");
++    public static class MultithreadedTrackerThread extends TickThread {
++        private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(0);
++        public MultithreadedTrackerThread(Runnable run, String name) {
++            super(run, name, THREAD_COUNTER.incrementAndGet());
++        }
++
++        @Override
++        public void run() {
++            super.run();
++        }
++    }
 +    private static final Executor trackerExecutor = new ThreadPoolExecutor(
 +            1,
 +            org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads,
 +            org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerKeepalive, TimeUnit.SECONDS,
 +            new LinkedBlockingQueue<>(),
 +            new ThreadFactoryBuilder()
++                    .setThreadFactory(
++                            r -> new MultithreadedTrackerThread(r, "Leaf Async Tracker Thread") {
++                                @Override
++                                public void run() {
++                                    r.run();
++                                }
++                            }
++                    )
 +                    .setNameFormat("Leaf Async Tracker Thread - %d")
 +                    .setPriority(Thread.NORM_PRIORITY - 2)
 +                    .build());

--- a/patches/server/0113-Multithreaded-Tracker.patch
+++ b/patches/server/0113-Multithreaded-Tracker.patch
@@ -352,7 +352,7 @@ index 14ceb3308474e76220bd64b0254df3f2925d4206..6cd45791b19df76e367d2693bce349c6
      private final net.minecraft.world.entity.LivingEntity entity; // Purpur
 diff --git a/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java b/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..587c2c5b75dedfd8e218a8e26284ef83f56a0d51
+index 0000000000000000000000000000000000000000..d94d34c8b63079c9a18b860a22e91c17a88b062e
 --- /dev/null
 +++ b/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
 @@ -0,0 +1,189 @@
@@ -382,7 +382,7 @@ index 0000000000000000000000000000000000000000..587c2c5b75dedfd8e218a8e26284ef83
 +public class MultithreadedTracker {
 +
 +    private static final Logger LOGGER = LogManager.getLogger("MultithreadedTracker");
-+    public static class MultithreadedTrackerThread extends TickThread {
++    private static class MultithreadedTrackerThread extends TickThread {
 +        private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(0);
 +        public MultithreadedTrackerThread(Runnable run, String name) {
 +            super(run, name, THREAD_COUNTER.incrementAndGet());

--- a/patches/server/0113-Multithreaded-Tracker.patch
+++ b/patches/server/0113-Multithreaded-Tracker.patch
@@ -223,10 +223,25 @@ index 4f91107f9ae42f96c060c310596db9aa869a8dbc..f9889f593ed144ee8f1f5bd380e631c6
      public boolean visible = true;
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
-index 05125144ce0cb50fa6ac769fa025cda010c93f14..3b40fc420ec1a8aca4c66a77f54cf628a39aa6f2 100644
+index 05125144ce0cb50fa6ac769fa025cda010c93f14..189bfe0e97943f3f560fa3c2674013e2e833bd5e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerEntity.java
 +++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
-@@ -336,7 +336,11 @@ public class ServerEntity {
+@@ -115,7 +115,13 @@ public class ServerEntity {
+             this.broadcastAndSend(new ClientboundSetPassengersPacket(this.entity)); // CraftBukkit
+             ServerEntity.removedPassengers(list, this.lastPassengers).forEach((entity) -> {
+                 if (entity instanceof ServerPlayer entityplayer) {
+-                    entityplayer.connection.teleport(entityplayer.getX(), entityplayer.getY(), entityplayer.getZ(), entityplayer.getYRot(), entityplayer.getXRot());
++                    // Leaf start - Multithreaded tracker - Ensure teleport is executed on server thread
++                    if (org.dreeam.leaf.config.modules.async.MultithreadedTracker.enabled && Thread.currentThread() instanceof org.dreeam.leaf.async.tracker.MultithreadedTracker.MultithreadedTrackerThread) {
++                        net.minecraft.server.MinecraftServer.getServer().scheduleOnMain(() -> entityplayer.connection.teleport(entityplayer.getX(), entityplayer.getY(), entityplayer.getZ(), entityplayer.getYRot(), entityplayer.getXRot()));
++                    } else {
++                        entityplayer.connection.teleport(entityplayer.getX(), entityplayer.getY(), entityplayer.getZ(), entityplayer.getYRot(), entityplayer.getXRot());
++                    }
++                    // Leaf end - Multithreaded tracker - Ensure teleport is executed on server thread
+                 }
+ 
+             });
+@@ -336,7 +342,11 @@ public class ServerEntity {
  
      public void removePairing(ServerPlayer player) {
          this.entity.stopSeenByPlayer(player);
@@ -239,7 +254,7 @@ index 05125144ce0cb50fa6ac769fa025cda010c93f14..3b40fc420ec1a8aca4c66a77f54cf628
      }
  
      public void addPairing(ServerPlayer player) {
-@@ -344,7 +348,11 @@ public class ServerEntity {
+@@ -344,7 +354,11 @@ public class ServerEntity {
  
          Objects.requireNonNull(list);
          this.sendPairingData(player, list::add);
@@ -252,7 +267,7 @@ index 05125144ce0cb50fa6ac769fa025cda010c93f14..3b40fc420ec1a8aca4c66a77f54cf628
          this.entity.startSeenByPlayer(player);
      }
  
-@@ -464,19 +472,28 @@ public class ServerEntity {
+@@ -464,19 +478,28 @@ public class ServerEntity {
  
          if (list != null) {
              this.trackedDataValues = datawatcher.getNonDefaultValues();
@@ -352,7 +367,7 @@ index 14ceb3308474e76220bd64b0254df3f2925d4206..6cd45791b19df76e367d2693bce349c6
      private final net.minecraft.world.entity.LivingEntity entity; // Purpur
 diff --git a/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java b/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d94d34c8b63079c9a18b860a22e91c17a88b062e
+index 0000000000000000000000000000000000000000..587c2c5b75dedfd8e218a8e26284ef83f56a0d51
 --- /dev/null
 +++ b/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
 @@ -0,0 +1,189 @@
@@ -382,7 +397,7 @@ index 0000000000000000000000000000000000000000..d94d34c8b63079c9a18b860a22e91c17
 +public class MultithreadedTracker {
 +
 +    private static final Logger LOGGER = LogManager.getLogger("MultithreadedTracker");
-+    private static class MultithreadedTrackerThread extends TickThread {
++    public static class MultithreadedTrackerThread extends TickThread {
 +        private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(0);
 +        public MultithreadedTrackerThread(Runnable run, String name) {
 +            super(run, name, THREAD_COUNTER.incrementAndGet());

--- a/patches/server/0124-Optimize-Entity-distanceToSqr.patch
+++ b/patches/server/0124-Optimize-Entity-distanceToSqr.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 29 Oct 2077 00:00:00 +0800
+Subject: [PATCH] Optimize Entity distanceToSqr
+
+This patch optimizes Entity#distanceToSqr call by using Math#fma which is around 1.2x to 4x faster than original method on CPUs support Fused Multiply-Add (FMA) operation,
+avoids multiple casting in Entity#distanceTo, using Math#hypot instead of Mojang's Mth#sqrt. Additionally, this patch makes
+these methods more able to be inlined by the JIT compiler.
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 08a3714c530fb375ee729e91965c65efb9e6e3d2..976d72b611011cccf4b4efadc9772ce1c68ef5ee 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -2368,33 +2368,41 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+         this.xRotO = this.getXRot();
+     }
+ 
+-    public float distanceTo(Entity entity) {
+-        float f = (float) (this.getX() - entity.getX());
+-        float f1 = (float) (this.getY() - entity.getY());
+-        float f2 = (float) (this.getZ() - entity.getZ());
++    // Leaf start - Optimize distanceTo - inlining
++    public final float distanceTo(Entity entity) {
++        // Leaf start - Optimize distanceTo - Avoid casting
++        final double dx = this.getX() - entity.getX();
++        final double dy = this.getY() - entity.getY();
++        final double dz = this.getZ() - entity.getZ();
++        // Leaf end - Optimize distanceTo - Avoid casting
+ 
+-        return Mth.sqrt(f * f + f1 * f1 + f2 * f2);
++        return (float) Math.hypot(dx, Math.hypot(dy, dz)); // Leaf - Use Math#hypot instead of Mojang's Mth#sqrt
+     }
++    // Leaf end - Optimize distanceTo - inlining
+ 
+-    public double distanceToSqr(double x, double y, double z) {
+-        double d3 = this.getX() - x;
+-        double d4 = this.getY() - y;
+-        double d5 = this.getZ() - z;
++    // Leaf start - Optimize distanceToSqr - inlining
++    public final double distanceToSqr(final double x, final double y, final double z) {
++        final double dx = this.getX() - x;
++        final double dy = this.getY() - y;
++        final double dz = this.getZ() - z;
+ 
+-        return d3 * d3 + d4 * d4 + d5 * d5;
++        return org.dreeam.leaf.LeafBootstrap.enableFMA ? Math.fma(dx, dx, Math.fma(dy, dy, dz * dz)) : dx * dx + dy * dy + dz * dz; // Leaf - Use FMA for distanceToSqr
+     }
++    // Leaf end - Optimize distanceToSqr
+ 
+     public double distanceToSqr(Entity entity) {
+         return this.distanceToSqr(entity.position());
+     }
+ 
+-    public double distanceToSqr(Vec3 vector) {
+-        double d0 = this.getX() - vector.x;
+-        double d1 = this.getY() - vector.y;
+-        double d2 = this.getZ() - vector.z;
++    // Leaf start - Optimize distanceToSqr - inlining
++    public final double distanceToSqr(Vec3 vector) {
++        final double dx = this.getX() - vector.x;
++        final double dy = this.getY() - vector.y;
++        final double dz = this.getZ() - vector.z;
+ 
+-        return d0 * d0 + d1 * d1 + d2 * d2;
++        return org.dreeam.leaf.LeafBootstrap.enableFMA ? Math.fma(dx, dx, Math.fma(dy, dy, dz * dz)) : dx * dx + dy * dy + dz * dz; // Leaf - Use FMA for distanceToSqr
+     }
++    // Leaf end - Optimize distanceToSqr - inlining
+ 
+     public void playerTouch(Player player) {}
+ 
+diff --git a/src/main/java/org/dreeam/leaf/LeafBootstrap.java b/src/main/java/org/dreeam/leaf/LeafBootstrap.java
+index 2f5122a61af183d6a4c20a175122c228b6e9fc48..9055727c16659ae43eb5424f0aa61e419f53483e 100644
+--- a/src/main/java/org/dreeam/leaf/LeafBootstrap.java
++++ b/src/main/java/org/dreeam/leaf/LeafBootstrap.java
+@@ -4,6 +4,7 @@ import io.papermc.paper.PaperBootstrap;
+ import joptsimple.OptionSet;
+ 
+ public class LeafBootstrap {
++    public static final boolean enableFMA = Boolean.parseBoolean(System.getProperty("Leaf.enableFMA", "false")); // Leaf - FMA feature
+ 
+     public static void boot(final OptionSet options) {
+         runPreBootTasks();

--- a/patches/server/0124-Optimize-Entity-distanceToSqr.patch
+++ b/patches/server/0124-Optimize-Entity-distanceToSqr.patch
@@ -1,9 +1,9 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
-Date: Tue, 29 Oct 2077 00:00:00 +0800
+Date: Fri, 29 Oct 2077 00:00:00 +0800
 Subject: [PATCH] Optimize Entity distanceToSqr
 
-This patch optimizes Entity#distanceToSqr call by using Math#fma which is around 1.2x to 4x faster than original method on CPUs support Fused Multiply-Add (FMA) operation,
+This patch optimizes Entity#distanceToSqr call by using Math#fma which is around 1.2x to 4x faster than original method,
 avoids multiple casting in Entity#distanceTo, using Math#hypot instead of Mojang's Mth#sqrt. Additionally, this patch makes
 these methods more able to be inlined by the JIT compiler.
 


### PR DESCRIPTION
This pull request added a config option `dont-enable-if-in-water` to DAB. After enabling this, non-aquatic entities in the water will not be affected by DAB.  This could fix entities suffocate in the water.