### PR TITLE
Optimize more for rail optimization

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/world/block/OptimizedPoweredRails.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/world/block/OptimizedPoweredRails.java
@@ -1,5 +1,6 @@
 package org.dreeam.leaf.world.block;
 
+import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
@@ -23,6 +24,8 @@ public class OptimizedPoweredRails {
 
     private static int RAIL_POWER_LIMIT = 8;
 
+    private static final ThreadLocal<Object2BooleanOpenHashMap<BlockPos>> CHECKED_POS_POOL = ThreadLocal.withInitial(Object2BooleanOpenHashMap::new);
+
     private static void giveShapeUpdate(Level level, BlockState state, BlockPos pos, BlockPos fromPos, Direction direction) {
         BlockState oldState = level.getBlockState(pos);
         Block.updateOrDestroy(
@@ -45,8 +48,8 @@ public class OptimizedPoweredRails {
 
     public static void updateState(PoweredRailBlock self, BlockState state, Level level, BlockPos pos) {
         boolean shouldBePowered = level.hasNeighborSignal(pos) ||
-            self.findPoweredRailSignal(level, pos, state, true, 0) ||
-            self.findPoweredRailSignal(level, pos, state, false, 0);
+            findPoweredRailSignalFaster(self, level, pos, state, true, 0, CHECKED_POS_POOL.get()) ||
+            findPoweredRailSignalFaster(self, level, pos, state, false, 0, CHECKED_POS_POOL.get());
         if (shouldBePowered != state.getValue(POWERED)) {
             RailShape railShape = state.getValue(SHAPE);
             if (railShape.isSlope()) {
@@ -63,9 +66,9 @@ public class OptimizedPoweredRails {
 
     private static boolean findPoweredRailSignalFaster(PoweredRailBlock self, Level world, BlockPos pos,
                                                        boolean bl, int distance, RailShape shape,
-                                                       HashMap<BlockPos, Boolean> checkedPos) {
+                                                       Object2BooleanOpenHashMap<BlockPos> checkedPos) {
         BlockState blockState = world.getBlockState(pos);
-        boolean speedCheck = checkedPos.containsKey(pos) && checkedPos.get(pos);
+        boolean speedCheck = checkedPos.containsKey(pos) && checkedPos.getBoolean(pos);
         if (speedCheck) {
             return world.hasNeighborSignal(pos) ||
                 findPoweredRailSignalFaster(self, world, pos, blockState, bl, distance + 1, checkedPos);
@@ -95,7 +98,7 @@ public class OptimizedPoweredRails {
 
     private static boolean findPoweredRailSignalFaster(PoweredRailBlock self, Level level,
                                                        BlockPos pos, BlockState state, boolean bl, int distance,
-                                                       HashMap<BlockPos, Boolean> checkedPos) {
+                                                       Object2BooleanOpenHashMap<BlockPos> checkedPos) {
         if (distance >= RAIL_POWER_LIMIT - 1) return false;
         int i = pos.getX();
         int j = pos.getY();
@@ -165,7 +168,8 @@ public class OptimizedPoweredRails {
     private static void powerLane(PoweredRailBlock self, Level world, BlockPos pos,
                                   BlockState mainState, RailShape railShape) {
         world.setBlock(pos, mainState.setValue(POWERED, true), UPDATE_FORCE_PLACE);
-        HashMap<BlockPos, Boolean> checkedPos = new HashMap<>();
+        Object2BooleanOpenHashMap<BlockPos> checkedPos = CHECKED_POS_POOL.get();
+        checkedPos.clear();
         checkedPos.put(pos, true);
         int[] count = new int[2];
         if (railShape == RailShape.NORTH_SOUTH) { // Order: +z, -z
@@ -179,6 +183,7 @@ public class OptimizedPoweredRails {
             }
             updateRails(self, true, world, pos, mainState, count);
         }
+        checkedPos.clear();
     }
 
     private static void dePowerLane(PoweredRailBlock self, Level world, BlockPos pos,
@@ -199,39 +204,46 @@ public class OptimizedPoweredRails {
     }
 
     private static void setRailPositionsPower(PoweredRailBlock self, Level world, BlockPos pos,
-                                              HashMap<BlockPos, Boolean> checkedPos, int[] count, int i, Direction dir) {
+            Object2BooleanOpenHashMap<BlockPos> checkedPos, int[] count, int i, Direction dir) {
         for (int z = 1; z < RAIL_POWER_LIMIT; z++) {
             BlockPos newPos = pos.relative(dir, z);
             BlockState state = world.getBlockState(newPos);
             if (checkedPos.containsKey(newPos)) {
-                if (!checkedPos.get(newPos)) break;
+                if (!checkedPos.getBoolean(newPos))
+                    break;
                 count[i]++;
-            } else if (!state.is(self) || state.getValue(POWERED) || !(
-                world.hasNeighborSignal(newPos) ||
+            } else if (!state.is(self) || state.getValue(POWERED) || !(world.hasNeighborSignal(newPos) ||
                     findPoweredRailSignalFaster(self, world, newPos, state, true, 0, checkedPos) ||
-                    findPoweredRailSignalFaster(self, world, newPos, state, false, 0, checkedPos)
-            )) {
+                    findPoweredRailSignalFaster(self, world, newPos, state, false, 0, checkedPos))) {
                 checkedPos.put(newPos, false);
                 break;
             } else {
                 checkedPos.put(newPos, true);
-                world.setBlock(newPos, state.setValue(POWERED, true), UPDATE_FORCE_PLACE);
+                if (!state.getValue(POWERED)) {
+                    world.setBlock(newPos, state.setValue(POWERED, true), UPDATE_FORCE_PLACE);
+                }
                 count[i]++;
             }
         }
     }
 
     private static void setRailPositionsDePower(PoweredRailBlock self, Level world, BlockPos pos,
-                                                int[] count, int i, Direction dir) {
+            int[] count, int i, Direction dir) {
+        Object2BooleanOpenHashMap<BlockPos> checkedPos = CHECKED_POS_POOL.get();
+        checkedPos.clear();
         for (int z = 1; z < RAIL_POWER_LIMIT; z++) {
             BlockPos newPos = pos.relative(dir, z);
             BlockState state = world.getBlockState(newPos);
             if (!state.is(self) || !state.getValue(POWERED) || world.hasNeighborSignal(newPos) ||
-                self.findPoweredRailSignal(world, newPos, state, true, 0) ||
-                self.findPoweredRailSignal(world, newPos, state, false, 0)) break;
-            world.setBlock(newPos, state.setValue(POWERED, false), UPDATE_FORCE_PLACE);
+                    findPoweredRailSignalFaster(self, world, newPos, state, true, 0, checkedPos) ||
+                    findPoweredRailSignalFaster(self, world, newPos, state, false, 0, checkedPos))
+                break;
+            if (state.getValue(POWERED)) {
+                world.setBlock(newPos, state.setValue(POWERED, false), UPDATE_FORCE_PLACE);
+            }
             count[i]++;
         }
+        checkedPos.clear();
     }
 
     private static void shapeUpdateEnd(PoweredRailBlock self, Level world, BlockPos pos, BlockState mainState,

--- a/leaf-server/src/main/java/org/dreeam/leaf/world/block/OptimizedPoweredRails.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/world/block/OptimizedPoweredRails.java
@@ -9,8 +9,6 @@ import net.minecraft.world.level.block.PoweredRailBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.RailShape;
 
-import java.util.HashMap;
-
 import static net.minecraft.world.level.block.Block.*;
 import static net.minecraft.world.level.block.PoweredRailBlock.POWERED;
 import static net.minecraft.world.level.block.PoweredRailBlock.SHAPE;
@@ -24,7 +22,7 @@ public class OptimizedPoweredRails {
 
     private static int RAIL_POWER_LIMIT = 8;
 
-    private static final ThreadLocal<Object2BooleanOpenHashMap<BlockPos>> CHECKED_POS_POOL = ThreadLocal.withInitial(Object2BooleanOpenHashMap::new);
+    private static final Object2BooleanOpenHashMap<BlockPos> CHECKED_POS_POOL = new Object2BooleanOpenHashMap<>();
 
     private static void giveShapeUpdate(Level level, BlockState state, BlockPos pos, BlockPos fromPos, Direction direction) {
         BlockState oldState = level.getBlockState(pos);
@@ -48,8 +46,8 @@ public class OptimizedPoweredRails {
 
     public static void updateState(PoweredRailBlock self, BlockState state, Level level, BlockPos pos) {
         boolean shouldBePowered = level.hasNeighborSignal(pos) ||
-            findPoweredRailSignalFaster(self, level, pos, state, true, 0, CHECKED_POS_POOL.get()) ||
-            findPoweredRailSignalFaster(self, level, pos, state, false, 0, CHECKED_POS_POOL.get());
+            findPoweredRailSignalFaster(self, level, pos, state, true, 0, CHECKED_POS_POOL) ||
+            findPoweredRailSignalFaster(self, level, pos, state, false, 0, CHECKED_POS_POOL);
         if (shouldBePowered != state.getValue(POWERED)) {
             RailShape railShape = state.getValue(SHAPE);
             if (railShape.isSlope()) {
@@ -168,7 +166,7 @@ public class OptimizedPoweredRails {
     private static void powerLane(PoweredRailBlock self, Level world, BlockPos pos,
                                   BlockState mainState, RailShape railShape) {
         world.setBlock(pos, mainState.setValue(POWERED, true), UPDATE_FORCE_PLACE);
-        Object2BooleanOpenHashMap<BlockPos> checkedPos = CHECKED_POS_POOL.get();
+        Object2BooleanOpenHashMap<BlockPos> checkedPos = CHECKED_POS_POOL;
         checkedPos.clear();
         checkedPos.put(pos, true);
         int[] count = new int[2];
@@ -228,8 +226,8 @@ public class OptimizedPoweredRails {
     }
 
     private static void setRailPositionsDePower(PoweredRailBlock self, Level world, BlockPos pos,
-            int[] count, int i, Direction dir) {
-        Object2BooleanOpenHashMap<BlockPos> checkedPos = CHECKED_POS_POOL.get();
+        int[] count, int i, Direction dir) {
+        Object2BooleanOpenHashMap<BlockPos> checkedPos = CHECKED_POS_POOL;
         checkedPos.clear();
         for (int z = 1; z < RAIL_POWER_LIMIT; z++) {
             BlockPos newPos = pos.relative(dir, z);


### PR DESCRIPTION
This pull request optimizes the `OptimizedPoweredRails` class by replacing the `HashMap` used for tracking block positions with a more efficient `Object2BooleanOpenHashMap`. This change reduces memory usage and improves performance for operations involving powered rails. Key changes include updating method signatures, introducing a shared pool for the map, and ensuring proper cleanup after use.

### Performance Optimization:
* Replaced `HashMap<BlockPos, Boolean>` with `Object2BooleanOpenHashMap<BlockPos>` in methods like `findPoweredRailSignalFaster`, `powerLane`, and `setRailPositionsPower`, leading to better memory efficiency and faster lookups. [[1]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dL66-R69) [[2]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dL98-R99) [[3]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dL202-R244)
* Introduced a shared static pool (`CHECKED_POS_POOL`) for `Object2BooleanOpenHashMap` to reduce object creation overhead. The pool is cleared before and after use to ensure no residual data. [[1]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dR25-R26) [[2]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dL168-R170) [[3]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dR184)

### Code Refactoring:
* Updated method signatures and logic to accommodate the new `Object2BooleanOpenHashMap` type, ensuring compatibility and correctness. [[1]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dL48-R50) [[2]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dL202-R244)
* Added calls to `checkedPos.clear()` at appropriate points to reset the shared pool and prevent stale data from being reused. [[1]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dL168-R170) [[2]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dR184) [[3]](diffhunk://#diff-32413c7c861da4ce974c708e0ec58476db135c076996d992b769c18d610d677dL202-R244)

summary by copilot