### PR TITLE
Async task handling improvement

### DIFF
--- a/.github/workflows/build-1214.yml
+++ b/.github/workflows/build-1214.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "dev/1.21.4" ]
   pull_request:
-    branches: [ "ver/1.21.4" ]
+    branches: [ "dev/1.21.4" ]
 
 jobs:
   build:

--- a/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
+++ b/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
@@ -10,6 +10,10 @@ Original project:  https://github.com/KaiijuMC/Kaiiju
 Original license: GPLv3
 Original project: https://github.com/Bloom-host/Petal
 
+Co-authored-by: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Co-authored-by: Taiyou06 <kaandindar21@gmail.com>
+Co-authored-by: Altiami <yoshimo.kristin@gmail.com>
+
 This patch was ported downstream from the Petal fork.
 
 Makes most pathfinding-related work happen asynchronously

--- a/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
+++ b/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
@@ -725,7 +725,7 @@ index d6d3c8f5e5dd4a8cab0d3fcc131c3a59f06130c6..add5b8b98e4d09617cbd4e7dd2710dc5
              return false;
          } else if (pathentity.nodes.size() != this.nodes.size()) {
 diff --git a/net/minecraft/world/level/pathfinder/PathFinder.java b/net/minecraft/world/level/pathfinder/PathFinder.java
-index c2baadcdceb1df6a881d6f73aa4eb4dd264bcdfe..61912c67611ded5a8f34e0c55d3d3017f144f970 100644
+index c2baadcdceb1df6a881d6f73aa4eb4dd264bcdfe..754f71ae575cad5ec975b1c88441e1b67c92c240 100644
 --- a/net/minecraft/world/level/pathfinder/PathFinder.java
 +++ b/net/minecraft/world/level/pathfinder/PathFinder.java
 @@ -22,10 +22,18 @@ public class PathFinder {
@@ -785,7 +785,7 @@ index c2baadcdceb1df6a881d6f73aa4eb4dd264bcdfe..61912c67611ded5a8f34e0c55d3d3017
 +                return this.findPath(start, map, maxRange, accuracy, searchDepthMultiplier);
 +            }
 +
-+            return new org.dreeam.leaf.async.path.AsyncPath(Lists.newArrayList(), targetPositions, () -> {
++            return new org.dreeam.leaf.async.path.AsyncPath(mob.getUUID(), Lists.newArrayList(), targetPositions, () -> {
 +                try {
 +                    return this.processPath(nodeEvaluator, start, map, maxRange, accuracy, searchDepthMultiplier);
 +                } catch (Exception e) {

--- a/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
+++ b/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
@@ -27,7 +27,7 @@ index 14d9dceacc82cc6c085dab8f52e59a318dd8cae5..8b3dfb1385a2252a4aaead5558c0ffbd
      }
  
 diff --git a/net/minecraft/world/entity/ai/behavior/AcquirePoi.java b/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
-index 7f0975f8bd6d5f8ca28f503f93c8cb5c42557420..36a9771076d0b323cba828d142a8116f8c28481a 100644
+index 7f0975f8bd6d5f8ca28f503f93c8cb5c42557420..eb71f045d3e8698a8a9e9f51176c2884f71a034c 100644
 --- a/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
 +++ b/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
 @@ -102,21 +102,20 @@ public class AcquirePoi {
@@ -49,7 +49,7 @@ index 7f0975f8bd6d5f8ca28f503f93c8cb5c42557420..36a9771076d0b323cba828d142a8116f
 +                                Path possiblePath = findPathToPois(mob, set);
 +
 +                                // wait on the path to be processed
-+                                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(mob, possiblePath, path -> {
++                                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(possiblePath, path -> {
 +                                    processPath(acquirablePois, entityEventId, (Long2ObjectMap<JitteredLinearRetry>) map, memoryAccessor, level, mob, time, poiManager, set, path);
                                  });
                              } else {
@@ -225,7 +225,7 @@ index 621ba76784f2b92790eca62be4d0688834335ab6..e2e1532d2ffb709e347db42b1b5b6cae
      private boolean tryComputePath(Mob mob, WalkTarget target, long time) {
          BlockPos blockPos = target.getTarget().currentBlockPosition();
 diff --git a/net/minecraft/world/entity/ai/behavior/SetClosestHomeAsWalkTarget.java b/net/minecraft/world/entity/ai/behavior/SetClosestHomeAsWalkTarget.java
-index 4f9f3367b1ca3903df03a80fa2b01a3d24e6e77d..8c1ad993aa7e59e96df9959c2c2a47cfa9e33515 100644
+index 4f9f3367b1ca3903df03a80fa2b01a3d24e6e77d..51413df5cd61b3ff59c6c6c3ec69d6732ab07d83 100644
 --- a/net/minecraft/world/entity/ai/behavior/SetClosestHomeAsWalkTarget.java
 +++ b/net/minecraft/world/entity/ai/behavior/SetClosestHomeAsWalkTarget.java
 @@ -60,17 +60,20 @@ public class SetClosestHomeAsWalkTarget {
@@ -238,7 +238,7 @@ index 4f9f3367b1ca3903df03a80fa2b01a3d24e6e77d..8c1ad993aa7e59e96df9959c2c2a47cf
 +                                    Path possiblePath = AcquirePoi.findPathToPois(mob, set);
 +
 +                                    // wait on the path to be processed
-+                                    org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(mob, possiblePath, path -> {
++                                    org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(possiblePath, path -> {
 +                                        processPath(speedModifier, map, mutableLong, walkTarget, level, poiManager, mutableInt, path);
 +                                    });
 +                                } else {
@@ -398,7 +398,7 @@ index 045cfafb3afe8271d60852ae3c7cdcb039b44d4f..3f55b00e2f8924a8450df8a3f9812a4a
      }
  
 diff --git a/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-index 6c8fb611943aee8cabc471c63166f9b44ef14826..d2a4fef7460b6ec6b9119cdde31663adaf14a697 100644
+index 6c8fb611943aee8cabc471c63166f9b44ef14826..25ef9b67eee01c6df466031c5dbc728b1a754ab2 100644
 --- a/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 +++ b/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 @@ -167,6 +167,10 @@ public abstract class PathNavigation {
@@ -421,7 +421,7 @@ index 6c8fb611943aee8cabc471c63166f9b44ef14826..d2a4fef7460b6ec6b9119cdde31663ad
 +                // assign early a target position. most calls will only have 1 position
 +                if (!targets.isEmpty()) this.targetPos = targets.iterator().next();
 +
-+                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(mob, path, processedPath -> {
++                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(path, processedPath -> {
 +                    // check that processing didn't take so long that we calculated a new path
 +                    if (processedPath != this.path) return;
 +
@@ -511,7 +511,7 @@ index 2979846853898d78a2df19df2287da16dbe4ae71..1289a6e85f3fdb9187323343b6c20e17
      }
  
 diff --git a/net/minecraft/world/entity/ai/sensing/NearestBedSensor.java b/net/minecraft/world/entity/ai/sensing/NearestBedSensor.java
-index 1f96fd5085bacb4c584576c7cb9f51e7898e9b03..3af61b7862e63acf691b1a401e4752076faf29c7 100644
+index 1f96fd5085bacb4c584576c7cb9f51e7898e9b03..8819717c5307a90abc493cf801b4e795c13b3460 100644
 --- a/net/minecraft/world/entity/ai/sensing/NearestBedSensor.java
 +++ b/net/minecraft/world/entity/ai/sensing/NearestBedSensor.java
 @@ -57,17 +57,32 @@ public class NearestBedSensor extends Sensor<Mob> {
@@ -531,8 +531,8 @@ index 1f96fd5085bacb4c584576c7cb9f51e7898e9b03..3af61b7862e63acf691b1a401e475207
 +            // Kaiiju start - await on async path processing
 +            if (org.dreeam.leaf.config.modules.async.AsyncPathfinding.enabled) {
 +                Path possiblePath = AcquirePoi.findPathToPois(entity, new java.util.HashSet<>(poiposes));
-+                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(entity, possiblePath, path -> {
-+                    processPath(entity, poiManager, possiblePath);
++                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(possiblePath, path -> {
++                    processPath(entity, poiManager, path);
 +                });
 +            } else {
 +                // Kaiiju end

--- a/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
+++ b/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
@@ -27,7 +27,7 @@ index 14d9dceacc82cc6c085dab8f52e59a318dd8cae5..8b3dfb1385a2252a4aaead5558c0ffbd
      }
  
 diff --git a/net/minecraft/world/entity/ai/behavior/AcquirePoi.java b/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
-index 7f0975f8bd6d5f8ca28f503f93c8cb5c42557420..eb71f045d3e8698a8a9e9f51176c2884f71a034c 100644
+index 7f0975f8bd6d5f8ca28f503f93c8cb5c42557420..36a9771076d0b323cba828d142a8116f8c28481a 100644
 --- a/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
 +++ b/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
 @@ -102,21 +102,20 @@ public class AcquirePoi {
@@ -49,7 +49,7 @@ index 7f0975f8bd6d5f8ca28f503f93c8cb5c42557420..eb71f045d3e8698a8a9e9f51176c2884
 +                                Path possiblePath = findPathToPois(mob, set);
 +
 +                                // wait on the path to be processed
-+                                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(possiblePath, path -> {
++                                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(mob, possiblePath, path -> {
 +                                    processPath(acquirablePois, entityEventId, (Long2ObjectMap<JitteredLinearRetry>) map, memoryAccessor, level, mob, time, poiManager, set, path);
                                  });
                              } else {
@@ -225,7 +225,7 @@ index 621ba76784f2b92790eca62be4d0688834335ab6..e2e1532d2ffb709e347db42b1b5b6cae
      private boolean tryComputePath(Mob mob, WalkTarget target, long time) {
          BlockPos blockPos = target.getTarget().currentBlockPosition();
 diff --git a/net/minecraft/world/entity/ai/behavior/SetClosestHomeAsWalkTarget.java b/net/minecraft/world/entity/ai/behavior/SetClosestHomeAsWalkTarget.java
-index 4f9f3367b1ca3903df03a80fa2b01a3d24e6e77d..51413df5cd61b3ff59c6c6c3ec69d6732ab07d83 100644
+index 4f9f3367b1ca3903df03a80fa2b01a3d24e6e77d..8c1ad993aa7e59e96df9959c2c2a47cfa9e33515 100644
 --- a/net/minecraft/world/entity/ai/behavior/SetClosestHomeAsWalkTarget.java
 +++ b/net/minecraft/world/entity/ai/behavior/SetClosestHomeAsWalkTarget.java
 @@ -60,17 +60,20 @@ public class SetClosestHomeAsWalkTarget {
@@ -238,7 +238,7 @@ index 4f9f3367b1ca3903df03a80fa2b01a3d24e6e77d..51413df5cd61b3ff59c6c6c3ec69d673
 +                                    Path possiblePath = AcquirePoi.findPathToPois(mob, set);
 +
 +                                    // wait on the path to be processed
-+                                    org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(possiblePath, path -> {
++                                    org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(mob, possiblePath, path -> {
 +                                        processPath(speedModifier, map, mutableLong, walkTarget, level, poiManager, mutableInt, path);
 +                                    });
 +                                } else {
@@ -398,7 +398,7 @@ index 045cfafb3afe8271d60852ae3c7cdcb039b44d4f..3f55b00e2f8924a8450df8a3f9812a4a
      }
  
 diff --git a/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-index 6c8fb611943aee8cabc471c63166f9b44ef14826..25ef9b67eee01c6df466031c5dbc728b1a754ab2 100644
+index 6c8fb611943aee8cabc471c63166f9b44ef14826..d2a4fef7460b6ec6b9119cdde31663adaf14a697 100644
 --- a/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 +++ b/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 @@ -167,6 +167,10 @@ public abstract class PathNavigation {
@@ -421,7 +421,7 @@ index 6c8fb611943aee8cabc471c63166f9b44ef14826..25ef9b67eee01c6df466031c5dbc728b
 +                // assign early a target position. most calls will only have 1 position
 +                if (!targets.isEmpty()) this.targetPos = targets.iterator().next();
 +
-+                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(path, processedPath -> {
++                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(mob, path, processedPath -> {
 +                    // check that processing didn't take so long that we calculated a new path
 +                    if (processedPath != this.path) return;
 +
@@ -511,7 +511,7 @@ index 2979846853898d78a2df19df2287da16dbe4ae71..1289a6e85f3fdb9187323343b6c20e17
      }
  
 diff --git a/net/minecraft/world/entity/ai/sensing/NearestBedSensor.java b/net/minecraft/world/entity/ai/sensing/NearestBedSensor.java
-index 1f96fd5085bacb4c584576c7cb9f51e7898e9b03..8819717c5307a90abc493cf801b4e795c13b3460 100644
+index 1f96fd5085bacb4c584576c7cb9f51e7898e9b03..3af61b7862e63acf691b1a401e4752076faf29c7 100644
 --- a/net/minecraft/world/entity/ai/sensing/NearestBedSensor.java
 +++ b/net/minecraft/world/entity/ai/sensing/NearestBedSensor.java
 @@ -57,17 +57,32 @@ public class NearestBedSensor extends Sensor<Mob> {
@@ -531,8 +531,8 @@ index 1f96fd5085bacb4c584576c7cb9f51e7898e9b03..8819717c5307a90abc493cf801b4e795
 +            // Kaiiju start - await on async path processing
 +            if (org.dreeam.leaf.config.modules.async.AsyncPathfinding.enabled) {
 +                Path possiblePath = AcquirePoi.findPathToPois(entity, new java.util.HashSet<>(poiposes));
-+                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(possiblePath, path -> {
-+                    processPath(entity, poiManager, path);
++                org.dreeam.leaf.async.path.AsyncPathProcessor.awaitProcessing(entity, possiblePath, path -> {
++                    processPath(entity, poiManager, possiblePath);
 +                });
 +            } else {
 +                // Kaiiju end

--- a/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
+++ b/leaf-server/minecraft-patches/features/0026-Petal-Async-Pathfinding.patch
@@ -725,7 +725,7 @@ index d6d3c8f5e5dd4a8cab0d3fcc131c3a59f06130c6..add5b8b98e4d09617cbd4e7dd2710dc5
              return false;
          } else if (pathentity.nodes.size() != this.nodes.size()) {
 diff --git a/net/minecraft/world/level/pathfinder/PathFinder.java b/net/minecraft/world/level/pathfinder/PathFinder.java
-index c2baadcdceb1df6a881d6f73aa4eb4dd264bcdfe..754f71ae575cad5ec975b1c88441e1b67c92c240 100644
+index c2baadcdceb1df6a881d6f73aa4eb4dd264bcdfe..61912c67611ded5a8f34e0c55d3d3017f144f970 100644
 --- a/net/minecraft/world/level/pathfinder/PathFinder.java
 +++ b/net/minecraft/world/level/pathfinder/PathFinder.java
 @@ -22,10 +22,18 @@ public class PathFinder {
@@ -785,7 +785,7 @@ index c2baadcdceb1df6a881d6f73aa4eb4dd264bcdfe..754f71ae575cad5ec975b1c88441e1b6
 +                return this.findPath(start, map, maxRange, accuracy, searchDepthMultiplier);
 +            }
 +
-+            return new org.dreeam.leaf.async.path.AsyncPath(mob.getUUID(), Lists.newArrayList(), targetPositions, () -> {
++            return new org.dreeam.leaf.async.path.AsyncPath(Lists.newArrayList(), targetPositions, () -> {
 +                try {
 +                    return this.processPath(nodeEvaluator, start, map, maxRange, accuracy, searchDepthMultiplier);
 +                } catch (Exception e) {

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
@@ -11,7 +11,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Supplier;
 
 /**
@@ -66,16 +65,13 @@ public class AsyncPath extends Path {
      */
     private boolean canReach = true;
 
-    private final UUID owner;
-
-    public AsyncPath(@NotNull UUID owner, @NotNull List<Node> emptyNodeList, @NotNull Set<BlockPos> positions, @NotNull Supplier<Path> pathSupplier) {
+    public AsyncPath(@NotNull List<Node> emptyNodeList, @NotNull Set<BlockPos> positions, @NotNull Supplier<Path> pathSupplier) {
         //noinspection ConstantConditions
         super(emptyNodeList, null, false);
 
         this.nodes = emptyNodeList;
         this.positions = positions;
         this.pathSupplier = pathSupplier;
-        this.owner = owner;
 
         AsyncPathProcessor.queue(this);
     }
@@ -119,7 +115,6 @@ public class AsyncPath extends Path {
             return;
         }
 
-        AsyncPathProcessor.removeFromQueue(this.owner);
         processState = PathProcessState.PROCESSING;
 
         final Path bestPath = this.pathSupplier.get();
@@ -289,9 +284,5 @@ public class AsyncPath extends Path {
 
     public PathProcessState getProcessState() {
         return processState;
-    }
-
-    public UUID getPathOwner() {
-        return owner;
     }
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
@@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 /**
@@ -65,13 +66,16 @@ public class AsyncPath extends Path {
      */
     private boolean canReach = true;
 
-    public AsyncPath(@NotNull List<Node> emptyNodeList, @NotNull Set<BlockPos> positions, @NotNull Supplier<Path> pathSupplier) {
+    private final UUID owner;
+
+    public AsyncPath(@NotNull UUID owner, @NotNull List<Node> emptyNodeList, @NotNull Set<BlockPos> positions, @NotNull Supplier<Path> pathSupplier) {
         //noinspection ConstantConditions
         super(emptyNodeList, null, false);
 
         this.nodes = emptyNodeList;
         this.positions = positions;
         this.pathSupplier = pathSupplier;
+        this.owner = owner;
 
         AsyncPathProcessor.queue(this);
     }
@@ -115,6 +119,7 @@ public class AsyncPath extends Path {
             return;
         }
 
+        AsyncPathProcessor.removeFromQueue(this.owner);
         processState = PathProcessState.PROCESSING;
 
         final Path bestPath = this.pathSupplier.get();
@@ -284,5 +289,9 @@ public class AsyncPath extends Path {
 
     public PathProcessState getProcessState() {
         return processState;
+    }
+
+    public UUID getPathOwner() {
+        return owner;
     }
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
@@ -20,7 +20,9 @@ import java.util.function.Consumer;
  * used to handle the scheduling of async path processing
  */
 public class AsyncPathProcessor {
-    private static final Logger LOGGER = LogManager.getLogger("AsyncPathProcessor");
+
+    private static final String THREAD_PREFIX = "Leaf Async Pathfinding";
+    private static final Logger LOGGER = LogManager.getLogger(THREAD_PREFIX);
     private static long lastWarnMillis = System.currentTimeMillis();
     private static final ThreadPoolExecutor pathProcessingExecutor = new ThreadPoolExecutor(
         org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingMaxThreads,
@@ -28,7 +30,7 @@ public class AsyncPathProcessor {
         org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingKeepalive, TimeUnit.SECONDS,
         getQueueImpl(),
         new ThreadFactoryBuilder()
-            .setNameFormat("Leaf Async Pathfinding Thread - %d")
+            .setNameFormat(THREAD_PREFIX + " Thread - %d")
             .setPriority(Thread.NORM_PRIORITY - 2)
             .build(),
         new RejectedTaskHandler()

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
@@ -25,7 +25,7 @@ public class AsyncPathProcessor {
     private static final Logger LOGGER = LogManager.getLogger(THREAD_PREFIX);
     private static long lastWarnMillis = System.currentTimeMillis();
     private static final ThreadPoolExecutor pathProcessingExecutor = new ThreadPoolExecutor(
-        org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingMaxThreads,
+        1,
         org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingMaxThreads,
         org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingKeepalive, TimeUnit.SECONDS,
         getQueueImpl(),
@@ -35,10 +35,6 @@ public class AsyncPathProcessor {
             .build(),
         new RejectedTaskHandler()
     );
-
-    static {
-        pathProcessingExecutor.allowCoreThreadTimeOut(true);
-    }
 
     private static class RejectedTaskHandler implements RejectedExecutionHandler {
         @Override

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
@@ -3,7 +3,7 @@ package org.dreeam.leaf.async.path;
 import com.destroystokyo.paper.util.SneakyThrow;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import net.minecraft.world.entity.Entity;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.level.pathfinder.Path;
 
 import org.apache.logging.log4j.LogManager;
@@ -77,14 +77,13 @@ public class AsyncPathProcessor {
      * the consumer will be immediately invoked if the path is already processed
      * the consumer will always be called on the main thread
      *
-     * @param entity          the entity that owns the path
      * @param path            a path to wait on
      * @param afterProcessing a consumer to be called
      */
-    public static void awaitProcessing(Entity entity, @Nullable Path path, Consumer<@Nullable Path> afterProcessing) {
+    public static void awaitProcessing(@Nullable Path path, Consumer<@Nullable Path> afterProcessing) {
         if (path != null && !path.isProcessed() && path instanceof AsyncPath asyncPath) {
             asyncPath.postProcessing(() ->
-                entity.getBukkitEntity().taskScheduler.schedule(nmsEntity -> afterProcessing.accept(path), null, 1)
+                MinecraftServer.getServer().scheduleOnMain(() -> afterProcessing.accept(path))
             );
         } else {
             afterProcessing.accept(path);

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
@@ -91,7 +91,7 @@ public class AsyncPathProcessor {
     }
 
     private static BlockingQueue<Runnable> getQueueImpl() {
-        final int queueCapacity = org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingMaxThreads * (Math.max(org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingMaxThreads, 4));
+        final int queueCapacity = org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingQueueSize;
 
         return new LinkedBlockingQueue<>(queueCapacity);
     }}

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
@@ -16,8 +16,8 @@ import java.util.function.Consumer;
  */
 public class AsyncPathProcessor {
 
-    private static final Executor pathProcessingExecutor = new ThreadPoolExecutor(
-        1,
+    private static final ThreadPoolExecutor pathProcessingExecutor = new ThreadPoolExecutor(
+        org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingMaxThreads,
         org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingMaxThreads,
         org.dreeam.leaf.config.modules.async.AsyncPathfinding.asyncPathfindingKeepalive, TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(),
@@ -26,6 +26,10 @@ public class AsyncPathProcessor {
             .setPriority(Thread.NORM_PRIORITY - 2)
             .build()
     );
+
+    static {
+        pathProcessingExecutor.allowCoreThreadTimeOut(true);
+    }
 
     protected static CompletableFuture<Void> queue(@NotNull AsyncPath path) {
         return CompletableFuture.runAsync(path::process, pathProcessingExecutor);

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/PathfindTaskRejectPolicy.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/PathfindTaskRejectPolicy.java
@@ -2,13 +2,15 @@ package org.dreeam.leaf.async.path;
 
 import org.dreeam.leaf.config.LeafConfig;
 
+import java.util.Locale;
+
 public enum PathfindTaskRejectPolicy {
     FLUSH_ALL,
     CALLER_RUNS;
 
     public static PathfindTaskRejectPolicy fromString(String policy) {
         try {
-            return PathfindTaskRejectPolicy.valueOf(policy);
+            return PathfindTaskRejectPolicy.valueOf(policy.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             LeafConfig.LOGGER.warn("Invalid pathfind task reject policy: {}, falling back to {}.", policy, FLUSH_ALL.toString());
             return FLUSH_ALL;

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/PathfindTaskRejectPolicy.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/PathfindTaskRejectPolicy.java
@@ -1,0 +1,17 @@
+package org.dreeam.leaf.async.path;
+
+import org.dreeam.leaf.config.LeafConfig;
+
+public enum PathfindTaskRejectPolicy {
+    FLUSH_ALL,
+    CALLER_RUNS;
+
+    public static PathfindTaskRejectPolicy fromString(String policy) {
+        try {
+            return PathfindTaskRejectPolicy.valueOf(policy);
+        } catch (IllegalArgumentException e) {
+            LeafConfig.LOGGER.warn("Invalid pathfind task reject policy: {}, falling back to {}.", policy, FLUSH_ALL.toString());
+            return FLUSH_ALL;
+        }
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
@@ -31,6 +31,10 @@ public class MultithreadedTracker {
         getRejectedPolicy()
     );
 
+    static {
+        trackerExecutor.allowCoreThreadTimeOut(true);
+    }
+
     private MultithreadedTracker() {
     }
 
@@ -124,22 +128,18 @@ public class MultithreadedTracker {
     }
 
     private static int getCorePoolSize() {
-        return 1;
+        return org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads;
     }
 
     private static int getMaxPoolSize() {
-        return org.dreeam.leaf.config.modules.async.MultithreadedTracker.autoResize ? Integer.MAX_VALUE : org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads;
+        return org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads;
     }
 
     private static long getKeepAliveTime() {
-        return org.dreeam.leaf.config.modules.async.MultithreadedTracker.autoResize ? 30L : org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerKeepalive;
+        return org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerKeepalive;
     }
 
     private static BlockingQueue<Runnable> getQueueImpl() {
-        if (org.dreeam.leaf.config.modules.async.MultithreadedTracker.autoResize) {
-            return new SynchronousQueue<>();
-        }
-
         final int queueCapacity = org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads * (Math.max(org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads, 4));
 
         return new LinkedBlockingQueue<>(queueCapacity);

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
@@ -20,7 +20,8 @@ import java.util.concurrent.*;
 
 public class MultithreadedTracker {
 
-    private static final Logger LOGGER = LogManager.getLogger("MultithreadedTracker");
+    private static final String THREAD_PREFIX = "Leaf Async Tracker";
+    private static final Logger LOGGER = LogManager.getLogger(THREAD_PREFIX);
     private static long lastWarnMillis = System.currentTimeMillis();
     private static final ThreadPoolExecutor trackerExecutor = new ThreadPoolExecutor(
         getCorePoolSize(),
@@ -148,7 +149,7 @@ public class MultithreadedTracker {
     private static @NotNull ThreadFactory getThreadFactory() {
         return new ThreadFactoryBuilder()
             .setThreadFactory(MultithreadedTrackerThread::new)
-            .setNameFormat("Leaf Async Tracker Thread - %d")
+            .setNameFormat(THREAD_PREFIX + " Thread - %d")
             .setPriority(Thread.NORM_PRIORITY - 2)
             .build();
     }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
@@ -137,7 +137,7 @@ public class MultithreadedTracker {
     }
 
     private static BlockingQueue<Runnable> getQueueImpl() {
-        final int queueCapacity = org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads * (Math.max(org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads, 4));
+        final int queueCapacity = org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerQueueSize;
 
         return new LinkedBlockingQueue<>(queueCapacity);
     }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
@@ -32,10 +32,6 @@ public class MultithreadedTracker {
         getRejectedPolicy()
     );
 
-    static {
-        trackerExecutor.allowCoreThreadTimeOut(true);
-    }
-
     private MultithreadedTracker() {
     }
 
@@ -129,7 +125,7 @@ public class MultithreadedTracker {
     }
 
     private static int getCorePoolSize() {
-        return org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads;
+        return 1;
     }
 
     private static int getMaxPoolSize() {

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/AsyncPathfinding.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/AsyncPathfinding.java
@@ -1,5 +1,6 @@
 package org.dreeam.leaf.config.modules.async;
 
+import org.dreeam.leaf.async.path.PathfindTaskRejectPolicy;
 import org.dreeam.leaf.config.ConfigModules;
 import org.dreeam.leaf.config.EnumConfigCategory;
 import org.dreeam.leaf.config.LeafConfig;
@@ -14,6 +15,7 @@ public class AsyncPathfinding extends ConfigModules {
     public static int asyncPathfindingMaxThreads = 0;
     public static int asyncPathfindingKeepalive = 60;
     public static int asyncPathfindingQueueSize = 0;
+    public static PathfindTaskRejectPolicy asyncPathfindingRejectPolicy = PathfindTaskRejectPolicy.FLUSH_ALL;
 
     @Override
     public void onLoaded() {
@@ -21,6 +23,16 @@ public class AsyncPathfinding extends ConfigModules {
         asyncPathfindingMaxThreads = config.getInt(getBasePath() + ".max-threads", asyncPathfindingMaxThreads);
         asyncPathfindingKeepalive = config.getInt(getBasePath() + ".keepalive", asyncPathfindingKeepalive);
         asyncPathfindingQueueSize = config.getInt(getBasePath() + ".queue-size", asyncPathfindingQueueSize);
+        asyncPathfindingRejectPolicy = PathfindTaskRejectPolicy.fromString(config.getString(getBasePath() + ".reject-policy", asyncPathfindingRejectPolicy.toString(), config.pickStringRegionBased(
+                """
+                The policy to use when the queue is full and a new task is submitted.
+                FLUSH_ALL: All pending tasks will be run on server thread.
+                CALLER_RUNS: Newly submitted task will be run on server thread.""",
+                """
+                当队列满时, 新提交的任务将使用以下策略处理.
+                FLUSH_ALL: 所有等待中的任务都将在主线程上运行.
+                CALLER_RUNS: 新提交的任务将在主线程上运行."""
+        )));
 
         if (asyncPathfindingMaxThreads < 0)
             asyncPathfindingMaxThreads = Math.max(Runtime.getRuntime().availableProcessors() + asyncPathfindingMaxThreads, 1);

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/AsyncPathfinding.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/AsyncPathfinding.java
@@ -13,12 +13,14 @@ public class AsyncPathfinding extends ConfigModules {
     public static boolean enabled = false;
     public static int asyncPathfindingMaxThreads = 0;
     public static int asyncPathfindingKeepalive = 60;
+    public static int asyncPathfindingQueueSize = 0;
 
     @Override
     public void onLoaded() {
         enabled = config.getBoolean(getBasePath() + ".enabled", enabled);
         asyncPathfindingMaxThreads = config.getInt(getBasePath() + ".max-threads", asyncPathfindingMaxThreads);
         asyncPathfindingKeepalive = config.getInt(getBasePath() + ".keepalive", asyncPathfindingKeepalive);
+        asyncPathfindingQueueSize = config.getInt(getBasePath() + ".queue-size", asyncPathfindingQueueSize);
 
         if (asyncPathfindingMaxThreads < 0)
             asyncPathfindingMaxThreads = Math.max(Runtime.getRuntime().availableProcessors() + asyncPathfindingMaxThreads, 1);
@@ -28,5 +30,8 @@ public class AsyncPathfinding extends ConfigModules {
             asyncPathfindingMaxThreads = 0;
         else
             LeafConfig.LOGGER.info("Using {} threads for Async Pathfinding", asyncPathfindingMaxThreads);
+
+        if (asyncPathfindingQueueSize <= 0)
+            asyncPathfindingQueueSize = asyncPathfindingMaxThreads * Math.max(asyncPathfindingMaxThreads, 4);
     }
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/MultithreadedTracker.java
@@ -14,6 +14,7 @@ public class MultithreadedTracker extends ConfigModules {
     public static boolean compatModeEnabled = false;
     public static int asyncEntityTrackerMaxThreads = 0;
     public static int asyncEntityTrackerKeepalive = 60;
+    public static int asyncEntityTrackerQueueSize = 0;
 
     @Override
     public void onLoaded() {
@@ -34,6 +35,7 @@ public class MultithreadedTracker extends ConfigModules {
                 如果你的服务器安装了 Citizens 或其他类似非发包 NPC 插件, 请开启此项."""));
         asyncEntityTrackerMaxThreads = config.getInt(getBasePath() + ".max-threads", asyncEntityTrackerMaxThreads);
         asyncEntityTrackerKeepalive = config.getInt(getBasePath() + ".keepalive", asyncEntityTrackerKeepalive);
+        asyncEntityTrackerQueueSize = config.getInt(getBasePath() + ".queue-size", asyncEntityTrackerQueueSize);
 
         if (asyncEntityTrackerMaxThreads < 0)
             asyncEntityTrackerMaxThreads = Math.max(Runtime.getRuntime().availableProcessors() + asyncEntityTrackerMaxThreads, 1);
@@ -44,5 +46,8 @@ public class MultithreadedTracker extends ConfigModules {
             asyncEntityTrackerMaxThreads = 0;
         else
             LeafConfig.LOGGER.info("Using {} threads for Async Entity Tracker", asyncEntityTrackerMaxThreads);
+
+        if (asyncEntityTrackerQueueSize <= 0)
+            asyncEntityTrackerQueueSize = asyncEntityTrackerMaxThreads * Math.max(asyncEntityTrackerMaxThreads, 4);
     }
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/MultithreadedTracker.java
@@ -12,7 +12,6 @@ public class MultithreadedTracker extends ConfigModules {
 
     public static boolean enabled = false;
     public static boolean compatModeEnabled = false;
-    public static boolean autoResize = false;
     public static int asyncEntityTrackerMaxThreads = 0;
     public static int asyncEntityTrackerKeepalive = 60;
 
@@ -33,14 +32,6 @@ public class MultithreadedTracker extends ConfigModules {
                 """
                 是否启用兼容模式,
                 如果你的服务器安装了 Citizens 或其他类似非发包 NPC 插件, 请开启此项."""));
-        autoResize = config.getBoolean(getBasePath() + ".auto-resize", autoResize, config.pickStringRegionBased("""
-                Auto adjust thread pool size based on server load,
-                This will tweak thread pool size dynamically,
-                overrides max-threads and keepalive.""",
-                """
-                根据服务器负载自动调整线程池大小,
-                这会使线程池大小动态调整,
-                覆盖设置 max-threads 和 keepalive."""));
         asyncEntityTrackerMaxThreads = config.getInt(getBasePath() + ".max-threads", asyncEntityTrackerMaxThreads);
         asyncEntityTrackerKeepalive = config.getInt(getBasePath() + ".keepalive", asyncEntityTrackerKeepalive);
 


### PR DESCRIPTION
Closes #184 and #102.

### Changes
- All threads are core thread in MultithreadedTracker and AsyncPathfinding, create new threads first instead of filling up the queue.
- Removed `auto-resize` option in async entity tracker, no longer needed.
- Schedule path consumer to Paper entity scheduler
- ~~Discard pathfinding tasks submitted later if we already have a task in the queue.~~

Great thanks to @Taiyou06 and other contributors for the help