### PR TITLE
Band-aid fix for async events

### DIFF
--- a/leaf-server/paper-patches/features/0031-SparklyPaper-Parallel-world-ticking.patch
+++ b/leaf-server/paper-patches/features/0031-SparklyPaper-Parallel-world-ticking.patch
@@ -237,6 +237,31 @@ index a4aa2615823d77920ff55b8aa0bcc27a54b8c3e1..2fb65ce228da94eb7d9364ee0f945823
      }
 +    // SparklyPaper end - parallel world ticking
  }
+diff --git a/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java b/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java
+index 548fcd9646dee0c40b6ba9b3dafb9ca157dfe324..67f69ea3c28578cb73d2df662d246f0056ff2cb2 100644
+--- a/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java
++++ b/src/main/java/io/papermc/paper/plugin/manager/PaperEventManager.java
+@@ -28,6 +28,7 @@ import java.util.logging.Level;
+ class PaperEventManager {
+ 
+     private final Server server;
++    private final org.purpurmc.purpur.util.MinecraftInternalPlugin minecraftInternalPlugin = new org.purpurmc.purpur.util.MinecraftInternalPlugin(); // Leaf - Parallel world ticking
+ 
+     public PaperEventManager(Server server) {
+         this.server = server;
+@@ -40,6 +41,12 @@ class PaperEventManager {
+         if (listeners.length == 0) return;
+         // Leaf end - Skip event if no listeners
+         if (event.isAsynchronous() && this.server.isPrimaryThread()) {
++            // Leaf start - Parallel world ticking
++            if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.runAsyncTasksSync) {
++                org.bukkit.Bukkit.getAsyncScheduler().runNow(minecraftInternalPlugin, task -> event.callEvent());
++                return;
++            }
++            // Leaf end - Parallel world ticking
+             throw new IllegalStateException(event.getEventName() + " may only be triggered asynchronously.");
+         } else if (!event.isAsynchronous() && !this.server.isPrimaryThread() && !this.server.isStopping()) {
+             // Leaf start - Multithreaded tracker
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 index 15673166e566b2a6d5093210d99b154e69fab0ad..49abf1100271452e9c79c8643a25af3ce519773b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/world/SparklyPaperServerLevelTickExecutorThreadFactory.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/world/SparklyPaperServerLevelTickExecutorThreadFactory.java
@@ -15,7 +15,7 @@ public class SparklyPaperServerLevelTickExecutorThreadFactory implements ThreadF
 
     @Override
     public Thread newThread(@NotNull Runnable runnable) {
-        TickThread.ServerLevelTickThread tickThread = new TickThread.ServerLevelTickThread(runnable, "LeafParallelWorld-ticker-worker " + this.worldName);
+        TickThread.ServerLevelTickThread tickThread = new TickThread.ServerLevelTickThread(runnable, "Leaf World Ticking Thread - " + this.worldName);
 
         if (tickThread.isDaemon()) {
             tickThread.setDaemon(false);

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/SparklyPaperParallelWorldTicking.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/SparklyPaperParallelWorldTicking.java
@@ -8,7 +8,7 @@ public class SparklyPaperParallelWorldTicking extends ConfigModules {
 
     public String getBasePath() {
         return EnumConfigCategory.ASYNC.getBaseKeyName() + ".parallel-world-tracking";
-    }
+    } // TODO: Correct config key when stable
 
     @Experimental
     public static boolean enabled = false;


### PR DESCRIPTION
A temporary fix for #265, plugin that fires async events in CraftAsyncScheduler will be redirected to FoliaAsyncScheduler