### PR TITLE
Add BlockExplosionHitEvent

### DIFF
--- a/leaf-api/src/main/java/org/dreeam/leaf/event/BlockExplosionHitEvent.java
+++ b/leaf-api/src/main/java/org/dreeam/leaf/event/BlockExplosionHitEvent.java
@@ -1,0 +1,63 @@
+package org.dreeam.leaf.event;
+
+import org.bukkit.ExplosionResult;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.block.BlockEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a block executes its explosion hit actions.
+ * If the event is cancelled, the block will not execute the explosion hit actions.
+ */
+public class BlockExplosionHitEvent extends BlockEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+    private boolean cancelled;
+    private final Entity source;
+    private final ExplosionResult result;
+
+    public BlockExplosionHitEvent(@NotNull Block block, Entity source, ExplosionResult result) {
+        super(block);
+        this.source = source;
+        this.result = result;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    /**
+     * Returns the entity responsible for the explosion.
+     *
+     * @return Entity responsible for the explosion
+     */
+    public Entity getSource() {
+        return source;
+    }
+
+    /**
+     * Returns the result of the explosion.
+     *
+     * @return the result of the explosion
+     */
+    public ExplosionResult getResult() {
+        return result;
+    }
+}

--- a/leaf-server/minecraft-patches/features/0189-Add-BlockExplosionHitEvent.patch
+++ b/leaf-server/minecraft-patches/features/0189-Add-BlockExplosionHitEvent.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pascalpex <pascalpex@gmail.com>
+Date: Wed, 4 Jun 2025 17:03:32 +0200
+Subject: [PATCH] Add BlockExplosionHitEvent
+
+
+diff --git a/net/minecraft/world/level/ServerExplosion.java b/net/minecraft/world/level/ServerExplosion.java
+index 6030c4eefd77969a1a9251de76d4291dcb0a2092..3b6758aba638fda2942cf43ed814971f20382d68 100644
+--- a/net/minecraft/world/level/ServerExplosion.java
++++ b/net/minecraft/world/level/ServerExplosion.java
+@@ -35,6 +35,7 @@ import net.minecraft.world.phys.Vec3;
+ import net.minecraft.world.entity.boss.EnderDragonPart;
+ import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+ import net.minecraft.world.level.block.Blocks;
++import org.bukkit.craftbukkit.CraftExplosionResult;
+ import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.bukkit.craftbukkit.util.CraftLocation;
+ import org.bukkit.event.entity.EntityExplodeEvent;
+@@ -623,9 +624,13 @@ public class ServerExplosion implements Explosion {
+             }
+             // CraftBukkit end
+ 
+-            this.level
+-                .getBlockState(blockPos)
+-                .onExplosionHit(this.level, blockPos, this, (itemStack, blockPos1) -> addOrAppendStack(list, itemStack, blockPos1));
++            // Leaf start - BlockExplosionHitEvent
++            if(new org.dreeam.leaf.event.BlockExplosionHitEvent(CraftLocation.toBukkit(blockPos, bworld).getBlock(), this.source == null ? null : this.source.getBukkitEntity(), CraftExplosionResult.toBukkit(this.blockInteraction)).callEvent()) {
++                this.level
++                    .getBlockState(blockPos)
++                    .onExplosionHit(this.level, blockPos, this, (itemStack, blockPos1) -> addOrAppendStack(list, itemStack, blockPos1));
++            }
++            // Leaf end
+         }
+ 
+         for (ServerExplosion.StackCollector stackCollector : list) {

--- a/leaf-server/minecraft-patches/features/0189-Add-BlockExplosionHitEvent.patch
+++ b/leaf-server/minecraft-patches/features/0189-Add-BlockExplosionHitEvent.patch
@@ -5,18 +5,10 @@ Subject: [PATCH] Add BlockExplosionHitEvent
 
 
 diff --git a/net/minecraft/world/level/ServerExplosion.java b/net/minecraft/world/level/ServerExplosion.java
-index 6030c4eefd77969a1a9251de76d4291dcb0a2092..3b6758aba638fda2942cf43ed814971f20382d68 100644
+index 6030c4eefd77969a1a9251de76d4291dcb0a2092..ea9c641fe9a9685307b6de2999ea4ff5342269b7 100644
 --- a/net/minecraft/world/level/ServerExplosion.java
 +++ b/net/minecraft/world/level/ServerExplosion.java
-@@ -35,6 +35,7 @@ import net.minecraft.world.phys.Vec3;
- import net.minecraft.world.entity.boss.EnderDragonPart;
- import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
- import net.minecraft.world.level.block.Blocks;
-+import org.bukkit.craftbukkit.CraftExplosionResult;
- import org.bukkit.craftbukkit.event.CraftEventFactory;
- import org.bukkit.craftbukkit.util.CraftLocation;
- import org.bukkit.event.entity.EntityExplodeEvent;
-@@ -623,9 +624,13 @@ public class ServerExplosion implements Explosion {
+@@ -623,9 +623,13 @@ public class ServerExplosion implements Explosion {
              }
              // CraftBukkit end
  
@@ -24,7 +16,7 @@ index 6030c4eefd77969a1a9251de76d4291dcb0a2092..3b6758aba638fda2942cf43ed814971f
 -                .getBlockState(blockPos)
 -                .onExplosionHit(this.level, blockPos, this, (itemStack, blockPos1) -> addOrAppendStack(list, itemStack, blockPos1));
 +            // Leaf start - BlockExplosionHitEvent
-+            if(new org.dreeam.leaf.event.BlockExplosionHitEvent(CraftLocation.toBukkit(blockPos, bworld).getBlock(), this.source == null ? null : this.source.getBukkitEntity(), CraftExplosionResult.toBukkit(this.blockInteraction)).callEvent()) {
++            if(new org.dreeam.leaf.event.BlockExplosionHitEvent(CraftLocation.toBukkit(blockPos, bworld).getBlock(), this.source == null ? null : this.source.getBukkitEntity(), org.bukkit.craftbukkit.CraftExplosionResult.toBukkit(this.blockInteraction)).callEvent()) {
 +                this.level
 +                    .getBlockState(blockPos)
 +                    .onExplosionHit(this.level, blockPos, this, (itemStack, blockPos1) -> addOrAppendStack(list, itemStack, blockPos1));


### PR DESCRIPTION
This event is called when a block is about to execute its `onExplosionHit` method.

You can cancel the event to prevent the block from executing this method.