### PR TITLE
No collision for spawner-spawned mobs

### DIFF
--- a/leaf-server/minecraft-patches/features/0302-No-collision-for-spawner-spawned-mobs.patch
+++ b/leaf-server/minecraft-patches/features/0302-No-collision-for-spawner-spawned-mobs.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pixl8 <68357832+pixl8dev@users.noreply.github.com>
+Date: Wed, 20 Aug 2025 15:58:16 -0400
+Subject: [PATCH] No collision for spawner-spawned mobs
+
+
+diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
+index dc66b2c59984ce62b1d3c4a97c769771229fb4f8..8979cac35f6e4f074f89836dd76d127827766af2 100644
+--- a/net/minecraft/world/entity/LivingEntity.java
++++ b/net/minecraft/world/entity/LivingEntity.java
+@@ -2986,6 +2986,11 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+ 
+     @Override
+     public void push(Entity entity) {
++        // Leaf start - No collision for spawner-spawned mobs
++        if (org.dreeam.leaf.config.modules.gameplay.NoSpawnerCollision.enabled && this.spawnedViaMobSpawner) {
++            return;
++        }
++        // Leaf end - No collision for spawner-spawned mobs
+         if (!this.isSleeping()) {
+             super.push(entity);
+         }
+@@ -4070,6 +4075,11 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+ 
+     @Override
+     public boolean isCollidable(boolean ignoreClimbing) {
++        // Leaf start - No collision for spawner-spawned mobs
++        if (org.dreeam.leaf.config.modules.gameplay.NoSpawnerCollision.enabled && this.spawnedViaMobSpawner) {
++            return false;
++        }
++        // Leaf end - No collision for spawner-spawned mobs
+         return this.isAlive() && !this.isSpectator() && (ignoreClimbing || !this.onClimbable()) && this.collides; // CraftBukkit
+         // Paper end - Climbing should not bypass cramming gamerule
+     }

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/NoSpawnerCollision.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/NoSpawnerCollision.java
@@ -1,0 +1,21 @@
+package org.dreeam.leaf.config.modules.gameplay;
+
+import org.dreeam.leaf.config.ConfigModules;
+import org.dreeam.leaf.config.EnumConfigCategory;
+
+public class NoSpawnerCollision extends ConfigModules {
+
+    public String getBasePath() {
+        return EnumConfigCategory.GAMEPLAY.getBaseKeyName() + ".no-spawner-collision";
+    }
+
+    public static boolean enabled = false;
+
+    @Override
+    public void onLoaded() {
+        enabled = config.getBoolean(getBasePath(), enabled, config.pickStringRegionBased(
+            "Enable to disable collision for mobs spawned from spawners",
+            "是否禁用从刷怪笼生成的生物与其他实体的碰撞"
+        ));
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/NoSpawnerCollision.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/NoSpawnerCollision.java
@@ -6,7 +6,7 @@ import org.dreeam.leaf.config.EnumConfigCategory;
 public class NoSpawnerCollision extends ConfigModules {
 
     public String getBasePath() {
-        return EnumConfigCategory.GAMEPLAY.getBaseKeyName() + ".no-spawner-collision";
+        return EnumConfigCategory.GAMEPLAY.getBaseKeyName() + ".disable-mob-collision-from-spawner";
     }
 
     public static boolean enabled = false;


### PR DESCRIPTION
This patch introduces a new setting that enables the disabling of collisions (pushing) for entities spawned from spawners. This feature proves particularly useful when dealing with servers that have many spawner mob farms.