### PR TITLE
Async optimized broadcastChanges with minimal memory allocation

### DIFF
--- a/leaf-server/minecraft-patches/features/0191-Async-optimized-broadcastChanges.patch
+++ b/leaf-server/minecraft-patches/features/0191-Async-optimized-broadcastChanges.patch
@@ -1,0 +1,96 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: wling-art <wlingzhenyu@163.com>
+Date: Sat, 14 Jun 2025 19:52:42 +0800
+Subject: [PATCH] Async optimized broadcastChanges
+
+
+diff --git a/net/minecraft/world/inventory/AbstractContainerMenu.java b/net/minecraft/world/inventory/AbstractContainerMenu.java
+index 2a49a0bdeb61c4fadddc241c8ebca908959d7e9c..ae6486065e1301ae1851cc70436d6543846daad6 100644
+--- a/net/minecraft/world/inventory/AbstractContainerMenu.java
++++ b/net/minecraft/world/inventory/AbstractContainerMenu.java
+@@ -61,7 +61,7 @@ public abstract class AbstractContainerMenu {
+     public int quickcraftType = -1;
+     public int quickcraftStatus;
+     public final Set<Slot> quickcraftSlots = Sets.newHashSet();
+-    private final List<ContainerListener> containerListeners = Lists.newArrayList();
++    public final List<ContainerListener> containerListeners = Lists.newArrayList(); // Leaf - Async optimized broadcastChanges with minimal memory allocation
+     @Nullable
+     private ContainerSynchronizer synchronizer;
+     private boolean suppressRemoteUpdates;
+@@ -231,24 +231,69 @@ public abstract class AbstractContainerMenu {
+     }
+ 
+     public void broadcastChanges() {
++        // Leaf start - Async optimized broadcastChanges with minimal memory allocation
++        boolean useAsync = org.dreeam.leaf.config.modules.async.AsyncContainerBroadcast.enabled;
++        java.util.List<Runnable> asyncTasks = useAsync ? org.dreeam.leaf.async.container.AsyncContainerBroadcaster.getTasks() : null;
++
+         for (int i = 0; i < this.slots.size(); i++) {
+-            ItemStack item = this.slots.get(i).getItem();
+-            Supplier<ItemStack> supplier = Suppliers.memoize(item::copy);
+-            this.triggerSlotListeners(i, item, supplier);
+-            this.synchronizeSlotToRemote(i, item, supplier);
++            ItemStack currentItem = this.slots.get(i).getItem();
++            ItemStack lastListenerItem = this.lastSlots.get(i);
++            boolean needsListenerUpdate = !ItemStack.matches(lastListenerItem, currentItem);
++            boolean needsRemoteSync = false;
++
++            if (!this.suppressRemoteUpdates) {
++                if (!ItemStack.matches(this.remoteSlots.get(i), currentItem)) {
++                    needsRemoteSync = true;
++                }
++            }
++
++            if (needsListenerUpdate || needsRemoteSync) {
++                ItemStack newItemCopy = currentItem.copy();
++                if (needsListenerUpdate) {
++                    this.lastSlots.set(i, newItemCopy);
++                    for (ContainerListener containerListener : this.containerListeners) {
++                        containerListener.slotChanged(this, i, lastListenerItem, newItemCopy);
++                    }
++                }
++                if (needsRemoteSync) {
++                    this.remoteSlots.set(i, newItemCopy);
++                    if (useAsync) {
++                        org.dreeam.leaf.async.container.AsyncContainerBroadcaster.addSlotSyncTask(asyncTasks, this.synchronizer, this, i, newItemCopy);
++                    } else {
++                        this.synchronizeSlotToRemote(i, currentItem, currentItem::copy);
++                    }
++                }
++            }
+         }
+ 
+         this.synchronizeCarriedToRemote();
+ 
+         for (int i = 0; i < this.dataSlots.size(); i++) {
+             DataSlot dataSlot = this.dataSlots.get(i);
+-            int i1 = dataSlot.get();
++            int currentValue = dataSlot.get();
++
+             if (dataSlot.checkAndClearUpdateFlag()) {
+-                this.updateDataSlotListeners(i, i1);
++                for (ContainerListener containerListener : this.containerListeners) {
++                    containerListener.dataChanged(this, i, currentValue);
++                }
+             }
+ 
+-            this.synchronizeDataSlotToRemote(i, i1);
++            if (!this.suppressRemoteUpdates) {
++                if (this.remoteDataSlots.getInt(i) != currentValue) {
++                    this.remoteDataSlots.set(i, currentValue);
++                    if (useAsync) {
++                        org.dreeam.leaf.async.container.AsyncContainerBroadcaster.addDataSyncTask(asyncTasks, this.synchronizer, this, i, currentValue);
++                    } else {
++                        this.synchronizeDataSlotToRemote(i, currentValue);
++                    }
++                }
++            }
++        }
++
++        if (useAsync && asyncTasks != null) {
++            org.dreeam.leaf.async.container.AsyncContainerBroadcaster.executeAsync(asyncTasks);
+         }
++        // Leaf end - Async optimized broadcastChanges with minimal memory allocation
+     }
+ 
+     public void broadcastFullState() {

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/ShutdownExecutors.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/ShutdownExecutors.java
@@ -57,5 +57,14 @@ public class ShutdownExecutors {
             } catch (InterruptedException ignored) {
             }
         }
+
+        if (org.dreeam.leaf.async.container.AsyncContainerBroadcaster.CONTAINER_POOL != null) {
+            LOGGER.info("Waiting for container broadcast executor to shutdown...");
+            org.dreeam.leaf.async.container.AsyncContainerBroadcaster.CONTAINER_POOL.shutdown();
+            try {
+                org.dreeam.leaf.async.container.AsyncContainerBroadcaster.CONTAINER_POOL.awaitTermination(10L, TimeUnit.SECONDS);
+            } catch (InterruptedException ignored) {
+            }
+        }
     }
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/container/AsyncContainerBroadcastThread.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/container/AsyncContainerBroadcastThread.java
@@ -1,0 +1,8 @@
+package org.dreeam.leaf.async.container;
+
+public class AsyncContainerBroadcastThread extends Thread {
+
+    protected AsyncContainerBroadcastThread(Runnable task) {
+        super(task);
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/container/AsyncContainerBroadcaster.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/container/AsyncContainerBroadcaster.java
@@ -1,0 +1,225 @@
+package org.dreeam.leaf.async.container;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import net.minecraft.Util;
+import net.minecraft.network.Connection;
+import net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket;
+import net.minecraft.network.protocol.game.ClientboundContainerSetDataPacket;
+import net.minecraft.server.level.ServerPlayer;
+import org.dreeam.leaf.config.modules.async.AsyncContainerBroadcast;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerSynchronizer;
+import net.minecraft.world.item.ItemStack;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class AsyncContainerBroadcaster {
+
+    public static ExecutorService CONTAINER_POOL = null;
+    public static final Logger LOGGER = LogManager.getLogger("Leaf Async Container Broadcast");
+    private static final ThreadLocal<List<Runnable>> TASK_POOL = ThreadLocal.withInitial(() -> new ArrayList<>(16));
+    private static final ThreadLocal<List<Object>> PACKET_BATCH = ThreadLocal.withInitial(() -> new ArrayList<>(8));
+    private static final ThreadLocal<AbstractContainerMenu> CURRENT_MENU = new ThreadLocal<>();
+    
+    private static volatile long totalTasksProcessed = 0;
+    private static volatile long totalPacketsSent = 0;
+    private static volatile long backpressureSkips = 0;
+
+    public static void init() {
+        if (CONTAINER_POOL != null) {
+            CONTAINER_POOL.shutdown();
+        }
+        
+        CONTAINER_POOL = new ThreadPoolExecutor(
+            AsyncContainerBroadcast.minThreads,
+            AsyncContainerBroadcast.maxThreads,
+            AsyncContainerBroadcast.keepalive, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<>(),
+            new ThreadFactoryBuilder()
+                .setPriority(Thread.NORM_PRIORITY)
+                .setNameFormat("Leaf Async Container Broadcast Thread-%d")
+                .setUncaughtExceptionHandler(Util::onThreadException)
+                .setThreadFactory(AsyncContainerBroadcastThread::new)
+                .build(),
+            new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+        
+        LOGGER.info("Initialized Async Container Broadcast with {}-{} threads", 
+            AsyncContainerBroadcast.minThreads, AsyncContainerBroadcast.maxThreads);
+    }
+
+    public static void executeAsync(List<Runnable> tasks) {
+        if (CONTAINER_POOL != null && !tasks.isEmpty()) {
+            totalTasksProcessed += tasks.size();
+            
+            if (AsyncContainerBroadcast.enableBatchedSending) {
+                CONTAINER_POOL.execute(() -> {
+                    List<Object> packets = PACKET_BATCH.get();
+                    AbstractContainerMenu currentMenu = null;
+                    
+                    for (Runnable task : tasks) {
+                        if (task instanceof PacketTask packetTask) {
+                            if (currentMenu != packetTask.menu) {
+                                if (currentMenu != null && !packets.isEmpty()) {
+                                    sendBatchedPackets(currentMenu, packets);
+                                    packets.clear();
+                                }
+                                currentMenu = packetTask.menu;
+                            }
+                            packets.add(packetTask.packet);
+                        } else {
+                            task.run();
+                        }
+                    }
+                    
+                    if (currentMenu != null && !packets.isEmpty()) {
+                        sendBatchedPackets(currentMenu, packets);
+                    }
+                    
+                    packets.clear();
+                });
+            } else {
+                CONTAINER_POOL.execute(() -> {
+                    for (Runnable task : tasks) {
+                        task.run();
+                    }
+                });
+            }
+            tasks.clear();
+        }
+    }
+
+    public static List<Runnable> getTasks() {
+        List<Runnable> tasks = TASK_POOL.get();
+        tasks.clear();
+        return tasks;
+    }
+
+    public static void addSlotSyncTask(List<Runnable> tasks, ContainerSynchronizer synchronizer,
+            AbstractContainerMenu menu, int slotIndex, ItemStack item) {
+        if (synchronizer != null) {
+            final ItemStack asyncItemCopy = item.copy();
+            final int containerId = menu.containerId;
+            final int stateId = menu.incrementStateId();
+
+            ClientboundContainerSetSlotPacket packet = new ClientboundContainerSetSlotPacket(
+                    containerId, stateId, slotIndex, asyncItemCopy);
+
+            tasks.add(new PacketTask(menu, packet, () -> {
+                try {
+                    menu.synchronizeSlotToRemote(slotIndex, asyncItemCopy, asyncItemCopy::copy);
+                } catch (Exception e) {
+                    LOGGER.error("Failed to send async slot change packet", e);
+                }
+            }));
+        }
+    }
+
+    public static void addDataSyncTask(List<Runnable> tasks, ContainerSynchronizer synchronizer,
+            AbstractContainerMenu menu, int dataIndex, int value) {
+        if (synchronizer != null) {
+            final int containerId = menu.containerId;
+
+            ClientboundContainerSetDataPacket packet = new ClientboundContainerSetDataPacket(
+                    containerId, dataIndex, value);
+
+            tasks.add(new PacketTask(menu, packet, () -> {
+                try {
+                    menu.synchronizeDataSlotToRemote(dataIndex, value);
+                } catch (Exception e) {
+                    LOGGER.error("Failed to send async data change packet", e);
+                }
+            }));
+        }
+    }
+
+    private static void sendPacketToContainerListeners(AbstractContainerMenu menu, Object packet) {
+        List<net.minecraft.world.inventory.ContainerListener> listeners = menu.containerListeners;
+        for (net.minecraft.world.inventory.ContainerListener listener : listeners) {
+            if (listener instanceof ServerPlayer player) {
+                Connection connection = player.connection.connection;
+                if (connection.channel != null && connection.channel.isActive()) {
+                    if (AsyncContainerBroadcast.enableBackpressureHandling && !connection.channel.isWritable()) {
+                        backpressureSkips++;
+                        LOGGER.debug("Channel not writable for player {}, skipping container update", player.getName().getString());
+                        continue;
+                    }
+                    
+                    totalPacketsSent++;
+                    connection.channel.eventLoop().execute(() -> {
+                        try {
+                            if (connection.channel.isActive()) {
+                                connection.send((net.minecraft.network.protocol.Packet<?>) packet);
+                            }
+                        } catch (Exception e) {
+                            LOGGER.warn("Failed to send packet to player {}: {}", player.getName().getString(), e.getMessage());
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    private static void sendBatchedPackets(AbstractContainerMenu menu, List<Object> packets) {
+        List<net.minecraft.world.inventory.ContainerListener> listeners = menu.containerListeners;
+        for (net.minecraft.world.inventory.ContainerListener listener : listeners) {
+            if (listener instanceof ServerPlayer player) {
+                Connection connection = player.connection.connection;
+                if (connection.channel != null && connection.channel.isActive()) {
+                    if (AsyncContainerBroadcast.enableBackpressureHandling && !connection.channel.isWritable()) {
+                        backpressureSkips += packets.size();
+                        LOGGER.debug("Channel not writable for player {}, skipping {} container updates", 
+                            player.getName().getString(), packets.size());
+                        continue;
+                    }
+                    
+                    totalPacketsSent += packets.size();
+                    connection.channel.eventLoop().execute(() -> {
+                        try {
+                            if (connection.channel.isActive()) {
+                                for (Object packet : packets) {
+                                    connection.send((net.minecraft.network.protocol.Packet<?>) packet);
+                                }
+                            }
+                        } catch (Exception e) {
+                            LOGGER.warn("Failed to send batched packets to player {}: {}", 
+                                player.getName().getString(), e.getMessage());
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    public static void logStatistics() {
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Async Container Broadcast Stats - Tasks: {}, Packets: {}, Backpressure Skips: {}",
+                totalTasksProcessed, totalPacketsSent, backpressureSkips);
+        }
+    }
+    
+    public static void resetStatistics() {
+        totalTasksProcessed = 0;
+        totalPacketsSent = 0;
+        backpressureSkips = 0;
+    }
+
+    private static record PacketTask(AbstractContainerMenu menu, Object packet, Runnable fallback) implements Runnable {
+        @Override
+        public void run() {
+            try {
+                sendPacketToContainerListeners(menu, packet);
+            } catch (Exception e) {
+                LOGGER.error("Failed to send packet, using fallback", e);
+                fallback.run();
+            }
+        }
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/container/AsyncContainerBroadcaster.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/container/AsyncContainerBroadcaster.java
@@ -25,18 +25,12 @@ public class AsyncContainerBroadcaster {
     public static ExecutorService CONTAINER_POOL = null;
     public static final Logger LOGGER = LogManager.getLogger("Leaf Async Container Broadcast");
     private static final ThreadLocal<List<Runnable>> TASK_POOL = ThreadLocal.withInitial(() -> new ArrayList<>(16));
-    private static final ThreadLocal<List<Object>> PACKET_BATCH = ThreadLocal.withInitial(() -> new ArrayList<>(8));
-    private static final ThreadLocal<AbstractContainerMenu> CURRENT_MENU = new ThreadLocal<>();
-    
-    private static volatile long totalTasksProcessed = 0;
-    private static volatile long totalPacketsSent = 0;
-    private static volatile long backpressureSkips = 0;
 
     public static void init() {
         if (CONTAINER_POOL != null) {
             CONTAINER_POOL.shutdown();
         }
-        
+
         CONTAINER_POOL = new ThreadPoolExecutor(
             AsyncContainerBroadcast.minThreads,
             AsyncContainerBroadcast.maxThreads,
@@ -50,48 +44,18 @@ public class AsyncContainerBroadcaster {
                 .build(),
             new ThreadPoolExecutor.CallerRunsPolicy()
         );
-        
-        LOGGER.info("Initialized Async Container Broadcast with {}-{} threads", 
+
+        LOGGER.info("Initialized Async Container Broadcast with {}-{} threads",
             AsyncContainerBroadcast.minThreads, AsyncContainerBroadcast.maxThreads);
     }
 
     public static void executeAsync(List<Runnable> tasks) {
         if (CONTAINER_POOL != null && !tasks.isEmpty()) {
-            totalTasksProcessed += tasks.size();
-            
-            if (AsyncContainerBroadcast.enableBatchedSending) {
-                CONTAINER_POOL.execute(() -> {
-                    List<Object> packets = PACKET_BATCH.get();
-                    AbstractContainerMenu currentMenu = null;
-                    
-                    for (Runnable task : tasks) {
-                        if (task instanceof PacketTask packetTask) {
-                            if (currentMenu != packetTask.menu) {
-                                if (currentMenu != null && !packets.isEmpty()) {
-                                    sendBatchedPackets(currentMenu, packets);
-                                    packets.clear();
-                                }
-                                currentMenu = packetTask.menu;
-                            }
-                            packets.add(packetTask.packet);
-                        } else {
-                            task.run();
-                        }
-                    }
-                    
-                    if (currentMenu != null && !packets.isEmpty()) {
-                        sendBatchedPackets(currentMenu, packets);
-                    }
-                    
-                    packets.clear();
-                });
-            } else {
-                CONTAINER_POOL.execute(() -> {
-                    for (Runnable task : tasks) {
-                        task.run();
-                    }
-                });
-            }
+            CONTAINER_POOL.execute(() -> {
+                for (Runnable task : tasks) {
+                    task.run();
+                }
+            });
             tasks.clear();
         }
     }
@@ -104,121 +68,49 @@ public class AsyncContainerBroadcaster {
 
     public static void addSlotSyncTask(List<Runnable> tasks, ContainerSynchronizer synchronizer,
             AbstractContainerMenu menu, int slotIndex, ItemStack item) {
-        if (synchronizer != null) {
-            final ItemStack asyncItemCopy = item.copy();
-            final int containerId = menu.containerId;
-            final int stateId = menu.incrementStateId();
+        if (synchronizer == null) return;
 
+        final ItemStack asyncItemCopy = item.copy();
+        final int containerId = menu.containerId;
+        final int stateId = menu.incrementStateId();
+
+        tasks.add(() -> {
             ClientboundContainerSetSlotPacket packet = new ClientboundContainerSetSlotPacket(
                     containerId, stateId, slotIndex, asyncItemCopy);
-
-            tasks.add(new PacketTask(menu, packet, () -> {
-                try {
-                    menu.synchronizeSlotToRemote(slotIndex, asyncItemCopy, asyncItemCopy::copy);
-                } catch (Exception e) {
-                    LOGGER.error("Failed to send async slot change packet", e);
-                }
-            }));
-        }
+            sendPacket(menu, packet);
+        });
     }
 
     public static void addDataSyncTask(List<Runnable> tasks, ContainerSynchronizer synchronizer,
             AbstractContainerMenu menu, int dataIndex, int value) {
-        if (synchronizer != null) {
-            final int containerId = menu.containerId;
+        if (synchronizer == null) return;
 
+        final int containerId = menu.containerId;
+
+        tasks.add(() -> {
             ClientboundContainerSetDataPacket packet = new ClientboundContainerSetDataPacket(
                     containerId, dataIndex, value);
-
-            tasks.add(new PacketTask(menu, packet, () -> {
-                try {
-                    menu.synchronizeDataSlotToRemote(dataIndex, value);
-                } catch (Exception e) {
-                    LOGGER.error("Failed to send async data change packet", e);
-                }
-            }));
-        }
+            sendPacket(menu, packet);
+        });
     }
 
-    private static void sendPacketToContainerListeners(AbstractContainerMenu menu, Object packet) {
-        List<net.minecraft.world.inventory.ContainerListener> listeners = menu.containerListeners;
-        for (net.minecraft.world.inventory.ContainerListener listener : listeners) {
+    private static void sendPacket(AbstractContainerMenu menu, Object packet) {
+        for (var listener : menu.containerListeners) {
             if (listener instanceof ServerPlayer player) {
                 Connection connection = player.connection.connection;
-                if (connection.channel != null && connection.channel.isActive()) {
-                    if (AsyncContainerBroadcast.enableBackpressureHandling && !connection.channel.isWritable()) {
-                        backpressureSkips++;
-                        LOGGER.debug("Channel not writable for player {}, skipping container update", player.getName().getString());
-                        continue;
-                    }
-                    
-                    totalPacketsSent++;
+                if (connection.channel != null && connection.channel.isActive() &&
+                    (!AsyncContainerBroadcast.enableBackpressureHandling || connection.channel.isWritable())) {
+
                     connection.channel.eventLoop().execute(() -> {
                         try {
                             if (connection.channel.isActive()) {
                                 connection.send((net.minecraft.network.protocol.Packet<?>) packet);
                             }
                         } catch (Exception e) {
-                            LOGGER.warn("Failed to send packet to player {}: {}", player.getName().getString(), e.getMessage());
+                            LOGGER.warn("Failed to send packet to {}: {}", player.getName().getString(), e.getMessage());
                         }
                     });
                 }
-            }
-        }
-    }
-
-    private static void sendBatchedPackets(AbstractContainerMenu menu, List<Object> packets) {
-        List<net.minecraft.world.inventory.ContainerListener> listeners = menu.containerListeners;
-        for (net.minecraft.world.inventory.ContainerListener listener : listeners) {
-            if (listener instanceof ServerPlayer player) {
-                Connection connection = player.connection.connection;
-                if (connection.channel != null && connection.channel.isActive()) {
-                    if (AsyncContainerBroadcast.enableBackpressureHandling && !connection.channel.isWritable()) {
-                        backpressureSkips += packets.size();
-                        LOGGER.debug("Channel not writable for player {}, skipping {} container updates", 
-                            player.getName().getString(), packets.size());
-                        continue;
-                    }
-                    
-                    totalPacketsSent += packets.size();
-                    connection.channel.eventLoop().execute(() -> {
-                        try {
-                            if (connection.channel.isActive()) {
-                                for (Object packet : packets) {
-                                    connection.send((net.minecraft.network.protocol.Packet<?>) packet);
-                                }
-                            }
-                        } catch (Exception e) {
-                            LOGGER.warn("Failed to send batched packets to player {}: {}", 
-                                player.getName().getString(), e.getMessage());
-                        }
-                    });
-                }
-            }
-        }
-    }
-
-    public static void logStatistics() {
-        if (LOGGER.isInfoEnabled()) {
-            LOGGER.info("Async Container Broadcast Stats - Tasks: {}, Packets: {}, Backpressure Skips: {}",
-                totalTasksProcessed, totalPacketsSent, backpressureSkips);
-        }
-    }
-    
-    public static void resetStatistics() {
-        totalTasksProcessed = 0;
-        totalPacketsSent = 0;
-        backpressureSkips = 0;
-    }
-
-    private static record PacketTask(AbstractContainerMenu menu, Object packet, Runnable fallback) implements Runnable {
-        @Override
-        public void run() {
-            try {
-                sendPacketToContainerListeners(menu, packet);
-            } catch (Exception e) {
-                LOGGER.error("Failed to send packet, using fallback", e);
-                fallback.run();
             }
         }
     }

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/AsyncContainerBroadcast.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/AsyncContainerBroadcast.java
@@ -15,17 +15,16 @@ public class AsyncContainerBroadcast extends ConfigModules {
     public static int maxThreads = 2;
     public static int keepalive = 30;
     public static boolean enableBackpressureHandling = true;
-    public static boolean enableBatchedSending = true;
     private static boolean asyncContainerBroadcastInitialized;
 
     @Override
     public void onLoaded() {
         config.addCommentRegionBased(getBasePath(), """
-                Asynchronous container network synchronization, reducing main thread blocking.
-                Uses dedicated threads for packet preparation while keeping network I/O on event loops.""",
+                Asynchronous container network synchronization to reduce main thread blocking.
+                Moves packet preparation to background threads while keeping network I/O on event loops.""",
             """
-                异步化容器网络同步，减少主线程阻塞.
-                使用专用线程进行数据包准备，同时在事件循环中保持网络 I/O.""");
+                异步化容器网络同步以减少主线程阻塞.
+                将数据包准备移至后台线程，同时在事件循环中保持网络 I/O.""");
 
         if (asyncContainerBroadcastInitialized) {
             config.getConfigSection(getBasePath());
@@ -38,7 +37,6 @@ public class AsyncContainerBroadcast extends ConfigModules {
         maxThreads = config.getInt(getBasePath() + ".max-threads", maxThreads);
         keepalive = config.getInt(getBasePath() + ".keepalive", keepalive);
         enableBackpressureHandling = config.getBoolean(getBasePath() + ".enable-backpressure-handling", enableBackpressureHandling);
-        enableBatchedSending = config.getBoolean(getBasePath() + ".enable-batched-sending", enableBatchedSending);
 
         if (minThreads <= 0) minThreads = 1;
         if (maxThreads <= 0) maxThreads = 2;

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/AsyncContainerBroadcast.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/AsyncContainerBroadcast.java
@@ -1,0 +1,56 @@
+package org.dreeam.leaf.config.modules.async;
+
+import org.dreeam.leaf.config.ConfigModules;
+import org.dreeam.leaf.config.EnumConfigCategory;
+import org.dreeam.leaf.config.LeafConfig;
+
+public class AsyncContainerBroadcast extends ConfigModules {
+
+    public String getBasePath() {
+        return EnumConfigCategory.ASYNC.getBaseKeyName() + ".async-container-broadcast";
+    }
+
+    public static boolean enabled = false;
+    public static int minThreads = 1;
+    public static int maxThreads = 2;
+    public static int keepalive = 30;
+    public static boolean enableBackpressureHandling = true;
+    public static boolean enableBatchedSending = true;
+    private static boolean asyncContainerBroadcastInitialized;
+
+    @Override
+    public void onLoaded() {
+        config.addCommentRegionBased(getBasePath(), """
+                Asynchronous container network synchronization, reducing main thread blocking.
+                Uses dedicated threads for packet preparation while keeping network I/O on event loops.""",
+            """
+                异步化容器网络同步，减少主线程阻塞.
+                使用专用线程进行数据包准备，同时在事件循环中保持网络 I/O.""");
+
+        if (asyncContainerBroadcastInitialized) {
+            config.getConfigSection(getBasePath());
+            return;
+        }
+        asyncContainerBroadcastInitialized = true;
+
+        enabled = config.getBoolean(getBasePath() + ".enabled", enabled);
+        minThreads = config.getInt(getBasePath() + ".min-threads", minThreads);
+        maxThreads = config.getInt(getBasePath() + ".max-threads", maxThreads);
+        keepalive = config.getInt(getBasePath() + ".keepalive", keepalive);
+        enableBackpressureHandling = config.getBoolean(getBasePath() + ".enable-backpressure-handling", enableBackpressureHandling);
+        enableBatchedSending = config.getBoolean(getBasePath() + ".enable-batched-sending", enableBatchedSending);
+
+        if (minThreads <= 0) minThreads = 1;
+        if (maxThreads <= 0) maxThreads = 2;
+        if (maxThreads < minThreads) maxThreads = minThreads;
+        if (keepalive <= 0) keepalive = 30;
+
+        if (!enabled) {
+            minThreads = 0;
+            maxThreads = 0;
+        } else {
+            LeafConfig.LOGGER.info("Using {}-{} threads for Async Container Broadcast", minThreads, maxThreads);
+            org.dreeam.leaf.async.container.AsyncContainerBroadcaster.init();
+        }
+    }
+}


### PR DESCRIPTION
这次改了一下 broadcastChanges，主要是把网络同步的逻辑做了异步处理，避免每次都在主线程同步一堆 slot 和数据，拉胯性能。之前那套同步逻辑每帧都遍历 slot 和 data slot，哪怕没什么变化也会有额外开销，尤其是在 GUI 比较复杂或者网络卡顿的时候，容易拖慢整体 tick。

现在如果启用了 AsyncContainerBroadcast 配置，slot 和 data 的同步就会被塞到一个后台线程池去跑，尽量减少对主线程的影响。逻辑上还是保持原有的触发和判断机制，不会改动游戏行为，纯粹优化执行位置和内存分配。

顺手也加了一下线程池的优雅关闭逻辑，避免服务关的时候留下未完成的任务。