### PR TITLE
Allow Non-ASCII character in unquoted string of command argument

### DIFF
--- a/leaf-server/minecraft-patches/features/0158-Allow-non-ascii-character-in-unquoted-string-of-comm.patch
+++ b/leaf-server/minecraft-patches/features/0158-Allow-non-ascii-character-in-unquoted-string-of-comm.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Allow non-ascii character in unquoted string of command
 
 
 diff --git a/com/mojang/brigadier/StringReader.java b/com/mojang/brigadier/StringReader.java
-index c1465df63a48e08ec9ccd6889be4f2f8d13d7552..8e395d2d907f6c4a5e5cb4075c1a382c29c3a226 100644
+index c1465df63a48e08ec9ccd6889be4f2f8d13d7552..347fe2f719507e7bba412bcd4a45a4d78a665c62 100644
 --- a/com/mojang/brigadier/StringReader.java
 +++ b/com/mojang/brigadier/StringReader.java
 @@ -167,11 +167,20 @@ public class StringReader implements ImmutableStringReader {
      }
  
      public static boolean isAllowedInUnquotedString(final char c) {
-+        // Leaf start
++        // Leaf start - Allow non-ascii character in unquoted string of command argument
 +        /*
          return c >= '0' && c <= '9'
              || c >= 'A' && c <= 'Z'
@@ -26,7 +26,7 @@ index c1465df63a48e08ec9ccd6889be4f2f8d13d7552..8e395d2d907f6c4a5e5cb4075c1a382c
 +            && c != '{' && c != '}'
 +            && c != ',' && c != SYNTAX_ESCAPE
 +            && !isQuotedStringStart(c);
-+        // Leaf end
++        // Leaf end - Allow non-ascii character in unquoted string of command argument
      }
  
      public String readUnquotedString() {

--- a/leaf-server/minecraft-patches/features/0158-Allow-non-ascii-character-in-unquoted-string-of-comm.patch
+++ b/leaf-server/minecraft-patches/features/0158-Allow-non-ascii-character-in-unquoted-string-of-comm.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: hayanesuru <mc@jvavav.com>
+Date: Tue, 1 Apr 2025 11:56:43 +0800
+Subject: [PATCH] Allow non-ascii character in unquoted string of command
+ argument
+
+
+diff --git a/com/mojang/brigadier/StringReader.java b/com/mojang/brigadier/StringReader.java
+index c1465df63a48e08ec9ccd6889be4f2f8d13d7552..8e395d2d907f6c4a5e5cb4075c1a382c29c3a226 100644
+--- a/com/mojang/brigadier/StringReader.java
++++ b/com/mojang/brigadier/StringReader.java
+@@ -167,11 +167,20 @@ public class StringReader implements ImmutableStringReader {
+     }
+ 
+     public static boolean isAllowedInUnquotedString(final char c) {
++        // Leaf start
++        /*
+         return c >= '0' && c <= '9'
+             || c >= 'A' && c <= 'Z'
+             || c >= 'a' && c <= 'z'
+             || c == '_' || c == '-'
+             || c == '.' || c == '+';
++        */
++        return c != ' ' && c != ':'
++            && c != '[' && c != ']'
++            && c != '{' && c != '}'
++            && c != ',' && c != SYNTAX_ESCAPE
++            && !isQuotedStringStart(c);
++        // Leaf end
+     }
+ 
+     public String readUnquotedString() {


### PR DESCRIPTION
#273

Client will display an error but still able to send.
It changed decode string of SNBT

test command:
```
/data merge storage ns:test {String:テスト}
/data get storage ns:test String
```