### PR TITLE
Use FastBitRadix on the NearestLivingEntitySensor

### DIFF
--- a/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
+++ b/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
@@ -13,7 +13,7 @@ This offers a 10~15% performance improvement in average.
 In best situation, this can give an up to 50% improvement.
 
 diff --git a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
-index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..c4dcf57f17bed0ae2609cc6f41e772fb657ad8d2 100644
+index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..e893afb9da39105655c06d93aecb01ecaa624d21 100644
 --- a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
 +++ b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
 @@ -1,7 +1,6 @@
@@ -24,7 +24,7 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..c4dcf57f17bed0ae2609cc6f41e772fb
  import java.util.List;
  import java.util.Set;
  import net.minecraft.server.level.ServerLevel;
-@@ -13,21 +12,162 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
+@@ -13,21 +12,163 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
  import net.minecraft.world.phys.AABB;
  
  public class NearestLivingEntitySensor<T extends LivingEntity> extends Sensor<T> {
@@ -83,7 +83,8 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..c4dcf57f17bed0ae2609cc6f41e772fb
 +
 +        // Choose sorting strategy based on array size - Leaf
 +        if (entities.length < BUCKET_SORT_THRESHOLD) {
-+            fastBitRadixSort(entityDistances, 0, entities.length - 1, 63);
++            // Start at bit 62 (exponent's MSB) instead of 63 (sign bit) - Leaf
++            fastBitRadixSort(entityDistances, 0, entities.length - 1, 62);
 +        } else {
 +            bucketSort(entityDistances, maxDist);
 +        }
@@ -148,7 +149,7 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..c4dcf57f17bed0ae2609cc6f41e772fb
 +            if (!bucket.isEmpty()) {
 +                EntityDistance[] bucketArray = bucket.toArray(new EntityDistance[0]);
 +                if (bucketArray.length > 1) {
-+                    fastBitRadixSort(bucketArray, 0, bucketArray.length - 1, 63);
++                    fastBitRadixSort(bucketArray, 0, bucketArray.length - 1, 62);
 +                }
 +                System.arraycopy(bucketArray, 0, arr, currentIndex, bucketArray.length);
 +                currentIndex += bucketArray.length;

--- a/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
+++ b/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
@@ -13,7 +13,7 @@ This offers a 10~15% performance improvement in average.
 In best situation, this can give an up to 50% improvement.
 
 diff --git a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
-index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..e893afb9da39105655c06d93aecb01ecaa624d21 100644
+index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..d4380c5487902babeef71ef99340c37210497f95 100644
 --- a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
 +++ b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
 @@ -1,7 +1,6 @@
@@ -24,17 +24,19 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..e893afb9da39105655c06d93aecb01ec
  import java.util.List;
  import java.util.Set;
  import net.minecraft.server.level.ServerLevel;
-@@ -13,21 +12,163 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
+@@ -13,21 +12,155 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
  import net.minecraft.world.phys.AABB;
  
  public class NearestLivingEntitySensor<T extends LivingEntity> extends Sensor<T> {
-+    // Constants for optimization tuning - Leaf
++    // Leaf start - Smart sort entities in NearestLivingEntitySensor
 +    private static final int NUM_BUCKETS = Integer.getInteger("Leaf.nearestEntitySensorBucketCount", 10);
++    private static final int NUM_BUCKETS_MINUS_1 = NUM_BUCKETS - 1;
 +    private static final int BUCKET_SORT_THRESHOLD = (int) Math.floor(NUM_BUCKETS *
 +        org.apache.commons.lang3.math.NumberUtils.toDouble(
 +            System.getProperty("Leaf.nearestEntitySensorBucketSortThresholdRatio", "2.0"),
 +            2.0D
 +        ));
++    // Leaf end - Smart sort entities in NearestLivingEntitySensor
 +    private static final int SMALL_ARRAY_THRESHOLD = 2;
 +
      @Override
@@ -65,31 +67,25 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..e893afb9da39105655c06d93aecb01ec
 +            return entities;
 +        }
 +
-+        // Create array to store distances and their corresponding entities - Leaf
 +        EntityDistance[] entityDistances = new EntityDistance[entities.length];
 +        double maxDist = 0.0;
 +
-+        // First pass - calculate distances and find max - Leaf
 +        for (int i = 0; i < entities.length; i++) {
 +            double distance = referenceEntity.distanceToSqr(entities[i]);
 +            maxDist = Math.max(maxDist, distance);
 +            entityDistances[i] = new EntityDistance(entities[i], distance);
 +        }
 +
-+        // Early exit if all distances are the same - Leaf
 +        if (maxDist == 0.0) {
 +            return entities;
 +        }
 +
-+        // Choose sorting strategy based on array size - Leaf
 +        if (entities.length < BUCKET_SORT_THRESHOLD) {
-+            // Start at bit 62 (exponent's MSB) instead of 63 (sign bit) - Leaf
 +            fastBitRadixSort(entityDistances, 0, entities.length - 1, 62);
 +        } else {
 +            bucketSort(entityDistances, maxDist);
 +        }
 +
-+        // Copy back sorted entities - Leaf
 +        for (int i = 0; i < entities.length; i++) {
 +            entities[i] = entityDistances[i].entity;
 +        }
@@ -102,7 +98,6 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..e893afb9da39105655c06d93aecb01ec
 +            return;
 +        }
 +
-+        // Use insertion sort for very small arrays - Leaf
 +        if (high - low <= SMALL_ARRAY_THRESHOLD) {
 +            insertionSort(arr, low, high);
 +            return;
@@ -110,13 +105,10 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..e893afb9da39105655c06d93aecb01ec
 +
 +        int i = low, j = high;
 +
-+        // Partition based on current bit - Leaf
 +        while (i <= j) {
-+            // Move pointers while checking current bit - Leaf
-+            while (i <= j && !getBit(arr[i].distance, bit)) i++;
-+            while (i <= j && getBit(arr[j].distance, bit)) j--;
++            while (i <= j && !getBit(arr[i], bit)) i++;
++            while (i <= j && getBit(arr[j], bit)) j--;
 +
-+            // Swap if needed - Leaf
 +            if (i < j) {
 +                EntityDistance temp = arr[i];
 +                arr[i++] = arr[j];
@@ -124,7 +116,6 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..e893afb9da39105655c06d93aecb01ec
 +            }
 +        }
 +
-+        // Recursively sort partitions if they exist - Leaf
 +        if (low < j) fastBitRadixSort(arr, low, j, bit - 1);
 +        if (i < high) fastBitRadixSort(arr, i, high, bit - 1);
 +    }
@@ -132,18 +123,18 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..e893afb9da39105655c06d93aecb01ec
 +    private void bucketSort(EntityDistance[] arr, double maxDist) {
 +        @SuppressWarnings("unchecked")
 +        List<EntityDistance>[] buckets = new List[NUM_BUCKETS];
++        double invMaxDist = 1.0 / maxDist;
 +
 +        for (int i = 0; i < NUM_BUCKETS; i++) {
 +            buckets[i] = new it.unimi.dsi.fastutil.objects.ObjectArrayList<>();
 +        }
 +
-+        // Distribute elements into buckets - Leaf
-+        for (EntityDistance e : arr) {
-+            int bucketIndex = (int) ((e.distance / maxDist) * (NUM_BUCKETS - 1));
++        for (int idx = 0; idx < arr.length; idx++) {
++            EntityDistance e = arr[idx];
++            int bucketIndex = (int) (e.distance * invMaxDist * NUM_BUCKETS_MINUS_1);
 +            buckets[bucketIndex].add(e);
 +        }
 +
-+        // Sort buckets and collect results - Leaf
 +        int currentIndex = 0;
 +        for (List<EntityDistance> bucket : buckets) {
 +            if (!bucket.isEmpty()) {
@@ -169,18 +160,19 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..e893afb9da39105655c06d93aecb01ec
 +        }
 +    }
 +
-+    private static boolean getBit(double value, int position) {
-+        long bits = Double.doubleToRawLongBits(value);
-+        return ((bits >> position) & 1) == 1;
++    private static boolean getBit(EntityDistance e, int position) {
++        return ((e.bits >> position) & 1) == 1;
 +    }
 +
 +    private static class EntityDistance {
 +        final LivingEntity entity;
 +        final double distance;
++        final long bits;
 +
 +        EntityDistance(LivingEntity entity, double distance) {
 +            this.entity = entity;
 +            this.distance = distance;
++            this.bits = Double.doubleToRawLongBits(distance);
 +        }
      }
  

--- a/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
+++ b/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
@@ -7,10 +7,11 @@ Co-authored-by: Taiyou06 <kaandindar21@gmail.com>
 
 This patch optimizes sorting algorithm by dynamically sorting based
 on entity count, if entity count doesn't reach the Bucket Sort threshold,
-Quick Sort of Fastutil will be used.
+FastBitRadix Sort will be used. (see https://ieeexplore.ieee.org/document/7822019 for more)
 When entity count reached the threshold, Bucket Sort will be used.
-This offers a 10~15% performance improvement in average.
-In best situation, this can give an up to 50% improvement.
+
+In non-strict testing, this can give ~20-40% improvement (54MSPT -> 44MSPT),
+under 625 villagers situation.
 
 diff --git a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
 index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..4898381d51cd9ea321ed75c5c253de96bdd46f7d 100644

--- a/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
+++ b/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
@@ -13,18 +13,10 @@ This offers a 10~15% performance improvement in average.
 In best situation, this can give an up to 50% improvement.
 
 diff --git a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
-index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..7039adc062b5d26af186f6de5bd5a2e54eab956f 100644
+index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..4898381d51cd9ea321ed75c5c253de96bdd46f7d 100644
 --- a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
 +++ b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
-@@ -1,7 +1,6 @@
- package net.minecraft.world.entity.ai.sensing;
- 
- import com.google.common.collect.ImmutableSet;
--import java.util.Comparator;
- import java.util.List;
- import java.util.Set;
- import net.minecraft.server.level.ServerLevel;
-@@ -13,18 +12,170 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
+@@ -13,6 +13,21 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
  import net.minecraft.world.phys.AABB;
  
  public class NearestLivingEntitySensor<T extends LivingEntity> extends Sensor<T> {
@@ -33,27 +25,24 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..7039adc062b5d26af186f6de5bd5a2e5
 +    private static final int NUM_BUCKETS_MINUS_1 = NUM_BUCKETS - 1;
 +    private static final int BUCKET_SORT_THRESHOLD = (int) Math.floor(NUM_BUCKETS * org.apache.commons.lang3.math.NumberUtils.toDouble(System.getProperty("Leaf.nearestEntitySensorBucketSortThresholdRatio", "2.0"), 2.0D));
 +    private static final List<EntityDistance>[] buckets = new List[NUM_BUCKETS];
-+    // Leaf end - Smart sort entities in NearestLivingEntitySensor
 +    private static final int SMALL_ARRAY_THRESHOLD = 2;
 +
 +    static {
-+        // Leaf start - Initialize bucket array
++        // Initialize bucket array
 +        for (int i = 0; i < NUM_BUCKETS; i++) {
 +            buckets[i] = new it.unimi.dsi.fastutil.objects.ObjectArrayList<>();
 +        }
-+        // Leaf end - Initialize bucket array
 +    }
++    // Leaf end - Smart sort entities in NearestLivingEntitySensor
 +
      @Override
      protected void doTick(ServerLevel level, T entity) {
          double attributeValue = entity.getAttributeValue(Attributes.FOLLOW_RANGE);
-         AABB aabb = entity.getBoundingBox().inflate(attributeValue, attributeValue, attributeValue);
--        List<LivingEntity> entitiesOfClass = level.getEntitiesOfClass(
--            LivingEntity.class, aabb, matchableEntity -> matchableEntity != entity && matchableEntity.isAlive()
--        );
+@@ -20,11 +35,150 @@ public class NearestLivingEntitySensor<T extends LivingEntity> extends Sensor<T>
+         List<LivingEntity> entitiesOfClass = level.getEntitiesOfClass(
+             LivingEntity.class, aabb, matchableEntity -> matchableEntity != entity && matchableEntity.isAlive()
+         );
 -        entitiesOfClass.sort(Comparator.comparingDouble(entity::distanceToSqr));
-+        List<LivingEntity> entitiesOfClass = level.getEntitiesOfClass(LivingEntity.class, aabb, matchableEntity -> matchableEntity != entity && matchableEntity.isAlive());
-+
 +        // Leaf start - Use smart sorting for entities
 +        LivingEntity[] sortedEntities = smartSortEntities(entitiesOfClass.toArray(new LivingEntity[0]), entity);
 +        List<LivingEntity> sortedList = java.util.Arrays.asList(sortedEntities);
@@ -62,8 +51,10 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..7039adc062b5d26af186f6de5bd5a2e5
          Brain<?> brain = entity.getBrain();
 -        brain.setMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES, entitiesOfClass);
 -        brain.setMemory(MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES, new NearestVisibleLivingEntities(level, entity, entitiesOfClass));
++        // Leaf start - Use smart sorting for entities
 +        brain.setMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES, sortedList);
 +        brain.setMemory(MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES, new NearestVisibleLivingEntities(level, entity, sortedList));
++        // Leaf end - Use smart sorting for entities
 +    }
 +
 +    // Leaf start - Smart entity sorting implementation

--- a/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
+++ b/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
@@ -13,94 +13,182 @@ This offers a 10~15% performance improvement in average.
 In best situation, this can give an up to 50% improvement.
 
 diff --git a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
-index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..bcfbb03a75c4e5c80517f9acd24588f1ac703e67 100644
+index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..c4dcf57f17bed0ae2609cc6f41e772fb657ad8d2 100644
 --- a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
 +++ b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
-@@ -13,6 +13,10 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
+@@ -1,7 +1,6 @@
+ package net.minecraft.world.entity.ai.sensing;
+ 
+ import com.google.common.collect.ImmutableSet;
+-import java.util.Comparator;
+ import java.util.List;
+ import java.util.Set;
+ import net.minecraft.server.level.ServerLevel;
+@@ -13,21 +12,162 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
  import net.minecraft.world.phys.AABB;
  
  public class NearestLivingEntitySensor<T extends LivingEntity> extends Sensor<T> {
-+    // Leaf start - Smart sort entities in NearestLivingEntitySensor
++    // Constants for optimization tuning - Leaf
 +    private static final int NUM_BUCKETS = Integer.getInteger("Leaf.nearestEntitySensorBucketCount", 10);
-+    private static final int BUCKET_SORT_THRESHOLD = (int) Math.floor(NUM_BUCKETS * org.apache.commons.lang3.math.NumberUtils.toDouble(System.getProperty("Leaf.nearestEntitySensorBucketSortThresholdRatio", "2.0"), 2.0D));
-+    // Leaf end - Smart sort entities in NearestLivingEntitySensor
++    private static final int BUCKET_SORT_THRESHOLD = (int) Math.floor(NUM_BUCKETS *
++        org.apache.commons.lang3.math.NumberUtils.toDouble(
++            System.getProperty("Leaf.nearestEntitySensorBucketSortThresholdRatio", "2.0"),
++            2.0D
++        ));
++    private static final int SMALL_ARRAY_THRESHOLD = 2;
++
      @Override
      protected void doTick(ServerLevel level, T entity) {
          double attributeValue = entity.getAttributeValue(Attributes.FOLLOW_RANGE);
-@@ -20,12 +24,73 @@ public class NearestLivingEntitySensor<T extends LivingEntity> extends Sensor<T>
+         AABB aabb = entity.getBoundingBox().inflate(attributeValue, attributeValue, attributeValue);
          List<LivingEntity> entitiesOfClass = level.getEntitiesOfClass(
-             LivingEntity.class, aabb, matchableEntity -> matchableEntity != entity && matchableEntity.isAlive()
+-            LivingEntity.class, aabb, matchableEntity -> matchableEntity != entity && matchableEntity.isAlive()
++            LivingEntity.class,
++            aabb,
++            matchableEntity -> matchableEntity != entity && matchableEntity.isAlive()
          );
 -        entitiesOfClass.sort(Comparator.comparingDouble(entity::distanceToSqr));
-+        // Leaf start - Smart sort entities in NearestLivingEntitySensor
++
 +        LivingEntity[] sortedEntities = smartSortEntities(entitiesOfClass.toArray(new LivingEntity[0]), entity);
 +        List<LivingEntity> sortedList = java.util.Arrays.asList(sortedEntities);
-+        // Leaf end - Smart sort entities in NearestLivingEntitySensor
++
          Brain<?> brain = entity.getBrain();
 -        brain.setMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES, entitiesOfClass);
 -        brain.setMemory(MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES, new NearestVisibleLivingEntities(level, entity, entitiesOfClass));
-+        // Leaf start - Smart sort entities in NearestLivingEntitySensor
 +        brain.setMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES, sortedList);
-+        brain.setMemory(MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES, new NearestVisibleLivingEntities(level, entity, sortedList));
-+        // Leaf end - Smart sort entities in NearestLivingEntitySensor
-     }
- 
-+    // Leaf start - Smart sort entities in NearestLivingEntitySensor
++        brain.setMemory(MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES,
++            new NearestVisibleLivingEntities(level, entity, sortedList));
++    }
++
 +    private LivingEntity[] smartSortEntities(LivingEntity[] entities, T referenceEntity) {
 +        if (entities.length <= 1) {
 +            return entities;
 +        }
 +
-+        final Comparator<LivingEntity> comparator = Comparator.comparingDouble(referenceEntity::distanceToSqr);
++        // Create array to store distances and their corresponding entities - Leaf
++        EntityDistance[] entityDistances = new EntityDistance[entities.length];
++        double maxDist = 0.0;
 +
-+        if (entities.length < BUCKET_SORT_THRESHOLD) {
-+            it.unimi.dsi.fastutil.objects.ObjectArrays.quickSort(entities, comparator);
++        // First pass - calculate distances and find max - Leaf
++        for (int i = 0; i < entities.length; i++) {
++            double distance = referenceEntity.distanceToSqr(entities[i]);
++            maxDist = Math.max(maxDist, distance);
++            entityDistances[i] = new EntityDistance(entities[i], distance);
++        }
++
++        // Early exit if all distances are the same - Leaf
++        if (maxDist == 0.0) {
 +            return entities;
 +        }
 +
-+        // Create buckets
++        // Choose sorting strategy based on array size - Leaf
++        if (entities.length < BUCKET_SORT_THRESHOLD) {
++            fastBitRadixSort(entityDistances, 0, entities.length - 1, 63);
++        } else {
++            bucketSort(entityDistances, maxDist);
++        }
++
++        // Copy back sorted entities - Leaf
++        for (int i = 0; i < entities.length; i++) {
++            entities[i] = entityDistances[i].entity;
++        }
++
++        return entities;
++    }
++
++    private void fastBitRadixSort(EntityDistance[] arr, int low, int high, int bit) {
++        if (bit < 0 || low >= high) {
++            return;
++        }
++
++        // Use insertion sort for very small arrays - Leaf
++        if (high - low <= SMALL_ARRAY_THRESHOLD) {
++            insertionSort(arr, low, high);
++            return;
++        }
++
++        int i = low, j = high;
++
++        // Partition based on current bit - Leaf
++        while (i <= j) {
++            // Move pointers while checking current bit - Leaf
++            while (i <= j && !getBit(arr[i].distance, bit)) i++;
++            while (i <= j && getBit(arr[j].distance, bit)) j--;
++
++            // Swap if needed - Leaf
++            if (i < j) {
++                EntityDistance temp = arr[i];
++                arr[i++] = arr[j];
++                arr[j--] = temp;
++            }
++        }
++
++        // Recursively sort partitions if they exist - Leaf
++        if (low < j) fastBitRadixSort(arr, low, j, bit - 1);
++        if (i < high) fastBitRadixSort(arr, i, high, bit - 1);
++    }
++
++    private void bucketSort(EntityDistance[] arr, double maxDist) {
 +        @SuppressWarnings("unchecked")
-+        List<LivingEntity>[] buckets = new List[NUM_BUCKETS];
++        List<EntityDistance>[] buckets = new List[NUM_BUCKETS];
 +
 +        for (int i = 0; i < NUM_BUCKETS; i++) {
 +            buckets[i] = new it.unimi.dsi.fastutil.objects.ObjectArrayList<>();
 +        }
 +
-+        // Find max distance to normalize bucket distribution - Leaf
-+        double maxDistSq = 0.0;
-+
-+        for (LivingEntity e : entities) {
-+            maxDistSq = Math.max(maxDistSq, referenceEntity.distanceToSqr(e));
-+        }
-+
-+        // Handle edge case where all entities are at the same position - Leaf
-+        if (maxDistSq == 0.0) {
-+            return entities;
-+        }
-+
-+        // Distribute entities into buckets
-+        for (LivingEntity e : entities) {
-+            double distSq = referenceEntity.distanceToSqr(e);
-+            int bucketIndex = (int) ((distSq / maxDistSq) * (NUM_BUCKETS - 1));
++        // Distribute elements into buckets - Leaf
++        for (EntityDistance e : arr) {
++            int bucketIndex = (int) ((e.distance / maxDist) * (NUM_BUCKETS - 1));
 +            buckets[bucketIndex].add(e);
 +        }
 +
-+        // Sort each bucket and combine results
++        // Sort buckets and collect results - Leaf
 +        int currentIndex = 0;
-+
-+        for (List<LivingEntity> bucket : buckets) {
++        for (List<EntityDistance> bucket : buckets) {
 +            if (!bucket.isEmpty()) {
-+                bucket.sort(comparator);
-+                for (LivingEntity e : bucket) {
-+                    entities[currentIndex++] = e;
++                EntityDistance[] bucketArray = bucket.toArray(new EntityDistance[0]);
++                if (bucketArray.length > 1) {
++                    fastBitRadixSort(bucketArray, 0, bucketArray.length - 1, 63);
 +                }
++                System.arraycopy(bucketArray, 0, arr, currentIndex, bucketArray.length);
++                currentIndex += bucketArray.length;
 +            }
 +        }
-+
-+        return entities;
 +    }
-+    // Leaf end - Smart sort entities in NearestLivingEntitySensor
 +
++    private void insertionSort(EntityDistance[] arr, int low, int high) {
++        for (int i = low + 1; i <= high; i++) {
++            EntityDistance key = arr[i];
++            int j = i - 1;
++            while (j >= low && arr[j].distance > key.distance) {
++                arr[j + 1] = arr[j];
++                j--;
++            }
++            arr[j + 1] = key;
++        }
++    }
++
++    private static boolean getBit(double value, int position) {
++        long bits = Double.doubleToRawLongBits(value);
++        return ((bits >> position) & 1) == 1;
++    }
++
++    private static class EntityDistance {
++        final LivingEntity entity;
++        final double distance;
++
++        EntityDistance(LivingEntity entity, double distance) {
++            this.entity = entity;
++            this.distance = distance;
++        }
+     }
+ 
      @Override
      public Set<MemoryModuleType<?>> requires() {
-         return ImmutableSet.of(MemoryModuleType.NEAREST_LIVING_ENTITIES, MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES);
+-        return ImmutableSet.of(MemoryModuleType.NEAREST_LIVING_ENTITIES, MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES);
++        return ImmutableSet.of(
++            MemoryModuleType.NEAREST_LIVING_ENTITIES,
++            MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES
++        );
+     }
+ }

--- a/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
+++ b/leaf-server/minecraft-patches/features/0089-Smart-sort-entities-in-NearestLivingEntitySensor.patch
@@ -13,7 +13,7 @@ This offers a 10~15% performance improvement in average.
 In best situation, this can give an up to 50% improvement.
 
 diff --git a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
-index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..d4380c5487902babeef71ef99340c37210497f95 100644
+index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..7039adc062b5d26af186f6de5bd5a2e54eab956f 100644
 --- a/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
 +++ b/net/minecraft/world/entity/ai/sensing/NearestLivingEntitySensor.java
 @@ -1,7 +1,6 @@
@@ -24,44 +24,49 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..d4380c5487902babeef71ef99340c372
  import java.util.List;
  import java.util.Set;
  import net.minecraft.server.level.ServerLevel;
-@@ -13,21 +12,155 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
+@@ -13,18 +12,170 @@ import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
  import net.minecraft.world.phys.AABB;
  
  public class NearestLivingEntitySensor<T extends LivingEntity> extends Sensor<T> {
 +    // Leaf start - Smart sort entities in NearestLivingEntitySensor
 +    private static final int NUM_BUCKETS = Integer.getInteger("Leaf.nearestEntitySensorBucketCount", 10);
 +    private static final int NUM_BUCKETS_MINUS_1 = NUM_BUCKETS - 1;
-+    private static final int BUCKET_SORT_THRESHOLD = (int) Math.floor(NUM_BUCKETS *
-+        org.apache.commons.lang3.math.NumberUtils.toDouble(
-+            System.getProperty("Leaf.nearestEntitySensorBucketSortThresholdRatio", "2.0"),
-+            2.0D
-+        ));
++    private static final int BUCKET_SORT_THRESHOLD = (int) Math.floor(NUM_BUCKETS * org.apache.commons.lang3.math.NumberUtils.toDouble(System.getProperty("Leaf.nearestEntitySensorBucketSortThresholdRatio", "2.0"), 2.0D));
++    private static final List<EntityDistance>[] buckets = new List[NUM_BUCKETS];
 +    // Leaf end - Smart sort entities in NearestLivingEntitySensor
 +    private static final int SMALL_ARRAY_THRESHOLD = 2;
++
++    static {
++        // Leaf start - Initialize bucket array
++        for (int i = 0; i < NUM_BUCKETS; i++) {
++            buckets[i] = new it.unimi.dsi.fastutil.objects.ObjectArrayList<>();
++        }
++        // Leaf end - Initialize bucket array
++    }
 +
      @Override
      protected void doTick(ServerLevel level, T entity) {
          double attributeValue = entity.getAttributeValue(Attributes.FOLLOW_RANGE);
          AABB aabb = entity.getBoundingBox().inflate(attributeValue, attributeValue, attributeValue);
-         List<LivingEntity> entitiesOfClass = level.getEntitiesOfClass(
+-        List<LivingEntity> entitiesOfClass = level.getEntitiesOfClass(
 -            LivingEntity.class, aabb, matchableEntity -> matchableEntity != entity && matchableEntity.isAlive()
-+            LivingEntity.class,
-+            aabb,
-+            matchableEntity -> matchableEntity != entity && matchableEntity.isAlive()
-         );
+-        );
 -        entitiesOfClass.sort(Comparator.comparingDouble(entity::distanceToSqr));
++        List<LivingEntity> entitiesOfClass = level.getEntitiesOfClass(LivingEntity.class, aabb, matchableEntity -> matchableEntity != entity && matchableEntity.isAlive());
 +
++        // Leaf start - Use smart sorting for entities
 +        LivingEntity[] sortedEntities = smartSortEntities(entitiesOfClass.toArray(new LivingEntity[0]), entity);
 +        List<LivingEntity> sortedList = java.util.Arrays.asList(sortedEntities);
++        // Leaf end - Use smart sorting for entities
 +
          Brain<?> brain = entity.getBrain();
 -        brain.setMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES, entitiesOfClass);
 -        brain.setMemory(MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES, new NearestVisibleLivingEntities(level, entity, entitiesOfClass));
 +        brain.setMemory(MemoryModuleType.NEAREST_LIVING_ENTITIES, sortedList);
-+        brain.setMemory(MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES,
-+            new NearestVisibleLivingEntities(level, entity, sortedList));
++        brain.setMemory(MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES, new NearestVisibleLivingEntities(level, entity, sortedList));
 +    }
 +
++    // Leaf start - Smart entity sorting implementation
 +    private LivingEntity[] smartSortEntities(LivingEntity[] entities, T referenceEntity) {
 +        if (entities.length <= 1) {
 +            return entities;
@@ -93,6 +98,15 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..d4380c5487902babeef71ef99340c372
 +        return entities;
 +    }
 +
++    /**
++     * Fast bit radix sort implementation
++     * 1. Partitioning array based on bits of the distance value, starting from most significant bit
++     * 2. For each bit position:
++     *    - Elements with 0 at that bit go to left side
++     *    - Elements with 1 at that bit go to right side
++     * 3. Recursively sorts left and right partitions
++     * 4. Falls back to insertion sort for very small partitions (<=2 elements)
++     */
 +    private void fastBitRadixSort(EntityDistance[] arr, int low, int high, int bit) {
 +        if (bit < 0 || low >= high) {
 +            return;
@@ -120,9 +134,17 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..d4380c5487902babeef71ef99340c372
 +        if (i < high) fastBitRadixSort(arr, i, high, bit - 1);
 +    }
 +
++    /**
++     * Bucket sort implementation
++     * 1. Divides distance range [0, maxDist] into NUM_BUCKETS equal-sized buckets
++     * 2. Places each entity into appropriate bucket based on its distance
++     * 3. Sorts each non-empty bucket using fastBitRadixSort
++     * 4. Concatenates sorted buckets in order
++     */
 +    private void bucketSort(EntityDistance[] arr, double maxDist) {
-+        @SuppressWarnings("unchecked")
-+        List<EntityDistance>[] buckets = new List[NUM_BUCKETS];
++        for (List<EntityDistance> bucket : buckets) {
++            bucket.clear();
++        }
 +        double invMaxDist = 1.0 / maxDist;
 +
 +        for (int i = 0; i < NUM_BUCKETS; i++) {
@@ -175,13 +197,7 @@ index b0c5e41fefc7c9adf1a61bd5b52861736657d37e..d4380c5487902babeef71ef99340c372
 +            this.bits = Double.doubleToRawLongBits(distance);
 +        }
      }
++    // Leaf end - Smart entity sorting implementation
  
      @Override
      public Set<MemoryModuleType<?>> requires() {
--        return ImmutableSet.of(MemoryModuleType.NEAREST_LIVING_ENTITIES, MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES);
-+        return ImmutableSet.of(
-+            MemoryModuleType.NEAREST_LIVING_ENTITIES,
-+            MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES
-+        );
-     }
- }


### PR DESCRIPTION
Replaces FastUtil.quicksort with FastBitRadix Sort implementation, that is explained on this research paper:
[Fastbit-radix_sort_Optimized_version_of_radix_sort.pdf](https://github.com/user-attachments/files/18680883/Fastbit-radix_sort_Optimized_version_of_radix_sort.pdf)
(As a fallback it includes InsertionSort for 2 elements, which may need to change or removed.. not sure needs to be discussed.)

Improves pretty much every living entity in the game including mainly Villagers as the main performance hog.

During the testing phase we found that It improves mspt around 20-40% using 625 villagers it went from 54MSPT to 44MSPT in @HaHaWTH's machine. 🚀 

Feel free to test this in your servers using the actions tab and let me know about any issues. 