### PR TITLE
Added back `getHighestBlockYAt` validation in CraftWorld

### DIFF
--- a/leaf-server/paper-patches/features/0050-SparklyPaper-Parallel-world-ticking.patch
+++ b/leaf-server/paper-patches/features/0050-SparklyPaper-Parallel-world-ticking.patch
@@ -251,7 +251,7 @@ index a4aa2615823d77920ff55b8aa0bcc27a54b8c3e1..e1bf7dfdb3be8f92ef2cb86d7f15a613
 +    // SparklyPaper end - parallel world ticking
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index adb2324949484bc543bab25a79ed6d2c39bcba42..728c8a554af42e71dbcc1656563bafcd4d976a02 100644
+index adb2324949484bc543bab25a79ed6d2c39bcba42..43efa9ce8262a0118328c555a146dca10d4f9367 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -479,7 +479,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -309,7 +309,16 @@ index adb2324949484bc543bab25a79ed6d2c39bcba42..728c8a554af42e71dbcc1656563bafcd
          net.minecraft.world.level.Level.ExplosionInteraction explosionType;
          if (!breakBlocks) {
              explosionType = net.minecraft.world.level.Level.ExplosionInteraction.NONE; // Don't break blocks
-@@ -1010,6 +1026,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -980,6 +996,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+ 
+     @Override
+     public int getHighestBlockYAt(int x, int z, org.bukkit.HeightMap heightMap) {
++        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) // Leaf - SparklyPaper - parallel world ticking mod (make configurable)
++            ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(this.world, x >> 4, z >> 4, "Cannot retrieve chunk asynchronously"); // SparklyPaper - parallel world ticking (additional concurrency issues logs)
+         warnUnsafeChunk("getting a faraway chunk", x >> 4, z >> 4); // Paper
+         // Transient load for this tick
+         return this.world.getChunk(x >> 4, z >> 4).getHeight(CraftHeightMap.toNMS(heightMap), x, z);
+@@ -1010,6 +1028,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public void setBiome(int x, int y, int z, Holder<net.minecraft.world.level.biome.Biome> bb) {
          BlockPos pos = new BlockPos(x, 0, z);
@@ -318,7 +327,7 @@ index adb2324949484bc543bab25a79ed6d2c39bcba42..728c8a554af42e71dbcc1656563bafcd
          if (this.world.hasChunkAt(pos)) {
              net.minecraft.world.level.chunk.LevelChunk chunk = this.world.getChunkAt(pos);
  
-@@ -2357,6 +2375,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2357,6 +2377,8 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void sendGameEvent(Entity sourceEntity, org.bukkit.GameEvent gameEvent, Vector position) {


### PR DESCRIPTION
This validation will break RTP plugins again most likely.
Only working one will probably be BetterRTP since they run it on the main thread if the async fails