### PR TITLE
Update PlayerInventoryOverflowEvent

### DIFF
--- a/leaf-api/paper-patches/features/0011-PlayerInventoryOverflowEvent.patch
+++ b/leaf-api/paper-patches/features/0011-PlayerInventoryOverflowEvent.patch
@@ -4,12 +4,40 @@ Date: Wed, 19 Feb 2025 00:34:16 -0500
 Subject: [PATCH] PlayerInventoryOverflowEvent
 
 
+diff --git a/src/main/java/org/bukkit/event/HandlerList.java b/src/main/java/org/bukkit/event/HandlerList.java
+index 64d8916a8ca1cc5678a34c17a8bbbff45323beb0..0a1f989a35e0f2e878176e273e9f3b65b96bc67b 100644
+--- a/src/main/java/org/bukkit/event/HandlerList.java
++++ b/src/main/java/org/bukkit/event/HandlerList.java
+@@ -66,6 +66,7 @@ public class HandlerList {
+                     h.handlers = null;
+                 }
+             }
++            org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.isListeningInvOverflowCached = -1; // Leaf - PlayerInventoryOverflowEvent
+         }
+     }
+ 
+@@ -79,6 +80,7 @@ public class HandlerList {
+             for (HandlerList h : allLists) {
+                 h.unregister(plugin);
+             }
++            org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.isListeningInvOverflowCached = -1; // Leaf - PlayerInventoryOverflowEvent
+         }
+     }
+ 
+@@ -92,6 +94,7 @@ public class HandlerList {
+             for (HandlerList h : allLists) {
+                 h.unregister(listener);
+             }
++            org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.isListeningInvOverflowCached = -1; // Leaf - PlayerInventoryOverflowEvent
+         }
+     }
+ 
 diff --git a/src/main/java/org/dreeam/leaf/event/player/PlayerInventoryOverflowEvent.java b/src/main/java/org/dreeam/leaf/event/player/PlayerInventoryOverflowEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..44c65eb6c503b94ac73d2b2169359be1b4810c98
+index 0000000000000000000000000000000000000000..eae76671190ef84529c0dd503263e43a15a74e8a
 --- /dev/null
 +++ b/src/main/java/org/dreeam/leaf/event/player/PlayerInventoryOverflowEvent.java
-@@ -0,0 +1,63 @@
+@@ -0,0 +1,65 @@
 +package org.dreeam.leaf.event.player;
 +
 +import org.bukkit.entity.Player;
@@ -35,6 +63,8 @@ index 0000000000000000000000000000000000000000..44c65eb6c503b94ac73d2b2169359be1
 +public class PlayerInventoryOverflowEvent extends PlayerEvent {
 +
 +    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    public static short isListeningInvOverflowCached = -1;
 +
 +    private final Inventory inventory;
 +    private final Map<Integer, ItemStack> overflowItemStacks;

--- a/leaf-server/paper-patches/features/0030-PlayerInventoryOverflowEvent.patch
+++ b/leaf-server/paper-patches/features/0030-PlayerInventoryOverflowEvent.patch
@@ -5,23 +5,54 @@ Subject: [PATCH] PlayerInventoryOverflowEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
-index 8b4f8a475faafe3b8a479160888145c4aa603a27..6b0067e83920d32c62416a0c3d8ef2940ca7ed2b 100644
+index 8b4f8a475faafe3b8a479160888145c4aa603a27..2f8377ceefa29fbf0827f673c7bf6e1d3215e477 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
-@@ -340,6 +340,16 @@ public class CraftInventory implements Inventory {
+@@ -340,9 +340,47 @@ public class CraftInventory implements Inventory {
                  }
              }
          }
 +
 +        // Leaf start - PlayerInventoryOverflowEvent
-+        if (org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.getHandlerList().getRegisteredListeners().length > 0
-+            && !leftover.isEmpty() && this.inventory instanceof net.minecraft.world.entity.player.Inventory && this.inventory.getOwner() instanceof org.bukkit.entity.Player player) {
++        if (isListeningInventoryOverflowEvent() && !leftover.isEmpty() && this.inventory instanceof net.minecraft.world.entity.player.Inventory && this.inventory.getOwner() instanceof org.bukkit.entity.Player player) {
 +            new org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent(player, leftover).callEvent();
 +
-+            leftover = new HashMap<>();
++            return new HashMap<>();
 +        }
 +        // Leaf end - PlayerInventoryOverflowEvent
 +
          return leftover;
      }
  
++    // Leaf start - PlayerInventoryOverflowEvent
++    private static boolean isListeningInventoryOverflowEvent() {
++        if (org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.isListeningInvOverflowCached == -1) {
++            org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.isListeningInvOverflowCached = 0;
++
++            if (!org.dreeam.leaf.config.modules.gameplay.ConfigurableInventoryOverflowEvent.enabled) {
++                return false;
++            }
++
++            org.bukkit.plugin.RegisteredListener[] listeners = org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.getHandlerList().getRegisteredListeners();
++            if (listeners.length == 1) {
++                if (listeners[0].getListener().getClass().getName().equals(org.dreeam.leaf.config.modules.gameplay.ConfigurableInventoryOverflowEvent.listenerClass)) {
++                    org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.isListeningInvOverflowCached = 1;
++                    return true;
++                }
++            } else if (listeners.length > 1) {
++                for (org.bukkit.plugin.RegisteredListener registeredListener : listeners) {
++                    if (registeredListener.getListener().getClass().getName().equals(org.dreeam.leaf.config.modules.gameplay.ConfigurableInventoryOverflowEvent.listenerClass)) {
++                        org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.isListeningInvOverflowCached = 1;
++                        return true;
++                    };
++                }
++            }
++        }
++
++        return org.dreeam.leaf.event.player.PlayerInventoryOverflowEvent.isListeningInvOverflowCached == 1;
++    }
++    // Leaf end - PlayerInventoryOverflowEvent
++
+     @Override
+     public HashMap<Integer, ItemStack> removeItem(ItemStack... items) {
+         // Paper start

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/ConfigurableInventoryOverflowEvent.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/ConfigurableInventoryOverflowEvent.java
@@ -1,0 +1,32 @@
+package org.dreeam.leaf.config.modules.gameplay;
+
+import org.dreeam.leaf.config.ConfigModules;
+import org.dreeam.leaf.config.EnumConfigCategory;
+
+public class ConfigurableInventoryOverflowEvent extends ConfigModules {
+
+    public String getBasePath() {
+        return EnumConfigCategory.GAMEPLAY.getBaseKeyName() + ".inventory-overflow-event";
+    }
+
+    public static boolean enabled = false;
+    public static String listenerClass = "com.example.package.PlayerInventoryOverflowEvent" ;
+
+    @Override
+    public void onLoaded() {
+        enabled = config.getBoolean(getBasePath() + ".enabled", enabled, config.pickStringRegionBased("""
+                The event called when used plugin to Inventory#addItem
+                into player's inventory, and the inventory is full.
+                This is not recommended to use, please re-design to use the
+                returned map of Inventory#addItem method as soon as possible!""",
+            """
+                此事件将在插件使用 Inventory#addItem 方法
+                添加物品到玩家背包, 但是背包已满时调用.
+                不建议使用此事件，请尽快迁移至使用 Inventory#addItem 方法
+                返回的 map"""));
+        listenerClass = config.getString(getBasePath() + ".listener-class", listenerClass, config.pickStringRegionBased("""
+                The full class name of the listener which listens to this inventory overflow event.""",
+            """
+                监听此物品栏物品溢出事件的完整类名."""));
+    }
+}


### PR DESCRIPTION
Changes:
* Add configurable option in config for PlayerInventoryOverflowEvent and able to define the class name of listener
* Update checking method for overflow items handling logic, only fire event when actual listener is listening to it
* Add cache for listener checking condition, refresh the cache when reload register of plugin listeners

Fixes https://github.com/Winds-Studio/Leaf/issues/300