### PR TITLE
Dev/tracker improvements

### DIFF
--- a/leaf-server/paper-patches/features/0042-Multithreaded-Tracker.patch
+++ b/leaf-server/paper-patches/features/0042-Multithreaded-Tracker.patch
@@ -72,7 +72,7 @@ index beae8a57a0ce9b8e7d81619efe4c39d908869319..6b1926080eddf61ff9c0156a6846f7f0
          }
          return set;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3d215494bf74fd06a31367a3bf955e9d13c63ecb..79e1e65c02b348bd2787bdc82d571a6d591553e1 100644
+index 53e6e3a8d753d93524dd1407b18c0df530c53f00..d8f8ece88730d720a50d496adfcbbab12b99b2bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2824,7 +2824,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
@@ -85,15 +85,14 @@ index 3d215494bf74fd06a31367a3bf955e9d13c63ecb..79e1e65c02b348bd2787bdc82d571a6d
                  break;
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a162440a583801671787163d998d6b9546ef7e61..5e73db484a5526f4c39c7cc2de5ddc3ff037d2e4 100644
+index a162440a583801671787163d998d6b9546ef7e61..d2125e516ad9e1459695fdede176ad4cb684cecd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1808,6 +1808,26 @@ public class CraftEventFactory {
+@@ -1808,6 +1808,29 @@ public class CraftEventFactory {
      }
  
      public static boolean handleBlockFormEvent(Level world, BlockPos pos, net.minecraft.world.level.block.state.BlockState state, int flags, @Nullable Entity entity, boolean checkSetResult) {
-+        // Leaf start - Multithreaded tracker
-+        if (org.dreeam.leaf.config.modules.async.MultithreadedTracker.enabled && Thread.currentThread() instanceof org.dreeam.leaf.async.tracker.MultithreadedTracker.MultithreadedTrackerThread) {
++        if (org.dreeam.leaf.config.modules.async.MultithreadedTracker.enabled && Thread.currentThread().isVirtual()) {
 +            java.util.concurrent.CompletableFuture<Boolean> future = new java.util.concurrent.CompletableFuture<>();
 +            net.minecraft.server.MinecraftServer.getServer().scheduleOnMain(() -> {
 +                boolean resultFlag = false;
@@ -109,9 +108,13 @@ index a162440a583801671787163d998d6b9546ef7e61..5e73db484a5526f4c39c7cc2de5ddc3f
 +                future.complete(resultFlag);
 +            });
 +
-+            return future.join();
++            try {
++                return future.join();
++            } catch (Exception e) {
++                return false;
++            }
 +        }
-+        // Leaf end - Multithreaded tracker
++
          CraftBlockState snapshot = CraftBlockStates.getBlockState(world, pos);
          snapshot.setData(state);
  

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/ShutdownExecutors.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/ShutdownExecutors.java
@@ -5,7 +5,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dreeam.leaf.async.ai.AsyncGoalThread;
 import org.dreeam.leaf.async.path.AsyncPathProcessor;
-import org.dreeam.leaf.async.tracker.MultithreadedTracker;
+// CHANGE: MultithreadedTracker import is no longer needed here.
 
 import java.util.concurrent.TimeUnit;
 
@@ -40,14 +40,6 @@ public class ShutdownExecutors {
             }
         }
 
-        if (MultithreadedTracker.TRACKER_EXECUTOR != null) {
-            LOGGER.info("Waiting for mob tracker executor to shutdown...");
-            MultithreadedTracker.TRACKER_EXECUTOR.shutdown();
-            try {
-                MultithreadedTracker.TRACKER_EXECUTOR.awaitTermination(10L, TimeUnit.SECONDS);
-            } catch (InterruptedException ignored) {
-            }
-        }
 
         if (AsyncPathProcessor.PATH_PROCESSING_EXECUTOR != null) {
             LOGGER.info("Waiting for mob pathfinding executor to shutdown...");

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
@@ -4,80 +4,58 @@ import ca.spottedleaf.moonrise.common.list.ReferenceList;
 import ca.spottedleaf.moonrise.common.misc.NearbyPlayers;
 import ca.spottedleaf.moonrise.patches.chunk_system.level.entity.server.ServerEntityLookup;
 import ca.spottedleaf.moonrise.patches.entity_tracker.EntityTrackerEntity;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import net.minecraft.Util;
 import net.minecraft.server.level.ChunkMap;
-import net.minecraft.server.level.FullChunkStatus;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.galemc.gale.virtualthread.VirtualThreadService;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
-// CHANGE: No longer need LinkedBlockingQueue
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 public class MultithreadedTracker {
 
     private static final String THREAD_PREFIX = "Leaf Async Tracker";
     private static final Logger LOGGER = LogManager.getLogger(THREAD_PREFIX);
-    private static long lastWarnMillis = System.currentTimeMillis();
-    public static ThreadPoolExecutor TRACKER_EXECUTOR = null;
 
     private MultithreadedTracker() {
     }
 
-    public static void init() {
-        if (TRACKER_EXECUTOR == null) {
-            TRACKER_EXECUTOR = new ThreadPoolExecutor(
-                getCorePoolSize(),
-                getMaxPoolSize(),
-                getKeepAliveTime(), TimeUnit.SECONDS,
-                getQueueImpl(),
-                getThreadFactory(),
-                getRejectedPolicy()
-            );
-        } else {
-            // Temp no-op
-            //throw new IllegalStateException();
-        }
-    }
-
     public static void tick(ServerLevel level) {
         try {
-            if (!org.dreeam.leaf.config.modules.async.MultithreadedTracker.compatModeEnabled) {
-                tickAsync(level);
-            } else {
-                tickAsyncWithCompatMode(level);
+            final Runnable task = org.dreeam.leaf.config.modules.async.MultithreadedTracker.compatModeEnabled
+                ? createCompatTask(level)
+                : createAsyncTask(level);
+
+            if (task == null) {
+                return;
             }
+
+            VirtualThreadService.get().start(task);
+
         } catch (Exception e) {
-            LOGGER.error("Error occurred while executing async task.", e);
+            LOGGER.error("Error occurred while submitting async tracker task.", e);
         }
     }
 
-    private static void tickAsync(ServerLevel level) {
-        final NearbyPlayers nearbyPlayers = level.moonrise$getNearbyPlayers();
+    @Nullable
+    private static Runnable createAsyncTask(ServerLevel level) {
         final ServerEntityLookup entityLookup = (ServerEntityLookup) level.moonrise$getEntityLookup();
-
         final ReferenceList<Entity> trackerEntities = entityLookup.trackerEntities;
+        if (trackerEntities.size() == 0) return null;
+
+        final NearbyPlayers nearbyPlayers = level.moonrise$getNearbyPlayers();
         final int trackerEntitiesSize = trackerEntities.size();
         final Entity[] trackerEntitiesRaw = trackerEntities.getRawDataUnchecked();
 
-        // Move tracking to off-main
-        TRACKER_EXECUTOR.execute(() -> {
+        return () -> {
             for (int i = 0; i < trackerEntitiesSize; i++) {
                 Entity entity = trackerEntitiesRaw[i];
                 if (entity == null) continue;
 
                 final ChunkMap.TrackedEntity tracker = ((EntityTrackerEntity) entity).moonrise$getTrackedEntity();
-
                 if (tracker == null) continue;
 
                 synchronized (tracker) {
@@ -86,16 +64,18 @@ public class MultithreadedTracker {
                     tracker.serverEntity.sendChanges();
                 }
             }
-        });
+        };
     }
 
-    private static void tickAsyncWithCompatMode(ServerLevel level) {
-        final NearbyPlayers nearbyPlayers = level.moonrise$getNearbyPlayers();
+    @Nullable
+    private static Runnable createCompatTask(ServerLevel level) {
         final ServerEntityLookup entityLookup = (ServerEntityLookup) level.moonrise$getEntityLookup();
-
         final ReferenceList<Entity> trackerEntities = entityLookup.trackerEntities;
-        final Entity[] trackerEntitiesRaw = trackerEntities.getRawDataUnchecked();
+        if (trackerEntities.size() == 0) return null;
+
+        final NearbyPlayers nearbyPlayers = level.moonrise$getNearbyPlayers();
         final int trackerEntitiesSize = trackerEntities.size();
+        final Entity[] trackerEntitiesRaw = trackerEntities.getRawDataUnchecked();
         final List<TrackingData> trackingTasks = new ArrayList<>(trackerEntitiesSize);
 
         for (int i = 0; i < trackerEntitiesSize; i++) {
@@ -103,7 +83,6 @@ public class MultithreadedTracker {
             if (entity == null) continue;
 
             final ChunkMap.TrackedEntity tracker = ((EntityTrackerEntity) entity).moonrise$getTrackedEntity();
-
             if (tracker == null) continue;
 
             synchronized (tracker) {
@@ -111,8 +90,7 @@ public class MultithreadedTracker {
             }
         }
 
-        // batch submit tasks
-        TRACKER_EXECUTOR.execute(() -> {
+        return () -> {
             for (final TrackingData task : trackingTasks) {
                 final Runnable tick = task.tracker.leafTickCompact(task.trackedChunk);
                 if (tick != null) {
@@ -122,74 +100,7 @@ public class MultithreadedTracker {
             for (final TrackingData task : trackingTasks) {
                 task.tracker.serverEntity.sendChanges();
             }
-        });
-    }
-
-    // Original ChunkMap#newTrackerTick of Paper
-    // Just for diff usage for future update
-    private static void tickOriginal(ServerLevel level) {
-        final ca.spottedleaf.moonrise.patches.chunk_system.level.entity.server.ServerEntityLookup entityLookup = (ca.spottedleaf.moonrise.patches.chunk_system.level.entity.server.ServerEntityLookup) ((ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemServerLevel) level).moonrise$getEntityLookup();
-
-        final ca.spottedleaf.moonrise.common.list.ReferenceList<net.minecraft.world.entity.Entity> trackerEntities = entityLookup.trackerEntities;
-        final Entity[] trackerEntitiesRaw = trackerEntities.getRawDataUnchecked();
-        for (int i = 0, len = trackerEntities.size(); i < len; ++i) {
-            final Entity entity = trackerEntitiesRaw[i];
-            final ChunkMap.TrackedEntity tracker = ((ca.spottedleaf.moonrise.patches.entity_tracker.EntityTrackerEntity) entity).moonrise$getTrackedEntity();
-            if (tracker == null) {
-                continue;
-            }
-            ((ca.spottedleaf.moonrise.patches.entity_tracker.EntityTrackerTrackedEntity) tracker).moonrise$tick(((ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity) entity).moonrise$getChunkData().nearbyPlayers);
-            if (((ca.spottedleaf.moonrise.patches.entity_tracker.EntityTrackerTrackedEntity) tracker).moonrise$hasPlayers()
-                || ((ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity) entity).moonrise$getChunkStatus().isOrAfter(FullChunkStatus.ENTITY_TICKING)) {
-                tracker.serverEntity.sendChanges();
-            }
-        }
-    }
-
-    private static int getCorePoolSize() {
-        return 1;
-    }
-
-    private static int getMaxPoolSize() {
-        return org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerMaxThreads;
-    }
-
-    private static long getKeepAliveTime() {
-        return org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerKeepalive;
-    }
-
-    private static BlockingQueue<Runnable> getQueueImpl() {
-        // A SynchronousQueue has no capacity and is used for direct hand-offs.
-        // This makes the CallerRunsPolicy trigger immediately when all threads are busy.
-        return new SynchronousQueue<>();
-    }
-
-    private static @NotNull ThreadFactory getThreadFactory() {
-        return new ThreadFactoryBuilder()
-            .setThreadFactory(MultithreadedTrackerThread::new)
-            .setNameFormat(THREAD_PREFIX + " Thread - %d")
-            .setPriority(Thread.NORM_PRIORITY - 2)
-            .setUncaughtExceptionHandler(Util::onThreadException)
-            .build();
-    }
-
-    private static @NotNull RejectedExecutionHandler getRejectedPolicy() {
-        final RejectedExecutionHandler callerRunsPolicy = new ThreadPoolExecutor.CallerRunsPolicy();
-        return (rejectedTask, executor) -> {
-            final long currentTime = System.currentTimeMillis();
-            if (currentTime - lastWarnMillis > 30000L) {
-                LOGGER.warn("Async entity tracker is busy! Tracking tasks will be done in the server thread. Increasing max-threads in Leaf config may help.");
-                lastWarnMillis = currentTime;
-            }
-            callerRunsPolicy.rejectedExecution(rejectedTask, executor);
         };
-    }
-
-    public static class MultithreadedTrackerThread extends Thread {
-
-        public MultithreadedTrackerThread(Runnable runnable) {
-            super(runnable);
-        }
     }
 
     private static class TrackingData {

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/MultithreadedTracker.java
@@ -17,7 +17,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+// CHANGE: No longer need LinkedBlockingQueue
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -95,12 +96,10 @@ public class MultithreadedTracker {
         final ReferenceList<Entity> trackerEntities = entityLookup.trackerEntities;
         final Entity[] trackerEntitiesRaw = trackerEntities.getRawDataUnchecked();
         final int trackerEntitiesSize = trackerEntities.size();
-        final Runnable[] sendChangesTasks = new Runnable[trackerEntitiesSize];
-        final Runnable[] tickTask = new Runnable[trackerEntitiesSize];
-        int index = 0;
+        final List<TrackingData> trackingTasks = new ArrayList<>(trackerEntitiesSize);
 
         for (int i = 0; i < trackerEntitiesSize; i++) {
-            Entity entity = trackerEntitiesRaw[i];
+            final Entity entity = trackerEntitiesRaw[i];
             if (entity == null) continue;
 
             final ChunkMap.TrackedEntity tracker = ((EntityTrackerEntity) entity).moonrise$getTrackedEntity();
@@ -108,23 +107,20 @@ public class MultithreadedTracker {
             if (tracker == null) continue;
 
             synchronized (tracker) {
-                tickTask[index] = tracker.leafTickCompact(nearbyPlayers.getChunk(entity.chunkPosition()));
-                sendChangesTasks[index] = tracker.serverEntity::sendChanges; // Collect send changes to task array
+                trackingTasks.add(new TrackingData(tracker, nearbyPlayers.getChunk(entity.chunkPosition())));
             }
-            index++;
         }
 
         // batch submit tasks
         TRACKER_EXECUTOR.execute(() -> {
-            for (final Runnable tick : tickTask) {
-                if (tick == null) continue;
-
-                tick.run();
+            for (final TrackingData task : trackingTasks) {
+                final Runnable tick = task.tracker.leafTickCompact(task.trackedChunk);
+                if (tick != null) {
+                    tick.run();
+                }
             }
-            for (final Runnable sendChanges : sendChangesTasks) {
-                if (sendChanges == null) continue;
-
-                sendChanges.run();
+            for (final TrackingData task : trackingTasks) {
+                task.tracker.serverEntity.sendChanges();
             }
         });
     }
@@ -163,9 +159,9 @@ public class MultithreadedTracker {
     }
 
     private static BlockingQueue<Runnable> getQueueImpl() {
-        final int queueCapacity = org.dreeam.leaf.config.modules.async.MultithreadedTracker.asyncEntityTrackerQueueSize;
-
-        return new LinkedBlockingQueue<>(queueCapacity);
+        // A SynchronousQueue has no capacity and is used for direct hand-offs.
+        // This makes the CallerRunsPolicy trigger immediately when all threads are busy.
+        return new SynchronousQueue<>();
     }
 
     private static @NotNull ThreadFactory getThreadFactory() {
@@ -178,27 +174,14 @@ public class MultithreadedTracker {
     }
 
     private static @NotNull RejectedExecutionHandler getRejectedPolicy() {
+        final RejectedExecutionHandler callerRunsPolicy = new ThreadPoolExecutor.CallerRunsPolicy();
         return (rejectedTask, executor) -> {
-            BlockingQueue<Runnable> workQueue = executor.getQueue();
-
-            if (!executor.isShutdown()) {
-                if (!workQueue.isEmpty()) {
-                    List<Runnable> pendingTasks = new ArrayList<>(workQueue.size());
-
-                    workQueue.drainTo(pendingTasks);
-
-                    for (Runnable pendingTask : pendingTasks) {
-                        pendingTask.run();
-                    }
-                }
-
-                rejectedTask.run();
-            }
-
-            if (System.currentTimeMillis() - lastWarnMillis > 30000L) {
+            final long currentTime = System.currentTimeMillis();
+            if (currentTime - lastWarnMillis > 30000L) {
                 LOGGER.warn("Async entity tracker is busy! Tracking tasks will be done in the server thread. Increasing max-threads in Leaf config may help.");
-                lastWarnMillis = System.currentTimeMillis();
+                lastWarnMillis = currentTime;
             }
+            callerRunsPolicy.rejectedExecution(rejectedTask, executor);
         };
     }
 
@@ -206,6 +189,16 @@ public class MultithreadedTracker {
 
         public MultithreadedTrackerThread(Runnable runnable) {
             super(runnable);
+        }
+    }
+
+    private static class TrackingData {
+        final ChunkMap.TrackedEntity tracker;
+        final NearbyPlayers.TrackedChunk trackedChunk;
+
+        TrackingData(final ChunkMap.TrackedEntity tracker, final NearbyPlayers.TrackedChunk trackedChunk) {
+            this.tracker = tracker;
+            this.trackedChunk = trackedChunk;
         }
     }
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/MultithreadedTracker.java
@@ -14,7 +14,6 @@ public class MultithreadedTracker extends ConfigModules {
     public static boolean compatModeEnabled = false;
     public static int asyncEntityTrackerMaxThreads = 0;
     public static int asyncEntityTrackerKeepalive = 60;
-    public static int asyncEntityTrackerQueueSize = 0;
     private static boolean asyncMultithreadedTrackerInitialized;
 
     @Override
@@ -43,20 +42,16 @@ public class MultithreadedTracker extends ConfigModules {
         compatModeEnabled = config.getBoolean(getBasePath() + ".compat-mode", compatModeEnabled);
         asyncEntityTrackerMaxThreads = config.getInt(getBasePath() + ".max-threads", asyncEntityTrackerMaxThreads);
         asyncEntityTrackerKeepalive = config.getInt(getBasePath() + ".keepalive", asyncEntityTrackerKeepalive);
-        asyncEntityTrackerQueueSize = config.getInt(getBasePath() + ".queue-size", asyncEntityTrackerQueueSize);
 
         if (asyncEntityTrackerMaxThreads < 0)
             asyncEntityTrackerMaxThreads = Math.max(Runtime.getRuntime().availableProcessors() + asyncEntityTrackerMaxThreads, 1);
         else if (asyncEntityTrackerMaxThreads == 0)
-            asyncEntityTrackerMaxThreads = Math.max(Runtime.getRuntime().availableProcessors() / 4, 1);
+            asyncEntityTrackerMaxThreads = Math.max(Runtime.getRuntime().availableProcessors() / 3, 1);
 
         if (!enabled)
             asyncEntityTrackerMaxThreads = 0;
         else
             LeafConfig.LOGGER.info("Using {} threads for Async Entity Tracker", asyncEntityTrackerMaxThreads);
-
-        if (asyncEntityTrackerQueueSize <= 0)
-            asyncEntityTrackerQueueSize = asyncEntityTrackerMaxThreads * 384;
 
         if (enabled) {
             org.dreeam.leaf.async.tracker.MultithreadedTracker.init();

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/MultithreadedTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/MultithreadedTracker.java
@@ -12,8 +12,6 @@ public class MultithreadedTracker extends ConfigModules {
 
     public static boolean enabled = false;
     public static boolean compatModeEnabled = false;
-    public static int asyncEntityTrackerMaxThreads = 0;
-    public static int asyncEntityTrackerKeepalive = 60;
     private static boolean asyncMultithreadedTrackerInitialized;
 
     @Override
@@ -40,21 +38,9 @@ public class MultithreadedTracker extends ConfigModules {
 
         enabled = config.getBoolean(getBasePath() + ".enabled", enabled);
         compatModeEnabled = config.getBoolean(getBasePath() + ".compat-mode", compatModeEnabled);
-        asyncEntityTrackerMaxThreads = config.getInt(getBasePath() + ".max-threads", asyncEntityTrackerMaxThreads);
-        asyncEntityTrackerKeepalive = config.getInt(getBasePath() + ".keepalive", asyncEntityTrackerKeepalive);
-
-        if (asyncEntityTrackerMaxThreads < 0)
-            asyncEntityTrackerMaxThreads = Math.max(Runtime.getRuntime().availableProcessors() + asyncEntityTrackerMaxThreads, 1);
-        else if (asyncEntityTrackerMaxThreads == 0)
-            asyncEntityTrackerMaxThreads = Math.max(Runtime.getRuntime().availableProcessors() / 3, 1);
-
-        if (!enabled)
-            asyncEntityTrackerMaxThreads = 0;
-        else
-            LeafConfig.LOGGER.info("Using {} threads for Async Entity Tracker", asyncEntityTrackerMaxThreads);
 
         if (enabled) {
-            org.dreeam.leaf.async.tracker.MultithreadedTracker.init();
+            LeafConfig.LOGGER.info("Async Entity Tracker is enabled.");
         }
     }
 }


### PR DESCRIPTION
Replaces thread pool approach with short lived VT threads that are created per tick

That way people won't bother with thread counts and queue being an issue. as each task will be handled at one point on the virtual thread.

(needs heavy testing and reviews)