### PR TITLE
Optimize async pathfinding

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
@@ -20,6 +20,8 @@ public class AsyncPath extends Path {
 
     private volatile boolean fastPath = false;
 
+    private volatile boolean processingFinished = false;
+
     /**
      * marks whether this async path has been processed
      */
@@ -92,6 +94,12 @@ public class AsyncPath extends Path {
             return;
         }
 
+        boolean finished = this.processingFinished;
+        if (finished) {
+            runnable.run();
+            return;
+        }
+
         synchronized (this) {
             if (isProcessed()) {
                 runnable.run();
@@ -124,13 +132,18 @@ public class AsyncPath extends Path {
      * starts processing this path
      */
     public void process() {
-        // Double-checked locking pattern for better performance
         if (this.processState == PathProcessState.COMPLETED) {
             return;
         }
 
+        // Can we also check for PROCESSING state here?
+        PathProcessState currentState = this.processState;
+        if (currentState == PathProcessState.COMPLETED || currentState == PathProcessState.PROCESSING) {
+            return;
+        }
+
         synchronized (this) {
-            // Check again after acquiring lock
+            // Double-check after acquiring lock
             if (this.processState != PathProcessState.WAITING) {
                 return;
             }
@@ -138,23 +151,43 @@ public class AsyncPath extends Path {
             processState = PathProcessState.PROCESSING;
         }
 
-        // Do the heavy lifting outside the synchronized block
-        final Path bestPath = this.pathSupplier.get();
+        // computation outside synchronized block
+        final Path bestPath;
+        try {
+            bestPath = this.pathSupplier.get();
+        } catch (Exception e) {
+            // Handle pathfinding failures gracefully
+            synchronized (this) {
+                processState = PathProcessState.COMPLETED;
+                this.processingFinished = true;
 
+                // Still run callbacks even if pathfinding failed
+                for (Runnable runnable : this.postProcessing) {
+                    runnable.run();
+                }
+                this.postProcessing.clear();
+            }
+            return;
+        }
+
+        // Final state update - minimal synchronization
+        List<Runnable> callbacksToRun;
         synchronized (this) {
-            // Only synchronize the final state update
             this.nodes.addAll(bestPath.nodes);
             this.target = bestPath.getTarget();
             this.distToTarget = bestPath.getDistToTarget();
             this.canReach = bestPath.canReach();
 
             processState = PathProcessState.COMPLETED;
+            this.processingFinished = true; // Mark as finished for postProcessing
 
-            // Process callbacks
-            for (Runnable runnable : this.postProcessing) {
-                runnable.run();
-            }
-            this.postProcessing.clear(); // Free memory
+            // Copy callbacks to run outside synchronized block
+            callbacksToRun = new ArrayList<>(this.postProcessing);
+            this.postProcessing.clear();
+        }
+
+        for (Runnable runnable : callbacksToRun) {
+            runnable.run();
         }
     }
 

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
@@ -100,12 +100,17 @@ public class AsyncPath extends Path {
             return;
         }
 
+        boolean shouldRun = false;
         synchronized (this) {
             if (isProcessed()) {
-                runnable.run();
+                shouldRun = true;
             } else {
                 this.postProcessing.add(runnable);
             }
+        }
+
+        if (shouldRun) {
+            runnable.run();
         }
     }
 

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
@@ -132,13 +132,8 @@ public class AsyncPath extends Path {
      * starts processing this path
      */
     public void process() {
-        if (this.processState == PathProcessState.COMPLETED) {
-            return;
-        }
-
-        // Can we also check for PROCESSING state here?
-        PathProcessState currentState = this.processState;
-        if (currentState == PathProcessState.COMPLETED || currentState == PathProcessState.PROCESSING) {
+        // Single check - if not WAITING, we're either COMPLETED or PROCESSING
+        if (this.processState != PathProcessState.WAITING) {
             return;
         }
 

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPath.java
@@ -18,6 +18,8 @@ import java.util.function.Supplier;
  */
 public class AsyncPath extends Path {
 
+    private volatile boolean fastPath = false;
+
     /**
      * marks whether this async path has been processed
      */
@@ -26,7 +28,7 @@ public class AsyncPath extends Path {
     /**
      * runnables waiting for this to be processed
      */
-    private final List<Runnable> postProcessing = new ArrayList<>(0);
+    private final List<Runnable> postProcessing = new ArrayList<>(2);
 
     /**
      * a list of positions that this path could path towards
@@ -78,17 +80,24 @@ public class AsyncPath extends Path {
 
     @Override
     public boolean isProcessed() {
-        return this.processState == PathProcessState.COMPLETED;
+        return fastPath || (this.processState == PathProcessState.COMPLETED);
     }
 
     /**
      * returns the future representing the processing state of this path
      */
-    public synchronized void postProcessing(@NotNull Runnable runnable) {
+    public void postProcessing(@NotNull Runnable runnable) {
         if (isProcessed()) {
             runnable.run();
-        } else {
-            this.postProcessing.add(runnable);
+            return;
+        }
+
+        synchronized (this) {
+            if (isProcessed()) {
+                runnable.run();
+            } else {
+                this.postProcessing.add(runnable);
+            }
         }
     }
 
@@ -103,40 +112,59 @@ public class AsyncPath extends Path {
             return false;
         }
 
+        // For single position (common case), do direct comparison
+        if (positions.size() == 1 && this.positions.size() == 1) {
+            return this.positions.iterator().next().equals(positions.iterator().next());
+        }
+
         return this.positions.containsAll(positions);
     }
 
     /**
      * starts processing this path
      */
-    public synchronized void process() {
-        if (this.processState == PathProcessState.COMPLETED ||
-            this.processState == PathProcessState.PROCESSING) {
+    public void process() {
+        // Double-checked locking pattern for better performance
+        if (this.processState == PathProcessState.COMPLETED) {
             return;
         }
 
-        processState = PathProcessState.PROCESSING;
+        synchronized (this) {
+            // Check again after acquiring lock
+            if (this.processState != PathProcessState.WAITING) {
+                return;
+            }
 
+            processState = PathProcessState.PROCESSING;
+        }
+
+        // Do the heavy lifting outside the synchronized block
         final Path bestPath = this.pathSupplier.get();
 
-        this.nodes.addAll(bestPath.nodes); // we mutate this list to reuse the logic in Path
-        this.target = bestPath.getTarget();
-        this.distToTarget = bestPath.getDistToTarget();
-        this.canReach = bestPath.canReach();
+        synchronized (this) {
+            // Only synchronize the final state update
+            this.nodes.addAll(bestPath.nodes);
+            this.target = bestPath.getTarget();
+            this.distToTarget = bestPath.getDistToTarget();
+            this.canReach = bestPath.canReach();
 
-        processState = PathProcessState.COMPLETED;
+            processState = PathProcessState.COMPLETED;
 
-        for (Runnable runnable : this.postProcessing) {
-            runnable.run();
-        } // Run tasks after processing
+            // Process callbacks
+            for (Runnable runnable : this.postProcessing) {
+                runnable.run();
+            }
+            this.postProcessing.clear(); // Free memory
+        }
     }
 
     /**
      * if this path is accessed while it hasn't processed, just process it in-place
      */
     private void checkProcessed() {
-        if (this.processState == PathProcessState.WAITING ||
-            this.processState == PathProcessState.PROCESSING) { // Block if we are on processing
+        // Use single volatile read instead of multiple comparisons
+        PathProcessState state = this.processState;
+        if (state != PathProcessState.COMPLETED) {
             this.process();
         }
     }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
@@ -106,18 +106,22 @@ public class AsyncPathProcessor {
     private static @NotNull RejectedExecutionHandler getRejectedPolicy() {
         return (Runnable rejectedTask, ThreadPoolExecutor executor) -> {
             BlockingQueue<Runnable> workQueue = executor.getQueue();
+            if (!executor.isShutdown()) {
+                switch (AsyncPathfinding.asyncPathfindingRejectPolicy) {
+                    case FLUSH_ALL -> {
+                        if (!workQueue.isEmpty()) {
+                            List<Runnable> pendingTasks = new ArrayList<>(workQueue.size());
 
-            switch (AsyncPathfinding.asyncPathfindingRejectPolicy) {
-                case FLUSH_ALL -> {
-                    // Process in batches instead of all at once to avoid blocking main thread
-                    int batchSize = Math.min(32, workQueue.size());
-                    List<Runnable> batch = new ArrayList<>(batchSize);
-                    workQueue.drainTo(batch, batchSize);
+                            workQueue.drainTo(pendingTasks);
 
-                    batch.forEach(Runnable::run);
-                    rejectedTask.run();
+                            for (Runnable pendingTask : pendingTasks) {
+                                pendingTask.run();
+                            }
+                        }
+                        rejectedTask.run();
+                    }
+                    case CALLER_RUNS -> rejectedTask.run();
                 }
-                case CALLER_RUNS -> rejectedTask.run();
             }
 
             long currentTime = System.currentTimeMillis();

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
@@ -31,6 +31,7 @@ public class AsyncPathProcessor {
     private static final Logger LOGGER = LogManager.getLogger(THREAD_PREFIX);
     private static long lastWarnMillis = System.currentTimeMillis();
     public static ThreadPoolExecutor PATH_PROCESSING_EXECUTOR = null;
+    private static long lastWarnNanos = System.nanoTime();
 
     public static void init() {
         if (PATH_PROCESSING_EXECUTOR == null) {
@@ -124,10 +125,10 @@ public class AsyncPathProcessor {
                 }
             }
 
-            long currentTime = System.currentTimeMillis();
-            if (currentTime - lastWarnMillis > 30000L) {
+            long currentNanos = System.nanoTime();
+            if (currentNanos - lastWarnNanos > 30_000_000_000L) {
                 LOGGER.warn("Async pathfinding processor is busy! Consider increasing max-threads.");
-                lastWarnMillis = currentTime;
+                lastWarnNanos = currentNanos;
             }
         };
     }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/AsyncPathProcessor.java
@@ -106,27 +106,24 @@ public class AsyncPathProcessor {
     private static @NotNull RejectedExecutionHandler getRejectedPolicy() {
         return (Runnable rejectedTask, ThreadPoolExecutor executor) -> {
             BlockingQueue<Runnable> workQueue = executor.getQueue();
-            if (!executor.isShutdown()) {
-                switch (AsyncPathfinding.asyncPathfindingRejectPolicy) {
-                    case FLUSH_ALL -> {
-                        if (!workQueue.isEmpty()) {
-                            List<Runnable> pendingTasks = new ArrayList<>(workQueue.size());
 
-                            workQueue.drainTo(pendingTasks);
+            switch (AsyncPathfinding.asyncPathfindingRejectPolicy) {
+                case FLUSH_ALL -> {
+                    // Process in batches instead of all at once to avoid blocking main thread
+                    int batchSize = Math.min(32, workQueue.size());
+                    List<Runnable> batch = new ArrayList<>(batchSize);
+                    workQueue.drainTo(batch, batchSize);
 
-                            for (Runnable pendingTask : pendingTasks) {
-                                pendingTask.run();
-                            }
-                        }
-                        rejectedTask.run();
-                    }
-                    case CALLER_RUNS -> rejectedTask.run();
+                    batch.forEach(Runnable::run);
+                    rejectedTask.run();
                 }
+                case CALLER_RUNS -> rejectedTask.run();
             }
 
-            if (System.currentTimeMillis() - lastWarnMillis > 30000L) {
-                LOGGER.warn("Async pathfinding processor is busy! Pathfinding tasks will be treated as policy defined in config. Increasing max-threads in Leaf config may help.");
-                lastWarnMillis = System.currentTimeMillis();
+            long currentTime = System.currentTimeMillis();
+            if (currentTime - lastWarnMillis > 30000L) {
+                LOGGER.warn("Async pathfinding processor is busy! Consider increasing max-threads.");
+                lastWarnMillis = currentTime;
             }
         };
     }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/path/NodeEvaluatorCache.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/path/NodeEvaluatorCache.java
@@ -14,8 +14,12 @@ public class NodeEvaluatorCache {
     private static final Map<NodeEvaluatorFeatures, MultiThreadedQueue<NodeEvaluator>> threadLocalNodeEvaluators = new ConcurrentHashMap<>();
     private static final Map<NodeEvaluator, NodeEvaluatorGenerator> nodeEvaluatorToGenerator = new ConcurrentHashMap<>();
 
-    private static @NotNull Queue<NodeEvaluator> getQueueForFeatures(@NotNull NodeEvaluatorFeatures nodeEvaluatorFeatures) {
-        return threadLocalNodeEvaluators.computeIfAbsent(nodeEvaluatorFeatures, key -> new MultiThreadedQueue<>());
+    private static @NotNull Queue<NodeEvaluator> getQueueForFeatures(@NotNull NodeEvaluatorFeatures features) {
+        Queue<NodeEvaluator> queue = threadLocalNodeEvaluators.get(features);
+        if (queue == null) {
+            queue = threadLocalNodeEvaluators.computeIfAbsent(features, k -> new MultiThreadedQueue<>());
+        }
+        return queue;
     }
 
     public static @NotNull NodeEvaluator takeNodeEvaluator(@NotNull NodeEvaluatorGenerator generator, @NotNull NodeEvaluator localNodeEvaluator) {


### PR DESCRIPTION
- Fast-path state checks and double-checked locking to reduce synchronization overhead
- Pre-sized collections and memory cleanup to minimize allocations
~~- Batch processing limits (32 tasks) to prevent main thread blocking~~
- Single-position comparison optimization for common pathfinding cases