### PR TITLE
Allowing endermen to despawn while holding mushroom

### DIFF
--- a/leaf-server/minecraft-patches/features/0159-Allowing-endermen-to-despawn-while-holding-mushroom.patch
+++ b/leaf-server/minecraft-patches/features/0159-Allowing-endermen-to-despawn-while-holding-mushroom.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: hayanesuru <mc@jvavav.com>
+Date: Sat, 19 Apr 2025 19:21:50 +0800
+Subject: [PATCH] Allowing endermen to despawn while holding mushroom
+
+
+diff --git a/net/minecraft/world/entity/monster/EnderMan.java b/net/minecraft/world/entity/monster/EnderMan.java
+index c7897532163d4fdf5a82982f7d24a47dd61e3dfa..111f7008f73ed4c7b1be38ad2cf3d86f9391ad69 100644
+--- a/net/minecraft/world/entity/monster/EnderMan.java
++++ b/net/minecraft/world/entity/monster/EnderMan.java
+@@ -485,7 +485,20 @@ public class EnderMan extends Monster implements NeutralMob {
+ 
+     @Override
+     public boolean requiresCustomPersistence() {
+-        return super.requiresCustomPersistence() || (!this.level().purpurConfig.endermanDespawnEvenWithBlock && this.getCarriedBlock() != null); // Purpur - Add config for allowing Endermen to despawn even while holding a block
++        // Leaf start - allowing endermen to despawn while holding mushroom
++        if (super.requiresCustomPersistence()) {
++            return true;
++        }
++        // Purpur - Add config for allowing Endermen to despawn even while holding a block
++        if (this.level().purpurConfig.endermanDespawnEvenWithBlock) {
++            return false;
++        }
++        var carried = this.getCarriedBlock();
++        if (carried == null) {
++            return false;
++        }
++        return !(org.dreeam.leaf.config.modules.fixes.DespawnEndermanWhileHoldingMushroom.despawn && (carried.is(Blocks.RED_MUSHROOM) || carried.is(Blocks.BROWN_MUSHROOM)));
++        // Leaf end
+     }
+ 
+     static class EndermanFreezeWhenLookedAt extends Goal {
+diff --git a/net/minecraft/world/level/block/MushroomBlock.java b/net/minecraft/world/level/block/MushroomBlock.java
+index afd952ddc8942818ec01d1c750413776b6537cc2..454181ae4168d87c4f3bf29cc9b6619dae2876e1 100644
+--- a/net/minecraft/world/level/block/MushroomBlock.java
++++ b/net/minecraft/world/level/block/MushroomBlock.java
+@@ -47,6 +47,12 @@ public class MushroomBlock extends BushBlock implements BonemealableBlock {
+ 
+     @Override
+     protected void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
++        // Leaf start - disable mushroom growth in the end
++        if (org.dreeam.leaf.config.modules.fixes.DespawnEndermanWhileHoldingMushroom.noGrowthInTheEnd && level.isTheEnd()) {
++            return;
++        }
++        // Leaf end
++
+         if (random.nextFloat() < (level.spigotConfig.mushroomModifier / (100.0f * 25))) { // Spigot - SPIGOT-7159: Better modifier resolution
+             int i = 5;
+             int i1 = 4;

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/DespawnEndermanWhileHoldingMushroom.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/DespawnEndermanWhileHoldingMushroom.java
@@ -13,11 +13,11 @@ public class DespawnEndermanWhileHoldingMushroom extends ConfigModules {
 
     @Override
     public void onLoaded() {
-        despawn = config.getBoolean(getBasePath() + ".despawn-enderman-holding-mushroom", despawn, config.pickStringRegionBased("""
+        despawn = config.getBoolean(getBasePath() + "mushroom.despawn-enderman-while-holding", despawn, config.pickStringRegionBased("""
                 Endermen are capable of despawning even while holding a mushroom.""",
             """
                 末影人拿着蘑菇时能够消失."""));
-        noGrowthInTheEnd = config.getBoolean(getBasePath() + ".disallow-mushroom-grow-in-the-end", noGrowthInTheEnd, config.pickStringRegionBased("""
+        noGrowthInTheEnd = config.getBoolean(getBasePath() + "mushroom.prevent-grow-in-the-end", noGrowthInTheEnd, config.pickStringRegionBased("""
                 Prevent mushrooms from growing in the end.""",
             """
                 阻止蘑菇在末地生长."""));

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/DespawnEndermanWhileHoldingMushroom.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/DespawnEndermanWhileHoldingMushroom.java
@@ -1,0 +1,25 @@
+package org.dreeam.leaf.config.modules.fixes;
+
+import org.dreeam.leaf.config.ConfigModules;
+import org.dreeam.leaf.config.EnumConfigCategory;
+
+public class DespawnEndermanWhileHoldingMushroom extends ConfigModules {
+    public String getBasePath() {
+        return EnumConfigCategory.FIXES.getBaseKeyName();
+    }
+
+    public static boolean despawn = true;
+    public static boolean noGrowthInTheEnd = true;
+
+    @Override
+    public void onLoaded() {
+        despawn = config.getBoolean(getBasePath() + ".despawn-enderman-holding-mushroom", despawn, config.pickStringRegionBased("""
+                Endermen are capable of despawning even while holding a mushroom.""",
+            """
+                末影人拿着蘑菇时能够消失."""));
+        noGrowthInTheEnd = config.getBoolean(getBasePath() + ".disallow-mushroom-grow-in-the-end", noGrowthInTheEnd, config.pickStringRegionBased("""
+                Prevent mushrooms from growing in the end.""",
+            """
+                阻止蘑菇在末地生长."""));
+    }
+}


### PR DESCRIPTION
this pr fixed lag caused by enderman entities in the end while holding mushroom

```yaml
mushroom:
  despawn-enderman-while-holding: true
  prevent-grow-in-the-end: true
```