### PR TITLE
Smooth teleport config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     `maven-publish`
-    id("io.papermc.paperweight.patcher") version "1.7.4-SNAPSHOT"
+    id("io.papermc.paperweight.patcher") version "1.7.6-SNAPSHOT"
 }
 
 val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"

--- a/patches/server/0155-Smooth-teleport-config.patch
+++ b/patches/server/0155-Smooth-teleport-config.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Smooth teleport config
+
+This abuses some of how Minecraft works and attempts to teleport a player to another world without
+triggering typical respawn packets. All of natural state of chunk resends, entity adds/removes, etc still
+happen but the visual "refresh" of a world change is hidden. Depending on the destination location/world,
+this can act as a "smooth teleport" to a world if the new world is very similar looking to the old one.
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index edef689792b163e6a33921fe2e4b1af69715a2ee..28723ab8bd72ff0db5e21c68f44f0a8d96b37653 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -1422,7 +1422,11 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+                 this.isChangingDimension = true; // CraftBukkit - Set teleport invulnerability only if player changing worlds
+                 LevelData worlddata = worldserver.getLevelData();
+ 
+-                this.connection.send(new ClientboundRespawnPacket(this.createCommonSpawnInfo(worldserver), (byte) 3));
++                // Leaf start - Smooth teleport
++                int previousLogicalHeight = worldserver1.getLogicalHeight();
++                int currentLogicalHeight = worldserver.getLogicalHeight();
++                if (!org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled || previousLogicalHeight != currentLogicalHeight) this.connection.send(new ClientboundRespawnPacket(this.createCommonSpawnInfo(worldserver), (byte) 3));
++                // Leaf end - Smooth teleport
+                 this.connection.send(new ClientboundChangeDifficultyPacket(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
+                 PlayerList playerlist = this.server.getPlayerList();
+ 
+@@ -1432,7 +1436,7 @@ public class ServerPlayer extends net.minecraft.world.entity.player.Player imple
+                 // CraftBukkit end
+                 this.portalPos = io.papermc.paper.util.MCUtil.toBlockPosition(exit); // Purpur - Fix stuck in portals
+                 this.setServerLevel(worldserver);
+-                this.connection.teleport(exit); // CraftBukkit - use internal teleport without event
++                if (!org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled || previousLogicalHeight != currentLogicalHeight) this.connection.teleport(exit); // CraftBukkit - use internal teleport without event // Leaf
+                 this.connection.resetPosition();
+                 worldserver.addDuringTeleport(this);
+                 this.triggerDimensionChangeTriggers(worldserver1);
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index f3b98a4a66cec8d6c9dc46479d573c2fb453837a..497da59f9b4002e176f96e3d6be6c0f18eab488d 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -1057,10 +1057,10 @@ public abstract class PlayerList {
+         ServerLevel worldserver1 = entityplayer1.serverLevel();
+         LevelData worlddata = worldserver1.getLevelData();
+ 
+-        if (!entityplayer.smoothWorldTeleport || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.send(new ClientboundRespawnPacket(entityplayer1.createCommonSpawnInfo(worldserver1), (byte) i)); // Slice // Leaf
++        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled) || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.send(new ClientboundRespawnPacket(entityplayer1.createCommonSpawnInfo(worldserver1), (byte) i)); // Slice // Leaf
+         entityplayer1.connection.send(new ClientboundSetChunkCacheRadiusPacket(worldserver1.spigotConfig.viewDistance)); // Spigot
+         entityplayer1.connection.send(new ClientboundSetSimulationDistancePacket(worldserver1.spigotConfig.simulationDistance)); // Spigot
+-        if (!entityplayer.smoothWorldTeleport || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.teleport(CraftLocation.toBukkit(entityplayer1.position(), worldserver1.getWorld(), entityplayer1.getYRot(), entityplayer1.getXRot())); // CraftBukkit // Slice // Leaf
++        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled) || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.teleport(CraftLocation.toBukkit(entityplayer1.position(), worldserver1.getWorld(), entityplayer1.getYRot(), entityplayer1.getXRot())); // CraftBukkit // Slice // Leaf
+         entityplayer1.connection.send(new ClientboundSetDefaultSpawnPositionPacket(worldserver.getSharedSpawnPos(), worldserver.getSharedSpawnAngle()));
+         entityplayer1.connection.send(new ClientboundChangeDifficultyPacket(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
+         entityplayer1.connection.send(new ClientboundSetExperiencePacket(entityplayer1.experienceProgress, entityplayer1.totalExperience, entityplayer1.experienceLevel));
+diff --git a/src/main/java/org/dreeam/leaf/config/modules/gameplay/SmoothTeleport.java b/src/main/java/org/dreeam/leaf/config/modules/gameplay/SmoothTeleport.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..5fd8923efb2f8369d990767d40d75c004ceb7a1b
+--- /dev/null
++++ b/src/main/java/org/dreeam/leaf/config/modules/gameplay/SmoothTeleport.java
+@@ -0,0 +1,27 @@
++package org.dreeam.leaf.config.modules.gameplay;
++
++import org.dreeam.leaf.config.ConfigModules;
++import org.dreeam.leaf.config.EnumConfigCategory;
++
++public class SmoothTeleport extends ConfigModules {
++
++    public String getBasePath() {
++        return EnumConfigCategory.GAMEPLAY.getBaseKeyName() + ".smooth-teleport";
++    }
++
++    public static boolean enabled = false;
++
++    @Override
++    public void onLoaded() {
++        enabled = config.getBoolean(getBasePath(), enabled, config.pickStringRegionBased(
++                """
++                        **Experimental feature, report any bugs you encounter!**
++                        Whether to make a "smooth teleport" when players changing dimension.
++                        This requires original world and target world have same logical height to work.""",
++                """
++                        **实验性功能, 请及时反馈你遇到的问题!**
++                        是否在玩家切换世界时尝试使用 "平滑传送".
++                        此项要求源世界和目标世界逻辑高度相同才会生效."""
++        ));
++    }
++}

--- a/patches/server/0155-Smooth-teleport-config.patch
+++ b/patches/server/0155-Smooth-teleport-config.patch
@@ -35,7 +35,7 @@ index edef689792b163e6a33921fe2e4b1af69715a2ee..28723ab8bd72ff0db5e21c68f44f0a8d
                  worldserver.addDuringTeleport(this);
                  this.triggerDimensionChangeTriggers(worldserver1);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f3b98a4a66cec8d6c9dc46479d573c2fb453837a..73e5823bef9e4d37bfe4e26336c797930c0690a1 100644
+index f3b98a4a66cec8d6c9dc46479d573c2fb453837a..00b9d244898ffdc1584eb254643557776bf4a76f 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1057,10 +1057,10 @@ public abstract class PlayerList {
@@ -43,11 +43,11 @@ index f3b98a4a66cec8d6c9dc46479d573c2fb453837a..73e5823bef9e4d37bfe4e26336c79793
          LevelData worlddata = worldserver1.getLevelData();
  
 -        if (!entityplayer.smoothWorldTeleport || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.send(new ClientboundRespawnPacket(entityplayer1.createCommonSpawnInfo(worldserver1), (byte) i)); // Slice // Leaf
-+        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled || i != 1) || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.send(new ClientboundRespawnPacket(entityplayer1.createCommonSpawnInfo(worldserver1), (byte) i)); // Slice // Leaf
++        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled) || i != 1 || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.send(new ClientboundRespawnPacket(entityplayer1.createCommonSpawnInfo(worldserver1), (byte) i)); // Slice // Leaf
          entityplayer1.connection.send(new ClientboundSetChunkCacheRadiusPacket(worldserver1.spigotConfig.viewDistance)); // Spigot
          entityplayer1.connection.send(new ClientboundSetSimulationDistancePacket(worldserver1.spigotConfig.simulationDistance)); // Spigot
 -        if (!entityplayer.smoothWorldTeleport || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.teleport(CraftLocation.toBukkit(entityplayer1.position(), worldserver1.getWorld(), entityplayer1.getYRot(), entityplayer1.getXRot())); // CraftBukkit // Slice // Leaf
-+        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled || i != 1) || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.teleport(CraftLocation.toBukkit(entityplayer1.position(), worldserver1.getWorld(), entityplayer1.getYRot(), entityplayer1.getXRot())); // CraftBukkit // Slice // Leaf
++        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled) || i != 1 || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.teleport(CraftLocation.toBukkit(entityplayer1.position(), worldserver1.getWorld(), entityplayer1.getYRot(), entityplayer1.getXRot())); // CraftBukkit // Slice // Leaf
          entityplayer1.connection.send(new ClientboundSetDefaultSpawnPositionPacket(worldserver.getSharedSpawnPos(), worldserver.getSharedSpawnAngle()));
          entityplayer1.connection.send(new ClientboundChangeDifficultyPacket(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
          entityplayer1.connection.send(new ClientboundSetExperiencePacket(entityplayer1.experienceProgress, entityplayer1.totalExperience, entityplayer1.experienceLevel));

--- a/patches/server/0155-Smooth-teleport-config.patch
+++ b/patches/server/0155-Smooth-teleport-config.patch
@@ -35,7 +35,7 @@ index edef689792b163e6a33921fe2e4b1af69715a2ee..28723ab8bd72ff0db5e21c68f44f0a8d
                  worldserver.addDuringTeleport(this);
                  this.triggerDimensionChangeTriggers(worldserver1);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f3b98a4a66cec8d6c9dc46479d573c2fb453837a..497da59f9b4002e176f96e3d6be6c0f18eab488d 100644
+index f3b98a4a66cec8d6c9dc46479d573c2fb453837a..73e5823bef9e4d37bfe4e26336c797930c0690a1 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1057,10 +1057,10 @@ public abstract class PlayerList {
@@ -43,11 +43,11 @@ index f3b98a4a66cec8d6c9dc46479d573c2fb453837a..497da59f9b4002e176f96e3d6be6c0f1
          LevelData worlddata = worldserver1.getLevelData();
  
 -        if (!entityplayer.smoothWorldTeleport || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.send(new ClientboundRespawnPacket(entityplayer1.createCommonSpawnInfo(worldserver1), (byte) i)); // Slice // Leaf
-+        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled) || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.send(new ClientboundRespawnPacket(entityplayer1.createCommonSpawnInfo(worldserver1), (byte) i)); // Slice // Leaf
++        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled || i != 1) || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.send(new ClientboundRespawnPacket(entityplayer1.createCommonSpawnInfo(worldserver1), (byte) i)); // Slice // Leaf
          entityplayer1.connection.send(new ClientboundSetChunkCacheRadiusPacket(worldserver1.spigotConfig.viewDistance)); // Spigot
          entityplayer1.connection.send(new ClientboundSetSimulationDistancePacket(worldserver1.spigotConfig.simulationDistance)); // Spigot
 -        if (!entityplayer.smoothWorldTeleport || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.teleport(CraftLocation.toBukkit(entityplayer1.position(), worldserver1.getWorld(), entityplayer1.getYRot(), entityplayer1.getXRot())); // CraftBukkit // Slice // Leaf
-+        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled) || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.teleport(CraftLocation.toBukkit(entityplayer1.position(), worldserver1.getWorld(), entityplayer1.getYRot(), entityplayer1.getXRot())); // CraftBukkit // Slice // Leaf
++        if ((!entityplayer.smoothWorldTeleport && !org.dreeam.leaf.config.modules.gameplay.SmoothTeleport.enabled || i != 1) || !isSameLogicalHeight((ServerLevel) fromWorld, worldserver)) entityplayer1.connection.teleport(CraftLocation.toBukkit(entityplayer1.position(), worldserver1.getWorld(), entityplayer1.getYRot(), entityplayer1.getXRot())); // CraftBukkit // Slice // Leaf
          entityplayer1.connection.send(new ClientboundSetDefaultSpawnPositionPacket(worldserver.getSharedSpawnPos(), worldserver.getSharedSpawnAngle()));
          entityplayer1.connection.send(new ClientboundChangeDifficultyPacket(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
          entityplayer1.connection.send(new ClientboundSetExperiencePacket(entityplayer1.experienceProgress, entityplayer1.totalExperience, entityplayer1.experienceLevel));


### PR DESCRIPTION
This pull request made smooth teleport not only through bukkit api calls but also through config, requires origin world and target world to have same logical height to work properly.

For example, overworld->nether/world_the_end will not trigger smooth teleport, but overworld->plot(which is backed by overworld) does.

Tested with Multiverse-core and MyWorld plugin, works fine.

Make it as a separate patch to clarify which part is taken from Slice.