### PR TITLE
Remove buffering in CraftBlock getNMS and getNMSFluid

### DIFF
--- a/leaf-server/paper-patches/features/0049-SparklyPaper-Parallel-world-ticking.patch
+++ b/leaf-server/paper-patches/features/0049-SparklyPaper-Parallel-world-ticking.patch
@@ -337,10 +337,10 @@ index 8c597b54491521f759e2983329a522ba065c647f..10a1f9cf6a558037be7b91e7dfa102a4
      }
      // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a472d68f3c 100644
+index dd122bbbe2c33183017dbde6997d3f1cd08479b5..f8f9a00d26a0706ac6f4bb46545a650145178dd2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -74,12 +74,97 @@ public class CraftBlock implements Block {
+@@ -74,6 +74,63 @@ public class CraftBlock implements Block {
          return new CraftBlock(world, position);
      }
  
@@ -402,45 +402,9 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
 +    // Leaf end - SparklyPaper - parallel world ticking
 +
      public net.minecraft.world.level.block.state.BlockState getNMS() {
--        return this.world.getBlockState(this.position);
-+        // Leaf start - SparklyPaper - parallel world ticking
-+        ServerLevel level = getServerLevel();
-+        String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+
-+        if (needsBuffering(level, handlingMode)) {
-+            // Buffered path
-+            return executeBufferedRead(level, org.dreeam.leaf.async.world.ReadOperationType.BLOCK_GET_NMS_STATE, new Object[]{this.position}, Blocks.AIR.defaultBlockState(), "getNMS");
-+        } else {
-+            // Strict/Disabled/Non-ServerLevel path
-+            checkStrictMode(level, handlingMode, "getNMS");
-+            try {
-+                return this.world.getBlockState(this.position);
-+            } catch (Exception e) {
-+                org.bukkit.Bukkit.getLogger().log(java.util.logging.Level.SEVERE, "PWT: Direct access failed for getNMS" + (level == null ? " (Not a ServerLevel)" : ""), e);
-+                return Blocks.AIR.defaultBlockState();
-+            }
-+        }
-+        // Leaf end - SparklyPaper - parallel world ticking
+         return this.world.getBlockState(this.position);
      }
- 
-     public net.minecraft.world.level.material.FluidState getNMSFluid() {
--        return this.world.getFluidState(this.position);
-+        // Leaf start - SparklyPaper - parallel world ticking
-+        ServerLevel level = getServerLevel();
-+        String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+        checkStrictMode(level, handlingMode, "getNMSFluid");
-+
-+        try {
-+            return this.world.getFluidState(this.position);
-+        } catch (Exception e) {
-+            org.bukkit.Bukkit.getLogger().log(java.util.logging.Level.SEVERE, "PWT: Direct access failed for getNMSFluid" + (level == null ? " (Not a ServerLevel)" : ""), e);
-+            return net.minecraft.world.level.material.Fluids.EMPTY.defaultFluidState();
-+        }
-+        // Leaf end - SparklyPaper - parallel world ticking
-     }
- 
-     public BlockPos getPosition() {
-@@ -142,10 +227,12 @@ public class CraftBlock implements Block {
+@@ -142,10 +199,12 @@ public class CraftBlock implements Block {
          return this.getWorld().getChunkAt(this);
      }
  
@@ -453,7 +417,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
      public void setData(final byte data, boolean applyPhysics) {
          if (applyPhysics) {
              this.setData(data, net.minecraft.world.level.block.Block.UPDATE_ALL);
-@@ -155,12 +242,18 @@ public class CraftBlock implements Block {
+@@ -155,12 +214,18 @@ public class CraftBlock implements Block {
      }
  
      private void setData(final byte data, int flags) {
@@ -473,7 +437,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
          return CraftMagicNumbers.toLegacyData(state);
      }
  
-@@ -177,6 +270,7 @@ public class CraftBlock implements Block {
+@@ -177,6 +242,7 @@ public class CraftBlock implements Block {
      @Override
      public void setType(Material type, boolean applyPhysics) {
          Preconditions.checkArgument(type != null, "Material cannot be null");
@@ -481,7 +445,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
          this.setBlockData(type.createBlockData(), applyPhysics);
      }
  
-@@ -196,6 +290,11 @@ public class CraftBlock implements Block {
+@@ -196,6 +262,11 @@ public class CraftBlock implements Block {
      }
  
      public static boolean setBlockState(LevelAccessor world, BlockPos pos, net.minecraft.world.level.block.state.BlockState oldState, net.minecraft.world.level.block.state.BlockState newState, boolean applyPhysics) {
@@ -493,7 +457,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
          // SPIGOT-611: need to do this to prevent glitchiness. Easier to handle this here (like /setblock) than to fix weirdness in block entity cleanup
          if (oldState.hasBlockEntity() && newState.getBlock() != oldState.getBlock()) { // SPIGOT-3725 remove old block entity if block changes
              // SPIGOT-4612: faster - just clear tile
-@@ -227,22 +326,62 @@ public class CraftBlock implements Block {
+@@ -227,22 +298,62 @@ public class CraftBlock implements Block {
  
      @Override
      public Material getType() {
@@ -560,7 +524,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
      }
  
      public Block getFace(final BlockFace face) {
-@@ -287,47 +426,32 @@ public class CraftBlock implements Block {
+@@ -287,47 +398,32 @@ public class CraftBlock implements Block {
      }
  
      public static BlockFace notchToBlockFace(Direction notch) {
@@ -631,7 +595,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
      }
  
      @Override
-@@ -344,18 +468,65 @@ public class CraftBlock implements Block {
+@@ -344,18 +440,65 @@ public class CraftBlock implements Block {
  
      @Override
      public Biome getBiome() {
@@ -699,7 +663,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
          this.getWorld().setBiome(this.getX(), this.getY(), this.getZ(), bio);
      }
  
-@@ -371,12 +542,50 @@ public class CraftBlock implements Block {
+@@ -371,12 +514,50 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean isBlockPowered() {
@@ -752,7 +716,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
      }
  
      @Override
-@@ -398,44 +607,103 @@ public class CraftBlock implements Block {
+@@ -398,45 +579,104 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean isBlockFacePowered(BlockFace face) {
@@ -835,7 +799,8 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
 +        if (needsBuffering(level, handlingMode)) {
 +            // Buffered path
 +            return executeBufferedRead(level, org.dreeam.leaf.async.world.ReadOperationType.BLOCK_GET_BLOCK_POWER, new Object[]{this.position, face}, 0, "getBlockPower");
-+        } else {
+         } else {
+-            return Math.max(state.getValue(RedStoneWireBlock.POWER), power);
 +            // Strict/Disabled/Non-ServerLevel path
 +            checkStrictMode(level, handlingMode, "getBlockPower");
 +            try {
@@ -863,24 +828,24 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
 +                org.bukkit.Bukkit.getLogger().log(java.util.logging.Level.SEVERE, "PWT: Direct access failed for getBlockPower" + (level == null ? " (Not a ServerLevel)" : ""), e);
 +                return 0;
 +            }
-+        }
-+    }
-+
+         }
+     }
+ 
 +    // Static helper, safe
 +    public static int getPower(int currentMax, net.minecraft.world.level.block.state.BlockState neighborState) {
 +        if (!neighborState.is(Blocks.REDSTONE_WIRE)) {
 +            return currentMax;
-         } else {
--            return Math.max(state.getValue(RedStoneWireBlock.POWER), power);
++        } else {
 +            int neighborPower = neighborState.getValue(RedStoneWireBlock.POWER);
 +            return Math.max(neighborPower, currentMax);
-         }
-     }
++        }
++    }
 +    // Leaf end - SparklyPaper - parallel world ticking
- 
++
      @Override
      public int getBlockPower() {
-@@ -478,23 +746,35 @@ public class CraftBlock implements Block {
+         return this.getBlockPower(BlockFace.SELF);
+@@ -478,23 +718,35 @@ public class CraftBlock implements Block {
  
      @Override
      public PistonMoveReaction getPistonMoveReaction() {
@@ -919,7 +884,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
      }
  
      @Override
-@@ -506,84 +786,147 @@ public class CraftBlock implements Block {
+@@ -506,84 +758,147 @@ public class CraftBlock implements Block {
      public boolean breakNaturally(ItemStack item, boolean triggerEffect, boolean dropExperience, boolean forceEffect) {
          // Paper end
          // Order matters here, need to drop before setting to air so skulls can get their data
@@ -973,12 +938,12 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
 +                    }
 +                }
 +                droppedItems = true;
-+            }
+             }
 +        } else {
 +            // Log if we couldn't drop XP because it wasn't a ServerLevel
 +            if (dropExperience && !state.isAir()) { // Only warn if XP was requested and block wasn't air
 +                org.bukkit.Bukkit.getLogger().log(java.util.logging.Level.WARNING, "PWT: Cannot drop experience for breakNaturally: Not a ServerLevel.");
-             }
++            }
 +            // Still trigger effects if requested and possible with LevelAccessor
 +            if (triggerEffect && !state.isAir()) {
 +                int eventId = (state.getBlock() instanceof net.minecraft.world.level.block.BaseFireBlock)
@@ -1104,7 +1069,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
      }
  
      @Override
-@@ -598,31 +941,70 @@ public class CraftBlock implements Block {
+@@ -598,31 +913,70 @@ public class CraftBlock implements Block {
  
      @Override
      public Collection<ItemStack> getDrops(ItemStack item, Entity entity) {
@@ -1185,7 +1150,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
      @Override
      public void setMetadata(String metadataKey, MetadataValue newMetadataValue) {
          this.getCraftWorld().getBlockMetadata().setMetadata(this, metadataKey, newMetadataValue);
-@@ -645,57 +1027,148 @@ public class CraftBlock implements Block {
+@@ -645,57 +999,148 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean isPassable() {
@@ -1357,7 +1322,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
      }
  
      @Override
-@@ -711,7 +1184,10 @@ public class CraftBlock implements Block {
+@@ -711,7 +1156,10 @@ public class CraftBlock implements Block {
      // Paper start
      @Override
      public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
@@ -1369,7 +1334,7 @@ index dd122bbbe2c33183017dbde6997d3f1cd08479b5..4d8c87bd55e3503a84ad9a24b04a11a4
      }
  
      @Override
-@@ -724,26 +1200,76 @@ public class CraftBlock implements Block {
+@@ -724,26 +1172,76 @@ public class CraftBlock implements Block {
          return this.getNMS().getBlock().getDescriptionId();
      }
  
@@ -1542,7 +1507,7 @@ index 18f09de5c6549df3562e710ede825f75d69c046e..1b06f97caeda6f33938ff5391ecaad5a
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 658385b2887d6debec7fc941c28621da5d263411..2e7ee5faf114e9b8619826c0252c5daac333f0b5 100644
+index 5d83fd5aafb69ac4fc6a3584417194bb67617e6a..b6b1930f377b2eab9c067ab901b876bca82212ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -829,6 +829,28 @@ public class CraftEventFactory {


### PR DESCRIPTION
Did as requested.
Honestly, I'd recommend preferably doing a little context analysis of the internal calls before actually merging.

For context, calls involved in `getNMS` include:
1. Retrieving a Chunk in `net.minecraft.world.level.Level#getBlockState` using `net.minecraft.world.level.Level#getChunk`.
2. If the Chunk is not loaded, it will fallback using `net.minecraft.world.level.ServerChunkCache#getChunkFallback`.
3. If the fallback fails to load the chunk asynchronously, it will schedule the load in the main thread and will force the async thread to wait using `net.minecraft.world.level.ServerChunkCache#syncLoad`.

If there were a lock, `syncLoad` can become troublesome, but seems like this is not the case on Leaf as it was on Fish.
Still, a little bit more research will be required to see if every buffered call to functions in `CraftBlock` that internally call `getNMS` are actually safe and free of possible deadlocks.