### PR TITLE
Prevent overriding spark flags

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/config/LeafConfig.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/LeafConfig.java
@@ -7,6 +7,7 @@ import net.minecraft.Util;
 import org.dreeam.leaf.config.modules.misc.SentryDSN;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -223,8 +224,10 @@ public class LeafConfig {
             "config/gale-world-defaults.yml"
         ));
 
-        String existing = System.getProperty("spark.serverconfigs.extra");
-        extraConfigs.addAll(Arrays.asList(existing.split(",")));
+        @Nullable String existing = System.getProperty("spark.serverconfigs.extra");
+        if (existing != null) {
+            extraConfigs.addAll(Arrays.asList(existing.split(",")));
+        }
 
         for (World world : Bukkit.getWorlds()) {
             extraConfigs.add(world.getWorldFolder().getName() + "/gale-world.yml"); // Gale world config
@@ -234,9 +237,9 @@ public class LeafConfig {
     }
 
     private static List<String> buildSparkHiddenPaths() {
-        String existing = System.getProperty("spark.serverconfigs.hiddenpaths");
+        @Nullable String existing = System.getProperty("spark.serverconfigs.hiddenpaths");
 
-        List<String> extraHidden = new ArrayList<>(Arrays.asList(existing.split(",")));
+        List<String> extraHidden = existing != null ? new ArrayList<>(Arrays.asList(existing.split(","))) : new ArrayList<>();
         extraHidden.add(SentryDSN.sentryDsnConfigPath); // Hide Sentry DSN key
 
         return extraHidden;

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/LeafConfig.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/LeafConfig.java
@@ -223,6 +223,9 @@ public class LeafConfig {
             "config/gale-world-defaults.yml"
         ));
 
+        String existing = System.getProperty("spark.serverconfigs.extra");
+        extraConfigs.addAll(Arrays.asList(existing.split(",")));
+
         for (World world : Bukkit.getWorlds()) {
             extraConfigs.add(world.getWorldFolder().getName() + "/gale-world.yml"); // Gale world config
         }
@@ -230,10 +233,13 @@ public class LeafConfig {
         return extraConfigs;
     }
 
-    private static String[] buildSparkHiddenPaths() {
-        return new String[]{
-            SentryDSN.sentryDsnConfigPath // Hide Sentry DSN key
-        };
+    private static List<String> buildSparkHiddenPaths() {
+        String existing = System.getProperty("spark.serverconfigs.hiddenpaths");
+
+        List<String> extraHidden = new ArrayList<>(Arrays.asList(existing.split(",")));
+        extraHidden.add(SentryDSN.sentryDsnConfigPath); // Hide Sentry DSN key
+
+        return extraHidden;
     }
 
     public static void regSparkExtraConfig() {


### PR DESCRIPTION
This should prevent overriding spark flags defined by the user.

## Example on leaf:
![image](https://github.com/user-attachments/assets/784ee250-d8d3-4aef-9e54-45c829a762c3)
![image](https://github.com/user-attachments/assets/e212f41f-f58a-4588-9b21-1030f6e292b9)


## Example on paper
![image](https://github.com/user-attachments/assets/24a39fed-e41d-43d4-8fbf-0f783e46ae29)
![image](https://github.com/user-attachments/assets/600b987d-a4cd-42ec-ba38-2c1ae3945603)
![image](https://github.com/user-attachments/assets/746f3091-cbe5-40a1-9fa0-cebb61c4c2d6)


