### PR TITLE
get craftDelegate on copying ItemStack

### DIFF
--- a/leaf-api/paper-patches/features/0021-get-craftDelegate-on-copying-ItemStack.patch
+++ b/leaf-api/paper-patches/features/0021-get-craftDelegate-on-copying-ItemStack.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ddggdd135 <1306334428@qq.com>
+Date: Wed, 6 Aug 2025 12:42:13 +0800
+Subject: [PATCH] get craftDelegate on copying ItemStack some plugins like
+ Slimefun may inherit ItemStack and override ItemStack#clone() and return
+ inheritance of ItemStack. It may cause ClassCastException on copying the
+ ItemStack again
+
+
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index 5ee730161c7f11ab7744c80563716e30921a6b5b..c1f891ab1b00fcbd57fbb7e23a4fe40f8732cfd2 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -185,7 +185,11 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+     @org.jetbrains.annotations.ApiStatus.Obsolete(since = "1.21") // Paper
+     public ItemStack(@NotNull final ItemStack stack) throws IllegalArgumentException {
+         Preconditions.checkArgument(stack != null, "Cannot copy null stack");
+-        this.craftDelegate = stack.clone(); // Paper - delegate
++
++        // Leaf start - get craftDelegate
++        this.craftDelegate = stack.clone().craftDelegate; // Paper - delegate
++        // Leaf end
++
+         if (stack.getType().isLegacy()) {
+             this.data = stack.getData();
+         }


### PR DESCRIPTION
some plugins like Slimefun may inherit ItemStack and override ItemStack#clone() and return inheritance of ItemStack. It may cause ClassCastException on copying the ItemStack again