### PR TITLE
fix async mob spawning with per player spawn off

### DIFF
--- a/leaf-server/minecraft-patches/features/0244-cache-getBiome.patch
+++ b/leaf-server/minecraft-patches/features/0244-cache-getBiome.patch
@@ -57,7 +57,7 @@ index 838146e997a2033c3d2a96602a252178093d263e..bb655318f49242858e2c25d5469705c0
  
      public static boolean isInNetherFortressBounds(BlockPos pos, ServerLevel level, MobCategory category, StructureManager structureManager) {
 diff --git a/net/minecraft/world/level/biome/BiomeManager.java b/net/minecraft/world/level/biome/BiomeManager.java
-index a48175a7ebb1788ace46395621ed78d910178a53..b8a0fa20101fa3831e34494fd56690343ff8d57e 100644
+index a48175a7ebb1788ace46395621ed78d910178a53..d008a409080eddfc8a0517e78a29857ece5d28d9 100644
 --- a/net/minecraft/world/level/biome/BiomeManager.java
 +++ b/net/minecraft/world/level/biome/BiomeManager.java
 @@ -15,10 +15,23 @@ public class BiomeManager {
@@ -84,113 +84,81 @@ index a48175a7ebb1788ace46395621ed78d910178a53..b8a0fa20101fa3831e34494fd5669034
      }
  
      public static long obfuscateSeed(long seed) {
-@@ -29,6 +42,105 @@ public class BiomeManager {
+@@ -29,17 +42,46 @@ public class BiomeManager {
          return new BiomeManager(newSource, this.biomeZoomSeed);
      }
  
+-    public Holder<Biome> getBiome(BlockPos pos) {
+-        // Leaf start - Carpet-Fixes - Optimized getBiome method
 +    // Leaf start - cache getBiome
 +    public Holder<Biome> getBiomeCached(@org.jetbrains.annotations.Nullable net.minecraft.world.level.chunk.LevelChunk chunk, BlockPos pos) {
 +        if (biomeCache == null) {
 +            return getBiome(pos);
 +        }
-+        int xMinus2 = pos.getX() - 2;
-+        int yMinus2 = pos.getY() - 2;
-+        int zMinus2 = pos.getZ() - 2;
+         int xMinus2 = pos.getX() - 2;
+         int yMinus2 = pos.getY() - 2;
+         int zMinus2 = pos.getZ() - 2;
 +        int x = xMinus2 >> 2;
 +        int y = yMinus2 >> 2;
 +        int z = zMinus2 >> 2;
 +        long packedPos = BlockPos.asLong(x, y, z);
-+        long hash = packedPos;
-+        hash = (hash ^ (hash >>> 32)) * 0xff51afd7ed558ccdL;
-+        hash = (hash ^ (hash >>> 32)) * 0xc4ceb9fe1a85ec53L;
-+        hash = (hash ^ (hash >>> 32)) & 65535L;
-+
-+        long pos1 = biomeCachePos[(int) hash];
-+        if (pos1 == packedPos) {
-+            Holder<Biome> biome = biomeCache[(int) hash];
++        int hash = (int) (it.unimi.dsi.fastutil.HashCommon.mix(packedPos) & 65535L);
++        if (biomeCachePos[hash] == packedPos) {
++            Holder<Biome> biome = biomeCache[hash];
 +            if (biome != null) {
 +                return biome;
 +            }
 +        }
 +
-+        Holder<Biome> biome = getBiomeCachedChunk(chunk, pos);
++        Holder<Biome> biome = getBiomeWithChunk(chunk, xMinus2, yMinus2, zMinus2);
 +
-+        biomeCache[(int) hash] = biome;
-+        biomeCachePos[(int) hash] = packedPos;
++        biomeCache[hash] = biome;
++        biomeCachePos[hash] = packedPos;
 +
 +        return biome;
 +    }
-+    private Holder<Biome> getBiomeCachedChunk(@org.jetbrains.annotations.Nullable net.minecraft.world.level.chunk.LevelChunk chunk, BlockPos pos) {
++
++    public Holder<Biome> getBiome(BlockPos pos) {
++        return getBiomeWithChunk(null, pos.getX() - 2, pos.getY() - 2, pos.getZ() - 2);
++    }
++
++    private Holder<Biome> getBiomeWithChunk(@org.jetbrains.annotations.Nullable net.minecraft.world.level.chunk.LevelChunk chunk, int xMinus2, int yMinus2, int zMinus2) {
 +        // Leaf start - Carpet-Fixes - Optimized getBiome method
-+        int xMinus2 = pos.getX() - 2;
-+        int yMinus2 = pos.getY() - 2;
-+        int zMinus2 = pos.getZ() - 2;
-+        int x = xMinus2 >> 2; // BlockPos to BiomePos
-+        int y = yMinus2 >> 2;
-+        int z = zMinus2 >> 2;
-+        double quartX = (double) (xMinus2 & 3) / 4.0; // quartLocal divided by 4
-+        double quartY = (double) (yMinus2 & 3) / 4.0; // 0/4, 1/4, 2/4, 3/4
-+        double quartZ = (double) (zMinus2 & 3) / 4.0; // [0, 0.25, 0.5, 0.75]
-+        int smallestX = 0;
-+        double smallestDist = Double.POSITIVE_INFINITY;
-+        for (int biomeX = 0; biomeX < 8; ++biomeX) {
-+            boolean everyOtherQuad = (biomeX & 4) == 0; // 1 1 1 1 0 0 0 0
-+            boolean everyOtherPair = (biomeX & 2) == 0; // 1 1 0 0 1 1 0 0
-+            boolean everyOther = (biomeX & 1) == 0; // 1 0 1 0 1 0 1 0
-+            double quartXX = everyOtherQuad ? quartX : quartX - 1.0; //[-1.0,-0.75,-0.5,-0.25,0.0,0.25,0.5,0.75]
-+            double quartYY = everyOtherPair ? quartY : quartY - 1.0;
-+            double quartZZ = everyOther ? quartZ : quartZ - 1.0;
-+
-+            //This code block is new
-+            double maxQuartYY = 0.0, maxQuartZZ = 0.0;
-+            if (biomeX != 0) {
-+                maxQuartYY = Mth.square(Math.max(quartYY + maxOffset, Math.abs(quartYY - maxOffset)));
-+                maxQuartZZ = Mth.square(Math.max(quartZZ + maxOffset, Math.abs(quartZZ - maxOffset)));
-+                double maxQuartXX = Mth.square(Math.max(quartXX + maxOffset, Math.abs(quartXX - maxOffset)));
-+                if (smallestDist < maxQuartXX + maxQuartYY + maxQuartZZ) continue;
-+            }
-+            int xx = everyOtherQuad ? x : x + 1;
-+            int yy = everyOtherPair ? y : y + 1;
-+            int zz = everyOther ? z : z + 1;
-+
-+            //I transferred the code from method_38106 to here, so I could call continue halfway through
-+            long seed = LinearCongruentialGenerator.next(this.biomeZoomSeed, xx);
-+            seed = LinearCongruentialGenerator.next(seed, yy);
-+            seed = LinearCongruentialGenerator.next(seed, zz);
-+            seed = LinearCongruentialGenerator.next(seed, xx);
-+            seed = LinearCongruentialGenerator.next(seed, yy);
-+            seed = LinearCongruentialGenerator.next(seed, zz);
-+            double offsetX = getFiddle(seed);
-+            double sqrX = Mth.square(quartXX + offsetX);
-+            if (biomeX != 0 && smallestDist < sqrX + maxQuartYY + maxQuartZZ) continue; //skip the rest of the loop
-+            seed = LinearCongruentialGenerator.next(seed, this.biomeZoomSeed);
-+            double offsetY = getFiddle(seed);
-+            double sqrY = Mth.square(quartYY + offsetY);
-+            if (biomeX != 0 && smallestDist < sqrX + sqrY + maxQuartZZ) continue; // skip the rest of the loop
-+            seed = LinearCongruentialGenerator.next(seed, this.biomeZoomSeed);
-+            double offsetZ = getFiddle(seed);
-+            double biomeDist = sqrX + sqrY + Mth.square(quartZZ + offsetZ);
-+
-+            if (smallestDist > biomeDist) {
-+                smallestX = biomeX;
-+                smallestDist = biomeDist;
-+            }
-+        }
+         int x = xMinus2 >> 2; // BlockPos to BiomePos
+         int y = yMinus2 >> 2;
+         int z = zMinus2 >> 2;
+-        double quartX = (double) (xMinus2 & 3) / 4.0; // quartLocal divided by 4
+-        double quartY = (double) (yMinus2 & 3) / 4.0; // 0/4, 1/4, 2/4, 3/4
+-        double quartZ = (double) (zMinus2 & 3) / 4.0; // [0, 0.25, 0.5, 0.75]
++        double quartX = (xMinus2 & 3) / 4.0; // quartLocal divided by 4
++        double quartY = (yMinus2 & 3) / 4.0; // 0/4, 1/4, 2/4, 3/4
++        double quartZ = (zMinus2 & 3) / 4.0; // [0, 0.25, 0.5, 0.75]
+         int smallestX = 0;
+         double smallestDist = Double.POSITIVE_INFINITY;
+         for (int biomeX = 0; biomeX < 8; ++biomeX) {
+@@ -85,13 +127,16 @@ public class BiomeManager {
+                 smallestDist = biomeDist;
+             }
+         }
+-        return this.noiseBiomeSource.getNoiseBiome(
+-            (smallestX & 4) == 0 ? x : x + 1,
+-            (smallestX & 2) == 0 ? y : y + 1,
+-            (smallestX & 1) == 0 ? z : z + 1
+-        );
 +        int x1 = (smallestX & 4) == 0 ? x : x + 1;
 +        int y1 = (smallestX & 2) == 0 ? y : y + 1;
 +        int z1 =  (smallestX & 1) == 0 ? z : z + 1;
-+        if (chunk != null && chunk.locX == x >> 2 && chunk.locZ == z >> 2) {
++        if (chunk != null && chunk.locX == x1 >> 2 && chunk.locZ == z1 >> 2) {
 +            return chunk.getNoiseBiome(x1, y1, z1);
 +        }
 +        return this.noiseBiomeSource.getNoiseBiome(x1, y1, z1);
-+        // Leaf end - Carpet-Fixes - Optimized getBiome method
-+    }
+         // Leaf end - Carpet-Fixes - Optimized getBiome method
+     }
 +    // Leaf end - cache getBiome
-+
-     public Holder<Biome> getBiome(BlockPos pos) {
-         // Leaf start - Carpet-Fixes - Optimized getBiome method
-         int xMinus2 = pos.getX() - 2;
-@@ -126,9 +238,18 @@ public class BiomeManager {
+ 
+     public Holder<Biome> getNoiseBiomeAtPosition(double x, double y, double z) {
+         int quartPosCoord = QuartPos.fromBlock(Mth.floor(x));
+@@ -126,9 +171,18 @@ public class BiomeManager {
          return Mth.square(zNoise + fiddle2) + Mth.square(yNoise + fiddle1) + Mth.square(xNoise + fiddle);
      }
  

--- a/leaf-server/minecraft-patches/features/0245-optimize-mob-spawning.patch
+++ b/leaf-server/minecraft-patches/features/0245-optimize-mob-spawning.patch
@@ -5,6 +5,8 @@ Subject: [PATCH] optimize mob spawning
 
 Avoid getChunk calls if its position is same as the chunk used for mob spawning
 
+Cache chunk generator
+
 Don't sync load chunks for mob spawning checks
 
 Fix data race in async mob spawning
@@ -28,7 +30,7 @@ index 5c369b3d94e369c3f240821ad90b9d96223f24ca..9803c395fce103cb7bc746f43a017ff9
       }
      // Paper end - Optional per player mob spawns
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..2721b999dcfcf1cd5a0919221f2d94da4c93a6e7 100644
+index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..f0d4b7414030f99a2ef0e257d531bf4634bdc724 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
 @@ -70,11 +70,11 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
@@ -45,55 +47,43 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..2721b999dcfcf1cd5a0919221f2d94da
      // Paper start
      public final ca.spottedleaf.concurrentutil.map.ConcurrentLong2ReferenceChainedHashTable<net.minecraft.world.level.chunk.LevelChunk> fullChunks = new ca.spottedleaf.concurrentutil.map.ConcurrentLong2ReferenceChainedHashTable<>();
      public int getFullChunksCount() {
-@@ -499,6 +499,23 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -183,8 +183,8 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
      }
+     // Paper end - chunk tick iteration optimisations
  
-     private void tickChunks() {
-+        // Leaf start - optimize mob spawning
-+        if (org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled && this.level.tickRateManager().runsNormally()) {
-+            for (ServerPlayer player : this.level.players) {
-+                // Paper start - per player mob spawning backoff
-+                for (int ii = 0; ii < ServerPlayer.MOBCATEGORY_TOTAL_ENUMS; ii++) {
-+                    player.mobCounts[ii] = 0;
-+
-+                    int newBackoff = player.mobBackoffCounts[ii] - 1; // TODO make configurable bleed // TODO use nonlinear algorithm?
-+                    if (newBackoff < 0) {
-+                        newBackoff = 0;
-+                    }
-+                    player.mobBackoffCounts[ii] = newBackoff;
-+                }
-+                // Paper end - per player mob spawning backoff
-+            }
-+        }
-+        // Leaf end - optimize mob spawning
-         long gameTime = this.level.getGameTime();
-         long l = gameTime - this.lastInhabitedUpdate;
-         this.lastInhabitedUpdate = gameTime;
-@@ -512,8 +529,8 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+-    public boolean firstRunSpawnCounts = true; // Pufferfish
+-    public final java.util.concurrent.atomic.AtomicBoolean _pufferfish_spawnCountsReady = new java.util.concurrent.atomic.AtomicBoolean(false); // Pufferfish - optimize countmobs
++    public final java.util.concurrent.atomic.AtomicInteger _pufferfish_spawnCountsReady = new java.util.concurrent.atomic.AtomicInteger(); // Leaf - optimize mob spawning
++    public static final MobCategory[] EMPTY_MOB_CATEGORIES = new MobCategory[0]; // Leaf - optimize mob spawning
+ 
+     public ServerChunkCache(
+         ServerLevel level,
+@@ -510,54 +510,6 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+ 
+             this.broadcastChangedChunks(); // Gale - Purpur - remove vanilla profiler
          }
- 
-         // Pufferfish start - optimize mob spawning
+-
+-        // Pufferfish start - optimize mob spawning
 -        if (org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled) {
 -            for (ServerPlayer player : this.level.players) {
-+        if (org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled && this.level.tickRateManager().runsNormally()) {
-+            /*for (ServerPlayer player : this.level.players) {
-                 // Paper start - per player mob spawning backoff
-                 for (int ii = 0; ii < ServerPlayer.MOBCATEGORY_TOTAL_ENUMS; ii++) {
-                     player.mobCounts[ii] = 0;
-@@ -525,34 +542,27 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
-                     player.mobBackoffCounts[ii] = newBackoff;
-                 }
-                 // Paper end - per player mob spawning backoff
+-                // Paper start - per player mob spawning backoff
+-                for (int ii = 0; ii < ServerPlayer.MOBCATEGORY_TOTAL_ENUMS; ii++) {
+-                    player.mobCounts[ii] = 0;
+-
+-                    int newBackoff = player.mobBackoffCounts[ii] - 1; // TODO make configurable bleed // TODO use nonlinear algorithm?
+-                    if (newBackoff < 0) {
+-                        newBackoff = 0;
+-                    }
+-                    player.mobBackoffCounts[ii] = newBackoff;
+-                }
+-                // Paper end - per player mob spawning backoff
 -            }
-+            }*/
-             if (firstRunSpawnCounts) {
-                 firstRunSpawnCounts = false;
-                 _pufferfish_spawnCountsReady.set(true);
-             }
-             if (_pufferfish_spawnCountsReady.getAndSet(false)) {
-+                final int mapped = distanceManager.getNaturalSpawnChunkCount();
-+                final Iterable<Entity> entities = this.level.getAllEntities();
-                 net.minecraft.server.MinecraftServer.getServer().mobSpawnExecutor.submit(() -> {
+-            if (firstRunSpawnCounts) {
+-                firstRunSpawnCounts = false;
+-                _pufferfish_spawnCountsReady.set(true);
+-            }
+-            if (_pufferfish_spawnCountsReady.getAndSet(false)) {
+-                net.minecraft.server.MinecraftServer.getServer().mobSpawnExecutor.submit(() -> {
 -                    int mapped = distanceManager.getNaturalSpawnChunkCount();
 -                    ca.spottedleaf.moonrise.common.list.IteratorSafeOrderedReferenceSet.Iterator<Entity> objectiterator =
 -                        level.entityTickList.entities.iterator(ca.spottedleaf.moonrise.common.list.IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS);
@@ -115,22 +105,56 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..2721b999dcfcf1cd5a0919221f2d94da
 -                    } finally {
 -                        objectiterator.finishedIterating();
 -                    }
-+                    // Fix: Use proper mob cap calculator based on configuration
-+                    LocalMobCapCalculator mobCapCalculator = !level.paperConfig().entities.spawning.perPlayerMobSpawns ?
-+                        new LocalMobCapCalculator(chunkMap) : null;
-+
-+                    // This ensures the caps are properly enforced by using the correct calculator
-+                    lastSpawnState = NaturalSpawner.createState1( // Leaf - optimize mob spawning
-+                        mapped,
-+                        entities,
-+                        this.level, // Leaf - optimize mob spawning
-+                        mobCapCalculator,  // This is the key fix - was previously null
-+                        level.paperConfig().entities.spawning.perPlayerMobSpawns
-+                    );
-                     _pufferfish_spawnCountsReady.set(true);
-                 });
+-                    _pufferfish_spawnCountsReady.set(true);
+-                });
+-            }
+-        }
+-        // Pufferfish end
+     }
+ 
+     private void broadcastChangedChunks() { // Gale - Purpur - remove vanilla profiler
+@@ -574,9 +526,9 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+     private void tickChunks(long timeInhabited) { // Gale - Purpur - remove vanilla profiler
+         int naturalSpawnChunkCount = this.distanceManager.getNaturalSpawnChunkCount();
+         // Paper start - Optional per player mob spawns
+-        NaturalSpawner.SpawnState spawnState;
++        //NaturalSpawner.SpawnState spawnState;
++        java.util.concurrent.atomic.AtomicInteger state = _pufferfish_spawnCountsReady;
+         if ((this.spawnFriendlies || this.spawnEnemies) && this.level.paperConfig().entities.spawning.perPlayerMobSpawns) { // don't count mobs when animals and monsters are disabled
+-            if (!org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled) { // Pufferfish - moved down when async processing
+             // re-set mob counts
+             for (ServerPlayer player : this.level.players) {
+                 // Paper start - per player mob spawning backoff
+@@ -591,19 +543,21 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+                 }
+                 // Paper end - per player mob spawning backoff
              }
-@@ -611,6 +621,7 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+-            lastSpawnState = NaturalSpawner.createState(naturalSpawnChunkCount, this.level.getAllEntities(), this::getFullChunk, null, true); // Pufferfish - async mob spawning
+-            } // Pufferfish - (endif) moved down when async processing
++            // Leaf start - optimize mob spawning
++            if (!org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled) {
++                state.set(2);
++                lastSpawnState = NaturalSpawner.createState(naturalSpawnChunkCount, this.level.getAllEntities(), this::getFullChunk, null, true); // Pufferfish - async mob spawning
++            }
++            // Leaf end - optimize mob spawning
+         } else {
+-            // Pufferfish start - async mob spawning
+-            lastSpawnState = NaturalSpawner.createState(naturalSpawnChunkCount, this.level.getAllEntities(), this::getFullChunk, !this.level.paperConfig().entities.spawning.perPlayerMobSpawns ? new LocalMobCapCalculator(this.chunkMap) : null, false);
+-            _pufferfish_spawnCountsReady.set(true);
+-            // Pufferfish end
++            state.set(2); // Leaf - optimize mob spawning
++            lastSpawnState = NaturalSpawner.createState(naturalSpawnChunkCount, this.level.getAllEntities(), this::getFullChunk, !this.level.paperConfig().entities.spawning.perPlayerMobSpawns ? new LocalMobCapCalculator(this.chunkMap) : null, false); // Leaf - optimize mob spawning
+         }
+         // Paper end - Optional per player mob spawns
+         //this.lastSpawnState = spawnState; // Pufferfish - this is managed asynchronously
+         boolean _boolean = this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING) && !this.level.players().isEmpty(); // CraftBukkit
+         int _int = this.level.getGameRules().getInt(GameRules.RULE_RANDOMTICKING);
+-        List<MobCategory> filteredSpawningCategories;
++        MobCategory[] filteredSpawningCategories; // Leaf - optimize mob spawning
+         if (_boolean && (this.spawnEnemies || this.spawnFriendlies)) {
+             // Paper start - PlayerNaturallySpawnCreaturesEvent
+             for (ServerPlayer entityPlayer : this.level.players()) {
+@@ -611,27 +565,61 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
                  chunkRange = Math.min(chunkRange, 8);
                  entityPlayer.playerNaturallySpawnedEvent = new com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent(entityPlayer.getBukkitEntity(), (byte) chunkRange);
                  entityPlayer.playerNaturallySpawnedEvent.callEvent();
@@ -138,14 +162,20 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..2721b999dcfcf1cd5a0919221f2d94da
              }
              // Paper end - PlayerNaturallySpawnCreaturesEvent
              boolean flag = this.level.ticksPerSpawnCategory.getLong(org.bukkit.entity.SpawnCategory.ANIMAL) != 0L && this.level.getLevelData().getGameTime() % this.level.ticksPerSpawnCategory.getLong(org.bukkit.entity.SpawnCategory.ANIMAL) == 0L; // CraftBukkit
-@@ -622,16 +633,34 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+-            filteredSpawningCategories = NaturalSpawner.getFilteredSpawningCategories(lastSpawnState, this.spawnFriendlies, this.spawnEnemies, flag, this.level); // CraftBukkit // Pufferfish
++            filteredSpawningCategories = NaturalSpawner.getFilteredSpawningCategories(lastSpawnState, this.spawnFriendlies, this.spawnEnemies, flag, this.level).toArray(EMPTY_MOB_CATEGORIES); // CraftBukkit // Pufferfish // Leaf - optimize mob spawning
+         } else {
+-            filteredSpawningCategories = List.of();
++            filteredSpawningCategories = EMPTY_MOB_CATEGORIES; // Leaf - optimize mob spawning
+         }
+ 
          List<LevelChunk> list = this.spawningChunks;
  
          try {
 -            this.chunkMap.collectSpawningChunks(list);
 +            // Leaf start - optimize mob spawning
 +            // this.chunkMap.collectSpawningChunks(list);
-+            this.level.natureSpawnChunkMap.build();
++            this.level.natureSpawnChunkMap.build(this.level);
 +            this.level.natureSpawnChunkMap.collectSpawningChunks(this.level.moonrise$getPlayerTickingChunks(), list);
              // Paper start - chunk tick iteration optimisation
              this.shuffleRandom.setSeed(this.level.random.nextLong());
@@ -154,37 +184,68 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..2721b999dcfcf1cd5a0919221f2d94da
  
 -            for (LevelChunk levelChunk : list) {
 -                this.tickSpawningChunk(levelChunk, timeInhabited, filteredSpawningCategories, lastSpawnState); // Pufferfish
-+            if (!org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled || _pufferfish_spawnCountsReady.get()) {
++            boolean enqueue = org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled
++                && (this.spawnFriendlies || this.spawnEnemies)
++                && this.level.paperConfig().entities.spawning.perPlayerMobSpawns;
++            if (!enqueue || state.compareAndSet(2, 0)) {
 +                NaturalSpawner.SpawnState currentState = lastSpawnState;
++                lastSpawnState = null;
 +                if (currentState != null) {
-+                    currentState.applyPerPlayerMobCount(level);
-+                    if (list instanceof it.unimi.dsi.fastutil.objects.ReferenceArrayList<LevelChunk> list1) {
-+                        LevelChunk[] raw = list1.elements();
-+                        for (int i = 0, j = list1.size(); i < j; i++) {
-+                            this.tickSpawningChunk(raw[i], timeInhabited, filteredSpawningCategories, currentState); // Pufferfish
-+                        }
-+                    } else {
-+                        for (LevelChunk levelChunk : list) {
-+                            this.tickSpawningChunk(levelChunk, timeInhabited, filteredSpawningCategories, currentState); // Pufferfish
-+                        }
++                    currentState.applyPerPlayerMobCount(this.level);
++                }
++                MobCategory[] categories = currentState == null ? EMPTY_MOB_CATEGORIES : filteredSpawningCategories;
++                ChunkGenerator generator = this.getGenerator();
++                if (list instanceof it.unimi.dsi.fastutil.objects.ReferenceArrayList<LevelChunk> list1) {
++                    LevelChunk[] raw = list1.elements();
++                    for (int i = 0, j = list1.size(); i < j; i++) {
++                        this.tickSpawningChunk(raw[i], timeInhabited, categories, currentState, generator);
++                    }
++                } else {
++                    for (LevelChunk levelChunk : list) {
++                        this.tickSpawningChunk(levelChunk, timeInhabited, categories, currentState, generator);
 +                    }
 +                }
              }
++            if (enqueue && state.compareAndSet(0, 1)) {
++                ServerLevel level = this.level;
++                int mapped = this.distanceManager.getNaturalSpawnChunkCount();
++                Iterable<Entity> entities = this.level.getAllEntities();
++                level.getServer().mobSpawnExecutor.submit(() -> {
++                    NaturalSpawner.SpawnState newState = NaturalSpawner.createStateAsync(mapped, entities, level);
++                    ServerChunkCache.this.lastSpawnState = !state.compareAndSet(1, 2) ? null : newState;
++                });
++            }
 +            // Leaf end - optimize mob spawning
          } finally {
 +            this.level.natureSpawnChunkMap.clear(); // Leaf - optimize mob spawning
              list.clear();
          }
  
-@@ -649,7 +678,7 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -641,16 +629,21 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+         }
+     }
+ 
++    // Leaf start - optimize mob spawning - cache ChunkGenerator
+     private void tickSpawningChunk(LevelChunk chunk, long timeInhabited, List<MobCategory> spawnCategories, NaturalSpawner.SpawnState spawnState) {
++        tickSpawningChunk(chunk, timeInhabited, spawnCategories.toArray(EMPTY_MOB_CATEGORIES), spawnState, getGenerator());
++    }
++    private void tickSpawningChunk(LevelChunk chunk, long timeInhabited, MobCategory[] spawnCategories, NaturalSpawner.SpawnState spawnState, ChunkGenerator generator) {
++    // Leaf end - optimize mob spawning - cache ChunkGenerator
+         ChunkPos pos = chunk.getPos();
+         chunk.incrementInhabitedTime(timeInhabited);
+         if (true) { // Paper - rewrite chunk system
+             this.level.tickThunder(chunk);
          }
  
-         if (!spawnCategories.isEmpty()) {
+-        if (!spawnCategories.isEmpty()) {
 -            if (this.level.getWorldBorder().isWithinBounds(pos) && (!org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled || _pufferfish_spawnCountsReady.get())) { // Paper - rewrite chunk system // Pufferfish
+-                NaturalSpawner.spawnForChunk(this.level, chunk, spawnState, spawnCategories);
++        if (spawnCategories.length != 0) {
 +            if (this.level.getWorldBorder().isWithinBounds(pos)) { // Paper - rewrite chunk system
-                 NaturalSpawner.spawnForChunk(this.level, chunk, spawnState, spawnCategories);
++                NaturalSpawner.spawnForChunk(this.level, chunk, spawnState, spawnCategories, generator); // Leaf - optimize mob spawning - cache ChunkGenerator
              }
          }
+     }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
 index b3d877089f4eebcd78f1019a91d9d71615a15148..b9986a9df48f6986c8151d727893b750557e9a74 100644
 --- a/net/minecraft/server/level/ServerLevel.java
@@ -197,8 +258,30 @@ index b3d877089f4eebcd78f1019a91d9d71615a15148..b9986a9df48f6986c8151d727893b750
      public void tickChunk(LevelChunk chunk, int randomTickSpeed) {
          final net.minecraft.world.level.levelgen.BitRandomSource simpleRandom = this.simpleRandom; // Paper - optimise random ticking // Leaf - Faster random generator - upcasting
          ChunkPos pos = chunk.getPos();
+diff --git a/net/minecraft/util/random/WeightedList.java b/net/minecraft/util/random/WeightedList.java
+index daab145028c59c07049a2cf75c4f159e4c5073dc..221976c3b3a4a4d6d00bc4eb13fc1859c1910271 100644
+--- a/net/minecraft/util/random/WeightedList.java
++++ b/net/minecraft/util/random/WeightedList.java
+@@ -70,6 +70,17 @@ public class WeightedList<E> { // Paper - non-final
+         }
+     }
+ 
++    // Leaf start - optimize mob spawning
++    @Nullable
++    public E getRandomNullable(RandomSource random) {
++        if (this.selector == null) {
++            return null;
++        } else {
++            return this.selector.get(random.nextInt(this.totalWeight));
++        }
++    }
++    // Leaf end - optimize mob spawning
++
+     public E getRandomOrThrow(RandomSource random) {
+         if (this.selector == null) {
+             throw new IllegalStateException("Weighted list has no elements");
 diff --git a/net/minecraft/world/level/NaturalSpawner.java b/net/minecraft/world/level/NaturalSpawner.java
-index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75dbb125f869 100644
+index bb655318f49242858e2c25d5469705c0c314ed85..c1ccb03768e54f144b8978cf27b6bc7b39bcef77 100644
 --- a/net/minecraft/world/level/NaturalSpawner.java
 +++ b/net/minecraft/world/level/NaturalSpawner.java
 @@ -68,6 +68,7 @@ public final class NaturalSpawner {
@@ -209,17 +292,13 @@ index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75db
      public static NaturalSpawner.SpawnState createState(
          int spawnableChunkCount, Iterable<Entity> entities, NaturalSpawner.ChunkGetter chunkGetter, LocalMobCapCalculator calculator, final boolean countMobs
      ) {
-@@ -108,9 +109,71 @@ public final class NaturalSpawner {
-             }
-         }
- 
--        return new NaturalSpawner.SpawnState(spawnableChunkCount, map, potentialCalculator, calculator);
-+        return new NaturalSpawner.SpawnState(spawnableChunkCount, map, potentialCalculator, calculator, new it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<>()); // Leaf - optimize mob spawning
+@@ -111,6 +112,63 @@ public final class NaturalSpawner {
+         return new NaturalSpawner.SpawnState(spawnableChunkCount, map, potentialCalculator, calculator);
      }
  
 +    // Leaf start - optimize mob spawning
-+    public static NaturalSpawner.SpawnState createState1(
-+        int spawnableChunkCount, Iterable<Entity> entities, ServerLevel level, LocalMobCapCalculator calculator, final boolean countMobs
++    public static NaturalSpawner.SpawnState createStateAsync(
++        int spawnableChunkCount, Iterable<Entity> entities, ServerLevel level
 +    ) {
 +        // Paper end - Optional per player mob spawns
 +        PotentialCalculator potentialCalculator = new PotentialCalculator();
@@ -245,15 +324,10 @@ index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75db
 +                            potentialCalculator.addCharge(entity.blockPosition(), mobSpawnCost.charge());
 +                        }
 +
-+                        if (calculator != null && entity instanceof Mob) { // Paper - Optional per player mob spawns
-+                            calculator.addMob(chunk.getPos(), category);
-+                        }
-+
 +                        map.addTo(category, 1);
 +                        // Paper start - Optional per player mob spawns
-+                        if (countMobs) {
-+                            final int index = entity.getType().getCategory().ordinal();
-+                            ++chunkCap.computeIfAbsent(chunk.getPos().longKey, k -> new int[net.minecraft.server.level.ServerPlayer.MOBCATEGORY_TOTAL_ENUMS])[index];
++                        final int index = entity.getType().getCategory().ordinal();
++                        ++chunkCap.computeIfAbsent(chunk.coordinateKey, k -> new int[net.minecraft.server.level.ServerPlayer.MOBCATEGORY_TOTAL_ENUMS])[index];
 +                        /*
 +                        final int index = entity.getType().getCategory().ordinal();
 +                        final var inRange = level.moonrise$getNearbyPlayers().getPlayers(entity.chunkPosition(), NearbyPlayers.NearbyMapType.TICK_VIEW_DISTANCE);
@@ -268,57 +342,103 @@ index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75db
 +                            ++playerCap.computeIfAbsent(player, k -> new int[net.minecraft.server.level.ServerPlayer.MOBCATEGORY_TOTAL_ENUMS])[index];
 +                        }
 +                        */
-+                        }
++
 +                        // Paper end - Optional per player mob spawns
 +                    }
 +                }
 +            }
 +        }
 +
-+        return new NaturalSpawner.SpawnState(spawnableChunkCount, map, potentialCalculator, calculator, chunkCap);
++        return new NaturalSpawner.SpawnState(spawnableChunkCount, map, potentialCalculator, null, chunkCap);
 +    }
 +    // Leaf end - optimize mob spawning
 +
      static Biome getRoughBiome(BlockPos pos, ChunkAccess chunk) {
          return chunk.getNoiseBiome(QuartPos.fromBlock(pos.getX()), QuartPos.fromBlock(pos.getY()), QuartPos.fromBlock(pos.getZ())).value();
      }
-@@ -265,28 +328,68 @@ public final class NaturalSpawner {
-         MobCategory category, ServerLevel level, ChunkAccess chunk, BlockPos pos, NaturalSpawner.SpawnPredicate filter, NaturalSpawner.AfterSpawnCallback callback, final int maxSpawns, final @Nullable Consumer<Entity> trackEntity, final boolean nothing
+@@ -149,7 +207,12 @@ public final class NaturalSpawner {
+         return list;
+     }
+ 
++    // Leaf start - optimize mob spawning - cache ChunkGenerator
+     public static void spawnForChunk(ServerLevel level, LevelChunk chunk, NaturalSpawner.SpawnState spawnState, List<MobCategory> categories) {
++        spawnForChunk(level, chunk, spawnState, categories.toArray(net.minecraft.server.level.ServerChunkCache.EMPTY_MOB_CATEGORIES), level.chunkSource.getGenerator());
++    }
++    public static void spawnForChunk(ServerLevel level, LevelChunk chunk, NaturalSpawner.SpawnState spawnState, MobCategory[] categories, ChunkGenerator generator) {
++    // Leaf end - optimize mob spawning - cache ChunkGenerator
+         for (MobCategory mobCategory : categories) {
+             // Paper start - Optional per player mob spawns
+             final boolean canSpawn;
+@@ -192,8 +255,8 @@ public final class NaturalSpawner {
+             }
+             if (canSpawn) {
+                 // Paper PR start - throttle failed spawn attempts
+-                int spawnCount = spawnCategoryForChunk(mobCategory, level, chunk, spawnState::canSpawn, spawnState::afterSpawn,
+-                    maxSpawns, level.paperConfig().entities.spawning.perPlayerMobSpawns ? level.getChunkSource().chunkMap::updatePlayerMobTypeMap : null, false);
++                int spawnCount = spawnCategoryForChunk(mobCategory, level, chunk, spawnState::canSpawn, spawnState::afterSpawn, // Leaf - optimize mob spawning - cache ChunkGenerator
++                    maxSpawns, level.paperConfig().entities.spawning.perPlayerMobSpawns ? level.getChunkSource().chunkMap::updatePlayerMobTypeMap : null, generator); // Leaf - optimize mob spawning - cache ChunkGenerator
+                 if (spawnCount == 0) {
+                     chunk.failedSpawnAttempts[mobCategory.ordinal()]++;
+                 } else {
+@@ -225,16 +288,16 @@ public final class NaturalSpawner {
+         MobCategory category, ServerLevel level, LevelChunk chunk, NaturalSpawner.SpawnPredicate filter, NaturalSpawner.AfterSpawnCallback callback, final int maxSpawns, final Consumer<Entity> trackEntity
+         // Paper PR start - throttle failed spawn attempts
+     ) {
+-        spawnCategoryForChunk(category, level, chunk, filter, callback, maxSpawns, trackEntity, false);
++        spawnCategoryForChunk(category, level, chunk, filter, callback, maxSpawns, trackEntity, level.chunkSource.getGenerator()); // Leaf - optimize mob spawning
+     }
+     public static int spawnCategoryForChunk(
+-        MobCategory category, ServerLevel level, LevelChunk chunk, NaturalSpawner.SpawnPredicate filter, NaturalSpawner.AfterSpawnCallback callback, final int maxSpawns, final Consumer<Entity> trackEntity, final boolean nothing
++        MobCategory category, ServerLevel level, LevelChunk chunk, NaturalSpawner.SpawnPredicate filter, NaturalSpawner.AfterSpawnCallback callback, final int maxSpawns, final Consumer<Entity> trackEntity, final ChunkGenerator generator // Leaf - optimize mob spawning - cache ChunkGenerator
          // Paper PR end - throttle failed spawn attempts
      ) {
-+        // Leaf start - optimize mob spawning
-+        if (!(chunk instanceof LevelChunk levelChunk)) {
-+            // unreachable
-+            return 0;
-+        }
-+        // Leaf end - optimize mob spawning
          // Paper end - Optional per player mob spawns
-         StructureManager structureManager = level.structureManager();
-         ChunkGenerator generator = level.getChunkSource().getGenerator();
-         int y = pos.getY();
+         BlockPos randomPosWithin = getRandomPosWithin(level, chunk);
+         if (randomPosWithin.getY() >= level.getMinY() + 1) {
+-            return spawnCategoryForPosition(category, level, chunk, randomPosWithin, filter, callback, maxSpawns, trackEntity, false); // Paper - Optional per player mob spawns // Paper PR - throttle failed spawn attempts
++            return spawnCategoryForPosition(category, level, chunk, randomPosWithin, filter, callback, maxSpawns, trackEntity, generator); // Paper - Optional per player mob spawns // Paper PR - throttle failed spawn attempts // Leaf - optimize mob spawning - cache ChunkGenerator
+         }
+ 
+         return 0; // Paper PR - throttle failed spawn attempts
+@@ -259,55 +322,89 @@ public final class NaturalSpawner {
+         MobCategory category, ServerLevel level, ChunkAccess chunk, BlockPos pos, NaturalSpawner.SpawnPredicate filter, NaturalSpawner.AfterSpawnCallback callback, final int maxSpawns, final @Nullable Consumer<Entity> trackEntity
+         // Paper PR start - throttle failed spawn attempts
+     ) {
+-        spawnCategoryForPosition(category, level, chunk, pos, filter, callback, maxSpawns, trackEntity, false);
++        if (chunk instanceof LevelChunk levelChunk) { spawnCategoryForPosition(category, level, levelChunk, pos, filter, callback, maxSpawns, trackEntity, level.chunkSource.getGenerator()); } // Leaf - optimize mob spawning - cache ChunkGenerator
+     }
+     public static int spawnCategoryForPosition(
+-        MobCategory category, ServerLevel level, ChunkAccess chunk, BlockPos pos, NaturalSpawner.SpawnPredicate filter, NaturalSpawner.AfterSpawnCallback callback, final int maxSpawns, final @Nullable Consumer<Entity> trackEntity, final boolean nothing
++        MobCategory category, ServerLevel level, LevelChunk chunk, BlockPos pos, NaturalSpawner.SpawnPredicate filter, NaturalSpawner.AfterSpawnCallback callback, final int maxSpawns, @Nullable final Consumer<Entity> trackEntity, final ChunkGenerator generator // Leaf - optimize mob spawning - cache ChunkGenerator
+         // Paper PR end - throttle failed spawn attempts
+     ) {
+         // Paper end - Optional per player mob spawns
 +        // Leaf start - optimize mob spawning
++        // ChunkGenerator generator = level.getChunkSource().getGenerator(); // cache ChunkGenerator
+         StructureManager structureManager = level.structureManager();
+-        ChunkGenerator generator = level.getChunkSource().getGenerator();
+         int y = pos.getY();
 +        int posX = pos.getX();
 +        int posZ = pos.getZ();
          int i = 0; // Paper PR - throttle failed spawn attempts
 -        BlockState blockState = level.getBlockStateIfLoadedAndInBounds(pos); // Paper - don't load chunks for mob spawn
-+        BlockState blockState = level.getWorldBorder().isWithinBounds(pos) ? (ChunkPos.asLong(pos) == levelChunk.getPos().longKey ? levelChunk.getBlockStateFinal(posX, y, posZ) : level.getBlockStateIfLoaded(pos)) : null; // Paper - don't load chunks for mob spawn // Leaf
++        BlockState blockState = ChunkPos.asLong(pos) == chunk.coordinateKey ? chunk.getBlockStateFinal(posX, y, posZ) : level.getBlockStateIfLoadedAndInBounds(pos); // Paper - don't load chunks for mob spawn
++        // Leaf end - optimize mob spawning
          if (blockState != null && !blockState.isRedstoneConductor(chunk, pos)) { // Paper - don't load chunks for mob spawn
              BlockPos.MutableBlockPos mutableBlockPos = new BlockPos.MutableBlockPos();
              //int i = 0; // Paper PR - throttle failed spawn attempts - move up
  
-+            // 3 * (2 + 3 * [1, 4] * 4)
++            // Leaf start - optimize mob spawning
 +            long rand = level.random.nextLong();
 +            int bits = 0;
              for (int i1 = 0; i1 < 3; i1++) {
 -                int x = pos.getX();
 -                int z = pos.getZ();
 -                int i2 = 6;
-+                int x = posX;
-+                int z = posZ;
-+                //int i2 = 6;
-                 MobSpawnSettings.SpawnerData spawnerData = null;
-                 SpawnGroupData spawnGroupData = null;
+-                MobSpawnSettings.SpawnerData spawnerData = null;
+-                SpawnGroupData spawnGroupData = null;
 -                int ceil = Mth.ceil(level.random.nextFloat() * 4.0F);
++                //int i2 = 6;
 +                //int ceil = Mth.ceil(level.random.nextFloat() * 4.0F);
 +                int ceil = (int) (((rand >>> bits) & 0x3L) + 1);
 +                bits += 2;
@@ -328,9 +448,14 @@ index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75db
 +                }
                  int i3 = 0;
  
++                int x = posX;
++                int z = posZ;
++                MobSpawnSettings.SpawnerData spawnerData = null;
++                SpawnGroupData spawnGroupData = null;
                  for (int i4 = 0; i4 < ceil; i4++) {
 -                    x += level.random.nextInt(6) - level.random.nextInt(6);
 -                    z += level.random.nextInt(6) - level.random.nextInt(6);
+-                    mutableBlockPos.set(x, y, z);
 +                    int rand1=0,rand2=0,rand3=0,rand4=0,valuesNeeded=4;
 +                    while (valuesNeeded > 0) {
 +                        // [0, 61] 3 remains
@@ -341,7 +466,7 @@ index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75db
 +                                case 1 -> rand4 = threeBits;
 +                                case 2 -> rand3 = threeBits;
 +                                case 3 -> rand2 = threeBits;
-+                                case 4 -> rand1 = threeBits;
++                                default -> rand1 = threeBits;
 +                            }
 +                            valuesNeeded--;
 +                        }
@@ -354,37 +479,70 @@ index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75db
 +                    z += rand3 - rand4;
 +                    // x += level.random.nextInt(6) - level.random.nextInt(6);
 +                    // z += level.random.nextInt(6) - level.random.nextInt(6);
-+                    // Leaf end - optimize mob spawning
-                     mutableBlockPos.set(x, y, z);
                      double d = x + 0.5;
                      double d1 = z + 0.5;
-@@ -295,8 +398,8 @@ public final class NaturalSpawner {
-                         double d2 = nearestPlayer.distanceToSqr(d, y, d1);
-                         if (level.isLoadedAndInBounds(mutableBlockPos) && isRightDistanceToPlayerAndSpawnPoint(level, chunk, mutableBlockPos, d2)) { // Paper - don't load chunks for mob spawn
+-                    Player nearestPlayer = level.getNearestPlayer(d, y, d1, -1.0, level.purpurConfig.mobSpawningIgnoreCreativePlayers); // Purpur - mob spawning option to ignore creative players
+-                    if (nearestPlayer != null) {
+-                        double d2 = nearestPlayer.distanceToSqr(d, y, d1);
+-                        if (level.isLoadedAndInBounds(mutableBlockPos) && isRightDistanceToPlayerAndSpawnPoint(level, chunk, mutableBlockPos, d2)) { // Paper - don't load chunks for mob spawn
++                    double d2 = level.natureSpawnChunkMap.nearest(d, y, d1); // Purpur - mob spawning option to ignore creative players
++                    if (d2 != Double.POSITIVE_INFINITY) {
++                        if (leaf$isRightDistanceToPlayerAndSpawnPoint(level, chunk, x, y, z, d2)) { // Paper - don't load chunks for mob spawn
++                            mutableBlockPos.set(x, y, z);
                              if (spawnerData == null) {
 -                                Optional<MobSpawnSettings.SpawnerData> randomSpawnMobAt = getRandomSpawnMobAt(
 -                                    level, structureManager, generator, category, level.random, mutableBlockPos
-+                                Optional<MobSpawnSettings.SpawnerData> randomSpawnMobAt = getRandomSpawnMobAtWithChunk( // Leaf - optimize mob spawning
-+                                    level, structureManager, generator, category, level.random, mutableBlockPos, levelChunk // Leaf - optimize mob spawning
++                                MobSpawnSettings.SpawnerData randomSpawnMobAt = getRandomSpawnMobAt(
++                                    level, structureManager, generator, category, level.random, mutableBlockPos, chunk
                                  );
-                                 if (randomSpawnMobAt.isEmpty()) {
+-                                if (randomSpawnMobAt.isEmpty()) {
++                                if (randomSpawnMobAt == null) {
                                      break;
-@@ -307,7 +410,7 @@ public final class NaturalSpawner {
+                                 }
+ 
+-                                spawnerData = randomSpawnMobAt.get();
++                                spawnerData = randomSpawnMobAt;
+                                 ceil = spawnerData.minCount() + level.random.nextInt(1 + spawnerData.maxCount() - spawnerData.minCount());
                              }
++            // Leaf end - optimize mob spawning
  
                              // Paper start - PreCreatureSpawnEvent
 -                            PreSpawnStatus doSpawning = isValidSpawnPostitionForType(level, category, structureManager, generator, spawnerData, mutableBlockPos, d2);
-+                            PreSpawnStatus doSpawning = isValidSpawnPostitionForTypeWithChunk(level, category, structureManager, generator, spawnerData, mutableBlockPos, d2, levelChunk); // Leaf
++                            PreSpawnStatus doSpawning = isValidSpawnPostitionForType(level, category, structureManager, generator, spawnerData, mutableBlockPos, d2, chunk); // Leaf - optimize mob spawning
                              // Paper start - per player mob count backoff
                              if (doSpawning == PreSpawnStatus.ABORT || doSpawning == PreSpawnStatus.CANCELLED) {
                                  level.getChunkSource().chunkMap.updateFailurePlayerMobTypeMap(mutableBlockPos.getX() >> 4, mutableBlockPos.getZ() >> 4, category);
-@@ -414,6 +517,44 @@ public final class NaturalSpawner {
-             && level.noCollision(entityType.getSpawnAABB(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5));
-         return success ? PreSpawnStatus.SUCCESS : PreSpawnStatus.FAIL; // Paper - PreCreatureSpawnEvent
+@@ -372,6 +469,22 @@ public final class NaturalSpawner {
+         }
      }
+ 
 +    // Leaf start - optimize mob spawning
-+    private static PreSpawnStatus isValidSpawnPostitionForTypeWithChunk(
-+        // Paper end - PreCreatureSpawnEvent
++    private static boolean leaf$isRightDistanceToPlayerAndSpawnPoint(ServerLevel level, ChunkAccess chunk, int x, int y, int z, double distance) {
++        if (distance <= 576.0 || distance == 16384.0) {
++            return false;
++        } else if (level.getSharedSpawnPos().distToCenterSqr(x + 0.5, y, z + 0.5) < 576.0) {
++            return false;
++        } else if (ChunkPos.asLong(x >> 4, z >> 4) == chunk.coordinateKey) {
++            return true;
++        } else if (level.getWorldBorder().isWithinBounds(new ChunkPos(x >> 4, z >> 4))) {
++            return level.chunkSource.getChunkAtIfLoadedImmediately(x >> 4, z >> 4).moonrise$getChunkHolder().isEntityTickingReady();
++        } else {
++            return false;
++        }
++    }
++    // Leaf end - optimize mob spawning
++
+     // Paper start - PreCreatureSpawnEvent
+     private enum PreSpawnStatus {
+         FAIL,
+@@ -389,6 +502,20 @@ public final class NaturalSpawner {
+         BlockPos.MutableBlockPos pos,
+         double distance
+     ) {
++    // Leaf start - optimize mob spawning
++        return isValidSpawnPostitionForType(level, category, structureManager, generator, data, pos, distance, level.getChunk(pos.getX() >> 4, pos.getZ() >> 4));
++    }
++    private static PreSpawnStatus isValidSpawnPostitionForType(
 +        ServerLevel level,
 +        MobCategory category,
 +        StructureManager structureManager,
@@ -394,62 +552,46 @@ index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75db
 +        double distance,
 +        LevelChunk chunk
 +    ) {
-+        EntityType<?> entityType = data.type();
-+        // Paper start - PreCreatureSpawnEvent
-+        com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
-+            org.bukkit.craftbukkit.util.CraftLocation.toBukkit(pos, level),
-+            org.bukkit.craftbukkit.entity.CraftEntityType.minecraftToBukkit(entityType), org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.NATURAL
-+        );
-+        if (!event.callEvent()) {
-+            if (event.shouldAbortSpawn()) {
-+                return PreSpawnStatus.ABORT;
-+            }
-+            return PreSpawnStatus.CANCELLED;
-+        }
-+        final boolean success = entityType.getCategory() != MobCategory.MISC
-+            // Paper end - PreCreatureSpawnEvent
-+            && (
-+            entityType.canSpawnFarFromPlayer()
-+                || !(distance > entityType.getCategory().getDespawnDistance() * entityType.getCategory().getDespawnDistance())
-+        )
-+            && entityType.canSummon()
-+            && mobsAtWithChunk(level, structureManager, generator, category, pos, null, chunk).contains(data)
-+            && SpawnPlacements.isSpawnPositionOk(entityType, level, pos)
-+            && SpawnPlacements.checkSpawnRules(entityType, level, EntitySpawnReason.NATURAL, pos, level.random)
-+            && level.noCollision(entityType.getSpawnAABB(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5));
-+        return success ? PreSpawnStatus.SUCCESS : PreSpawnStatus.FAIL; // Paper - PreCreatureSpawnEvent
-+    }
 +    // Leaf end - optimize mob spawning
- 
-     @Nullable
-     private static Mob getMobForSpawn(ServerLevel level, EntityType<?> entityType) {
-@@ -449,6 +590,17 @@ public final class NaturalSpawner {
+         EntityType<?> entityType = data.type();
+         // Paper start - PreCreatureSpawnEvent
+         com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
+@@ -408,7 +535,7 @@ public final class NaturalSpawner {
+                     || !(distance > entityType.getCategory().getDespawnDistance() * entityType.getCategory().getDespawnDistance())
+             )
+             && entityType.canSummon()
+-            && canSpawnMobAt(level, structureManager, generator, category, data, pos)
++            && mobsAt(level, structureManager, generator, category, pos, null, chunk).contains(data) // Leaf - optimize mob spawning
+             && SpawnPlacements.isSpawnPositionOk(entityType, level, pos)
+             && SpawnPlacements.checkSpawnRules(entityType, level, EntitySpawnReason.NATURAL, pos, level.random)
+             && level.noCollision(entityType.getSpawnAABB(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5));
+@@ -449,6 +576,17 @@ public final class NaturalSpawner {
              : mobsAt(level, structureManager, generator, category, pos, biome).getRandom(random);
      }
  
 +    // Leaf start - optimize mob spawning
-+    private static Optional<MobSpawnSettings.SpawnerData> getRandomSpawnMobAtWithChunk(
++    private static MobSpawnSettings.SpawnerData getRandomSpawnMobAt(
 +        ServerLevel level, StructureManager structureManager, ChunkGenerator generator, MobCategory category, RandomSource random, BlockPos pos, LevelChunk chunk
 +    ) {
 +        Holder<Biome> biome = org.dreeam.leaf.config.modules.opt.OptimizeBiome.mobSpawn ? level.getBiomeCached(chunk, pos) : level.getBiome(pos); // Leaf - cache getBiome
 +        return category == MobCategory.WATER_AMBIENT && biome.is(BiomeTags.REDUCED_WATER_AMBIENT_SPAWNS) && random.nextFloat() < 0.98F
-+            ? Optional.empty()
-+            : mobsAtWithChunk(level, structureManager, generator, category, pos, biome, chunk).getRandom(random);
++            ? null
++            : mobsAt(level, structureManager, generator, category, pos, biome, chunk).getRandomNullable(random);
 +    }
 +    // Leaf end - optimize mob spawning
 +
      private static boolean canSpawnMobAt(
          ServerLevel level, StructureManager structureManager, ChunkGenerator generator, MobCategory category, MobSpawnSettings.SpawnerData data, BlockPos pos
      ) {
-@@ -463,8 +615,22 @@ public final class NaturalSpawner {
+@@ -463,8 +601,22 @@ public final class NaturalSpawner {
              : generator.getMobsAt(biome != null ? biome : (org.dreeam.leaf.config.modules.opt.OptimizeBiome.mobSpawn ? level.getBiomeCached(null, pos) : level.getBiome(pos)), structureManager, cetagory, pos); // Leaf - cache getBiome
      }
  
 +    // Leaf start - optimize mob spawning
-+    private static WeightedList<MobSpawnSettings.SpawnerData> mobsAtWithChunk(
++    private static WeightedList<MobSpawnSettings.SpawnerData> mobsAt(
 +        ServerLevel level, StructureManager structureManager, ChunkGenerator generator, MobCategory cetagory, BlockPos pos, @Nullable Holder<Biome> biome, LevelChunk chunk
 +    ) {
-+        return isInNetherFortressBoundsChunk(pos, level, cetagory, structureManager, chunk)
++        return isInNetherFortressBounds(pos, level, cetagory, structureManager, chunk)
 +            ? NetherFortressStructure.FORTRESS_ENEMIES
 +            : generator.getMobsAtChunk(biome != null ? biome : (org.dreeam.leaf.config.modules.opt.OptimizeBiome.mobSpawn ? level.getBiomeCached(chunk, pos) : level.getBiome(pos)), structureManager, cetagory, pos, chunk); // Leaf - cache getBiome
 +    }
@@ -465,14 +607,14 @@ index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75db
              Structure structure = structureManager.registryAccess().lookupOrThrow(Registries.STRUCTURE).getValue(BuiltinStructures.FORTRESS);
              return structure != null && structureManager.getStructureAt(pos, structure).isValid();
          } else {
-@@ -472,6 +638,19 @@ public final class NaturalSpawner {
+@@ -472,6 +624,19 @@ public final class NaturalSpawner {
          }
      }
  
 +    // Leaf start - optimize mob spawning
-+    public static boolean isInNetherFortressBoundsChunk(BlockPos pos, ServerLevel level, MobCategory category, StructureManager structureManager, LevelChunk chunk) {
++    public static boolean isInNetherFortressBounds(BlockPos pos, ServerLevel level, MobCategory category, StructureManager structureManager, LevelChunk chunk) {
 +        if (category == MobCategory.MONSTER) {
-+            @Nullable BlockState blockState = chunk.getPos().longKey == ChunkPos.asLong(pos) ? chunk.getBlockStateFinal(pos.getX(), pos.getY() - 1, pos.getZ()) : level.getBlockStateIfLoaded(pos.below());
++            BlockState blockState = chunk.coordinateKey == ChunkPos.asLong(pos) ? chunk.getBlockStateFinal(pos.getX(), pos.getY() - 1, pos.getZ()) : level.getBlockStateIfLoaded(pos.below());
 +            if (blockState == null || !blockState.is(Blocks.NETHER_BRICKS)) return false;
 +            Structure structure = structureManager.registryAccess().lookupOrThrow(Registries.STRUCTURE).getValue(BuiltinStructures.FORTRESS);
 +            return structure != null && structureManager.getStructureAt(pos, structure).isValid();
@@ -485,30 +627,42 @@ index bb655318f49242858e2c25d5469705c0c314ed85..a015f0bbff3bb58fd4d28c59620f75db
      private static BlockPos getRandomPosWithin(Level level, LevelChunk chunk) {
          ChunkPos pos = chunk.getPos();
          int i = pos.getMinBlockX() + level.random.nextInt(16);
-@@ -612,18 +791,21 @@ public final class NaturalSpawner {
+@@ -612,6 +777,7 @@ public final class NaturalSpawner {
          @Nullable
          private EntityType<?> lastCheckedType;
          private double lastCharge;
-+        public final it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<int[]> chunkCap; // Leaf - optimize mob spawning
++        private final it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<int[]> chunkCap; // Leaf - optimize mob spawning
  
          SpawnState(
              int spawnableChunkCount,
-             Object2IntOpenHashMap<MobCategory> mobCategoryCounts,
-             PotentialCalculator spawnPotential,
--            LocalMobCapCalculator localMobCapCalculator
-+            LocalMobCapCalculator localMobCapCalculator,
-+            it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<int[]> playerCap // Leaf - optimize mob spawning
-         ) {
-             this.spawnableChunkCount = spawnableChunkCount;
-             this.mobCategoryCounts = mobCategoryCounts;
+@@ -624,8 +790,26 @@ public final class NaturalSpawner {
              this.spawnPotential = spawnPotential;
              this.localMobCapCalculator = localMobCapCalculator;
              this.unmodifiableMobCategoryCounts = Object2IntMaps.unmodifiable(mobCategoryCounts);
-+            this.chunkCap = playerCap; // Leaf - optimize mob spawning
++            this.chunkCap = new it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<>(); // Leaf - optimize mob spawning
          }
  
++        // Leaf start - optimize mob spawning
++        SpawnState(
++            int spawnableChunkCount,
++            Object2IntOpenHashMap<MobCategory> mobCategoryCounts,
++            PotentialCalculator spawnPotential,
++            LocalMobCapCalculator localMobCapCalculator,
++            it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<int[]> playerCap
++        ) {
++            this.spawnableChunkCount = spawnableChunkCount;
++            this.mobCategoryCounts = mobCategoryCounts;
++            this.spawnPotential = spawnPotential;
++            this.localMobCapCalculator = localMobCapCalculator;
++            this.unmodifiableMobCategoryCounts = Object2IntMaps.unmodifiable(mobCategoryCounts);
++            this.chunkCap = playerCap; // Leaf - optimize mob spawning
++        }
++        // Leaf end - optimize mob spawning
++
          private boolean canSpawn(EntityType<?> entityType, BlockPos pos, ChunkAccess chunk) {
-@@ -680,5 +862,32 @@ public final class NaturalSpawner {
+             this.lastCheckedPos = pos;
+             this.lastCheckedType = entityType;
+@@ -680,5 +864,32 @@ public final class NaturalSpawner {
          boolean canSpawnForCategoryLocal(MobCategory category, ChunkPos chunkPos) {
              return this.localMobCapCalculator.canSpawn(category, chunkPos);
          }
@@ -579,8 +733,21 @@ index db3b8a237d63255aa9ffd70c88a093002a6bd770..4a69f404eee00d8972e9501a76031d43
          this.mobSpawnCosts = ImmutableMap.copyOf(mobSpawnCosts);
      }
  
+diff --git a/net/minecraft/world/level/chunk/ChunkAccess.java b/net/minecraft/world/level/chunk/ChunkAccess.java
+index 7fc5e56586f2fe8ea1a7437b42da893383878880..529cbf81384c4b1da2366fea26f66d94d9a71118 100644
+--- a/net/minecraft/world/level/chunk/ChunkAccess.java
++++ b/net/minecraft/world/level/chunk/ChunkAccess.java
+@@ -92,7 +92,7 @@ public abstract class ChunkAccess implements BiomeManager.NoiseBiomeSource, Ligh
+     private boolean slimeChunk;
+     private boolean hasComputedSlimeChunk;
+     // Leaf end - Matter - Secure Seed
+-    public final long[] failedSpawnAttempts = new long[net.minecraft.world.entity.MobCategory.values().length]; // Paper PR - throttle failed spawn attempts
++    public final long[] failedSpawnAttempts = new long[net.minecraft.server.level.ServerPlayer.MOBCATEGORY_TOTAL_ENUMS]; // Paper PR - throttle failed spawn attempts // Leaf - optimize mob spawning
+ 
+     // Paper start - rewrite chunk system
+     private volatile ca.spottedleaf.moonrise.patches.starlight.light.SWMRNibbleArray[] blockNibbles;
 diff --git a/net/minecraft/world/level/chunk/ChunkGenerator.java b/net/minecraft/world/level/chunk/ChunkGenerator.java
-index fb77cd58542c1a690cbeaa6ed3a4d657de6e619d..e0267e84c8fd2267b047590d712728e963d165f2 100644
+index fb77cd58542c1a690cbeaa6ed3a4d657de6e619d..bd0278c9c1466291eb65d37afc90096f5abcbd56 100644
 --- a/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/net/minecraft/world/level/chunk/ChunkGenerator.java
 @@ -516,6 +516,35 @@ public abstract class ChunkGenerator {
@@ -589,9 +756,9 @@ index fb77cd58542c1a690cbeaa6ed3a4d657de6e619d..e0267e84c8fd2267b047590d712728e9
  
 +    // Leaf start - optimize mob spawning
 +    public WeightedList<MobSpawnSettings.SpawnerData> getMobsAtChunk(Holder<Biome> biome, StructureManager structureManager, MobCategory category, BlockPos pos, ChunkAccess chunk) {
-+        Map<Structure, LongSet> allStructuresAt = ChunkPos.asLong(pos) == chunk.getPos().longKey ? structureManager.getAllStructuresAtChunk(chunk) : structureManager.getAllStructuresAt(pos);
++        Map<Structure, LongSet> allStructuresAt = ChunkPos.asLong(pos) == chunk.coordinateKey ? structureManager.getAllStructuresAtChunk(chunk) : structureManager.getAllStructuresAt(pos);
 +
-+        for (Entry<Structure, LongSet> entry : allStructuresAt.entrySet()) {
++        if (!allStructuresAt.isEmpty()) for (Entry<Structure, LongSet> entry : allStructuresAt.entrySet()) {
 +            Structure structure = entry.getKey();
 +            StructureSpawnOverride structureSpawnOverride = structure.spawnOverrides().get(category);
 +            if (structureSpawnOverride != null) {

--- a/leaf-server/minecraft-patches/features/0245-optimize-mob-spawning.patch
+++ b/leaf-server/minecraft-patches/features/0245-optimize-mob-spawning.patch
@@ -30,7 +30,7 @@ index 5c369b3d94e369c3f240821ad90b9d96223f24ca..9803c395fce103cb7bc746f43a017ff9
       }
      // Paper end - Optional per player mob spawns
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..f0d4b7414030f99a2ef0e257d531bf4634bdc724 100644
+index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..ed267cb678206e3ced43e1aafbac203ff87bee74 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
 @@ -70,11 +70,11 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
@@ -133,8 +133,8 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..f0d4b7414030f99a2ef0e257d531bf46
 -            } // Pufferfish - (endif) moved down when async processing
 +            // Leaf start - optimize mob spawning
 +            if (!org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled) {
-+                state.set(2);
 +                lastSpawnState = NaturalSpawner.createState(naturalSpawnChunkCount, this.level.getAllEntities(), this::getFullChunk, null, true); // Pufferfish - async mob spawning
++                state.set(2);
 +            }
 +            // Leaf end - optimize mob spawning
          } else {
@@ -142,8 +142,8 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..f0d4b7414030f99a2ef0e257d531bf46
 -            lastSpawnState = NaturalSpawner.createState(naturalSpawnChunkCount, this.level.getAllEntities(), this::getFullChunk, !this.level.paperConfig().entities.spawning.perPlayerMobSpawns ? new LocalMobCapCalculator(this.chunkMap) : null, false);
 -            _pufferfish_spawnCountsReady.set(true);
 -            // Pufferfish end
-+            state.set(2); // Leaf - optimize mob spawning
 +            lastSpawnState = NaturalSpawner.createState(naturalSpawnChunkCount, this.level.getAllEntities(), this::getFullChunk, !this.level.paperConfig().entities.spawning.perPlayerMobSpawns ? new LocalMobCapCalculator(this.chunkMap) : null, false); // Leaf - optimize mob spawning
++            state.set(2); // Leaf - optimize mob spawning
          }
          // Paper end - Optional per player mob spawns
          //this.lastSpawnState = spawnState; // Pufferfish - this is managed asynchronously
@@ -154,7 +154,7 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..f0d4b7414030f99a2ef0e257d531bf46
          if (_boolean && (this.spawnEnemies || this.spawnFriendlies)) {
              // Paper start - PlayerNaturallySpawnCreaturesEvent
              for (ServerPlayer entityPlayer : this.level.players()) {
-@@ -611,27 +565,61 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -611,27 +565,62 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
                  chunkRange = Math.min(chunkRange, 8);
                  entityPlayer.playerNaturallySpawnedEvent = new com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent(entityPlayer.getBukkitEntity(), (byte) chunkRange);
                  entityPlayer.playerNaturallySpawnedEvent.callEvent();
@@ -187,22 +187,22 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..f0d4b7414030f99a2ef0e257d531bf46
 +            boolean enqueue = org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled
 +                && (this.spawnFriendlies || this.spawnEnemies)
 +                && this.level.paperConfig().entities.spawning.perPlayerMobSpawns;
-+            if (!enqueue || state.compareAndSet(2, 0)) {
-+                NaturalSpawner.SpawnState currentState = lastSpawnState;
-+                lastSpawnState = null;
-+                if (currentState != null) {
-+                    currentState.applyPerPlayerMobCount(this.level);
++            boolean cas = state.compareAndSet(2, 0);
++            if (!enqueue || cas) {
++                NaturalSpawner.SpawnState spawnState = cas ? lastSpawnState : null;
++                if (spawnState != null) {
++                    spawnState.applyPerPlayerMobCount(this.level);
 +                }
-+                MobCategory[] categories = currentState == null ? EMPTY_MOB_CATEGORIES : filteredSpawningCategories;
++                MobCategory[] categories = spawnState == null ? EMPTY_MOB_CATEGORIES : filteredSpawningCategories;
 +                ChunkGenerator generator = this.getGenerator();
 +                if (list instanceof it.unimi.dsi.fastutil.objects.ReferenceArrayList<LevelChunk> list1) {
 +                    LevelChunk[] raw = list1.elements();
 +                    for (int i = 0, j = list1.size(); i < j; i++) {
-+                        this.tickSpawningChunk(raw[i], timeInhabited, categories, currentState, generator);
++                        this.tickSpawningChunk(raw[i], timeInhabited, categories, spawnState, generator);
 +                    }
 +                } else {
 +                    for (LevelChunk levelChunk : list) {
-+                        this.tickSpawningChunk(levelChunk, timeInhabited, categories, currentState, generator);
++                        this.tickSpawningChunk(levelChunk, timeInhabited, categories, spawnState, generator);
 +                    }
 +                }
              }
@@ -212,7 +212,8 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..f0d4b7414030f99a2ef0e257d531bf46
 +                Iterable<Entity> entities = this.level.getAllEntities();
 +                level.getServer().mobSpawnExecutor.submit(() -> {
 +                    NaturalSpawner.SpawnState newState = NaturalSpawner.createStateAsync(mapped, entities, level);
-+                    ServerChunkCache.this.lastSpawnState = !state.compareAndSet(1, 2) ? null : newState;
++                    ServerChunkCache.this.lastSpawnState = state.get() != 1 ? null : newState;
++                    state.set(2);
 +                });
 +            }
 +            // Leaf end - optimize mob spawning
@@ -221,7 +222,7 @@ index 3a6c894178829cec8daa08ea9f0294f7f39a8efe..f0d4b7414030f99a2ef0e257d531bf46
              list.clear();
          }
  
-@@ -641,16 +629,21 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -641,16 +630,21 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
          }
      }
  

--- a/leaf-server/minecraft-patches/features/0252-optimize-random-tick.patch
+++ b/leaf-server/minecraft-patches/features/0252-optimize-random-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] optimize random tick
 
 
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index 2721b999dcfcf1cd5a0919221f2d94da4c93a6e7..2a1a6a0306b781e9ae5c0e3261cb740f37be4a8c 100644
+index f0d4b7414030f99a2ef0e257d531bf4634bdc724..85e943ceb5a5bc6856ead4593922628250c5e07a 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
-@@ -664,7 +664,13 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -623,7 +623,13 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
              list.clear();
          }
  

--- a/leaf-server/minecraft-patches/features/0252-optimize-random-tick.patch
+++ b/leaf-server/minecraft-patches/features/0252-optimize-random-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] optimize random tick
 
 
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index f0d4b7414030f99a2ef0e257d531bf4634bdc724..85e943ceb5a5bc6856ead4593922628250c5e07a 100644
+index ed267cb678206e3ced43e1aafbac203ff87bee74..d2b6689744b49574d504eeb1495c2b7b8e658c12 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
-@@ -623,7 +623,13 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -624,7 +624,13 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
              list.clear();
          }
  

--- a/leaf-server/minecraft-patches/features/0258-Paw-optimization.patch
+++ b/leaf-server/minecraft-patches/features/0258-Paw-optimization.patch
@@ -100,11 +100,11 @@ index 4535858701b2bb232b9d2feb2af6551526232ddc..e65c62dbe4c1560ae153e4c4344e9194
 -    // Paper end - detailed watchdog information
  }
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index 2a1a6a0306b781e9ae5c0e3261cb740f37be4a8c..7e84b94a4602801e8cc713b28d0d93052589fd5e 100644
+index 85e943ceb5a5bc6856ead4593922628250c5e07a..f438622d05724d02ce2d80c0a3b4c4d53fc0e31e 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
-@@ -638,8 +638,10 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
-             this.level.natureSpawnChunkMap.build();
+@@ -582,8 +582,10 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+             this.level.natureSpawnChunkMap.build(this.level);
              this.level.natureSpawnChunkMap.collectSpawningChunks(this.level.moonrise$getPlayerTickingChunks(), list);
              // Paper start - chunk tick iteration optimisation
 -            this.shuffleRandom.setSeed(this.level.random.nextLong());
@@ -115,7 +115,7 @@ index 2a1a6a0306b781e9ae5c0e3261cb740f37be4a8c..7e84b94a4602801e8cc713b28d0d9305
 +            }
              // Paper end - chunk tick iteration optimisation
  
-             if (!org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled || _pufferfish_spawnCountsReady.get()) {
+             boolean enqueue = org.dreeam.leaf.config.modules.async.AsyncMobSpawning.enabled
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
 index 88a3f390f615275c84237814e10c969bfe3c6a55..0ad594fe2548cf1c00f8d75fe076d62c3c99f393 100644
 --- a/net/minecraft/server/level/ServerLevel.java
@@ -149,7 +149,7 @@ index 88a3f390f615275c84237814e10c969bfe3c6a55..0ad594fe2548cf1c00f8d75fe076d62c
  
      private void tickPassenger(Entity ridingEntity, Entity passengerEntity, final boolean isActive) { // Paper - EAR 2
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 78ffbd45413f552042e8ec77df4e8d896ae5bec1..f3c0b29d50a001029f0275319b87b75a3ff0bca5 100644
+index 3451d87dff393be541da7ec3cb126c7abd49cd49..94c45a5d3f54ba216a19a5e61a1a8fbac945d4a5 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -1138,16 +1138,6 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess

--- a/leaf-server/minecraft-patches/features/0274-Skip-PreCreatureSpawnEvent-if-no-listeners.patch
+++ b/leaf-server/minecraft-patches/features/0274-Skip-PreCreatureSpawnEvent-if-no-listeners.patch
@@ -5,21 +5,15 @@ Subject: [PATCH] Skip PreCreatureSpawnEvent if no listeners
 
 
 diff --git a/net/minecraft/world/level/NaturalSpawner.java b/net/minecraft/world/level/NaturalSpawner.java
-index 388a22d4ce37f1471fb906118d9e2135d7789834..12731a0026531e33f28ce4b3ba1e690e2fc0b119 100644
+index 4a20e24324ad031a9fe9c6ad23df773d7c245eb9..ce0ee7bb5d10d7095e4201ef98c8874e50488cd3 100644
 --- a/net/minecraft/world/level/NaturalSpawner.java
 +++ b/net/minecraft/world/level/NaturalSpawner.java
-@@ -541,17 +541,35 @@ public final class NaturalSpawner {
-         LevelChunk chunk
+@@ -528,17 +528,35 @@ public final class NaturalSpawner {
      ) {
+     // Leaf end - optimize mob spawning
          EntityType<?> entityType = data.type();
 -        // Paper start - PreCreatureSpawnEvent
 -        com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
--            org.bukkit.craftbukkit.util.CraftLocation.toBukkit(pos, level),
--            org.bukkit.craftbukkit.entity.CraftEntityType.minecraftToBukkit(entityType), org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.NATURAL
--        );
--        if (!event.callEvent()) {
--            if (event.shouldAbortSpawn()) {
--                return PreSpawnStatus.ABORT;
 +
 +        // Leaf start - Skip PreCreatureSpawnEvent if no listeners
 +        boolean shouldAbort = false;
@@ -28,7 +22,12 @@ index 388a22d4ce37f1471fb906118d9e2135d7789834..12731a0026531e33f28ce4b3ba1e690e
 +        if (com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent.getHandlerList().getRegisteredListeners().length != 0) {
 +            // Paper start - PreCreatureSpawnEvent
 +            com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
-+                org.bukkit.craftbukkit.util.CraftLocation.toBukkit(pos, level),
+                 org.bukkit.craftbukkit.util.CraftLocation.toBukkit(pos, level),
+-                org.bukkit.craftbukkit.entity.CraftEntityType.minecraftToBukkit(entityType), org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.NATURAL
+-        );
+-        if (!event.callEvent()) {
+-            if (event.shouldAbortSpawn()) {
+-                return PreSpawnStatus.ABORT;
 +                org.bukkit.craftbukkit.entity.CraftEntityType.minecraftToBukkit(entityType),
 +                org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.NATURAL
 +            );
@@ -50,5 +49,5 @@ index 388a22d4ce37f1471fb906118d9e2135d7789834..12731a0026531e33f28ce4b3ba1e690e
 +        // Leaf end - Skip PreCreatureSpawnEvent if no listeners
 +
          final boolean success = entityType.getCategory() != MobCategory.MISC
-             // Paper end - PreCreatureSpawnEvent
+         // Paper end - PreCreatureSpawnEvent
              && (

--- a/leaf-server/src/main/java/org/dreeam/leaf/world/NatureSpawnChunkMap.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/world/NatureSpawnChunkMap.java
@@ -1,12 +1,15 @@
 package org.dreeam.leaf.world;
 
 import ca.spottedleaf.moonrise.common.list.ReferenceList;
+import ca.spottedleaf.moonrise.common.util.CoordinateUtils;
 import com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
+import org.dreeam.leaf.util.KDTree3D;
 
 import java.util.List;
 
@@ -14,7 +17,7 @@ public final class NatureSpawnChunkMap {
     /// breadth-first search
     ///
     /// 0 4 12 28 48 80 112 148 196
-    private static final long[][] TABLE_BFS = new long[][]{
+    private static final long[][] TABLE_BFS = {
         {0L},
         {0L, 4294967295L, -4294967296L, 4294967296L, 1L},
         {0L, -1L, 4294967295L, 8589934591L, -4294967296L, 4294967296L, -4294967295L, 1L, 4294967297L, 4294967294L, -8589934592L, 8589934592L, 2L},
@@ -32,6 +35,8 @@ public final class NatureSpawnChunkMap {
 
     private final LongArrayList[] centersByRadius;
     private final Long2LongOpenHashMap regionBitSets;
+    private final ObjectArrayList<ServerPlayer> players;
+    private final KDTree3D tree = new KDTree3D();
 
     public NatureSpawnChunkMap() {
         this.centersByRadius = new LongArrayList[SIZE_RADIUS];
@@ -39,6 +44,7 @@ public final class NatureSpawnChunkMap {
             this.centersByRadius[i] = new LongArrayList();
         }
         this.regionBitSets = new Long2LongOpenHashMap();
+        this.players = new ObjectArrayList<>();
     }
 
     public void clear() {
@@ -46,29 +52,56 @@ public final class NatureSpawnChunkMap {
             chunkPosition.clear();
         }
         this.regionBitSets.clear();
+        this.players.clear();
     }
 
     public void addPlayer(ServerPlayer player) {
         if (player.isSpectator()) {
             return;
         }
-        PlayerNaturallySpawnCreaturesEvent event = player.playerNaturallySpawnedEvent;
-        if (event == null || event.isCancelled()) {
-            return;
-        }
-        int range = event.getSpawnRadius();
-        if (range > MAX_RADIUS) {
-            range = MAX_RADIUS;
-        } else if (range < 0) {
-            return;
-        }
-        this.centersByRadius[range].add(player.chunkPosition().longKey);
+        players.add(player);
     }
 
-    public void build() {
+    public void build(ServerLevel world) {
+        for (ServerPlayer player : players) {
+            PlayerNaturallySpawnCreaturesEvent event = player.playerNaturallySpawnedEvent;
+            if (event == null || event.isCancelled()) {
+                continue;
+            }
+            int range = event.getSpawnRadius();
+            if (range > MAX_RADIUS) {
+                range = MAX_RADIUS;
+            } else if (range < 0) {
+                continue;
+            }
+            this.centersByRadius[range].add(player.chunkPosition().longKey);
+        }
         for (int index = 0; index < SIZE_RADIUS; index++) {
             buildBy(index);
         }
+
+        double[] pxl = new double[players.size()];
+        double[] pyl = new double[players.size()];
+        double[] pzl = new double[players.size()];
+        boolean ignoreCreativePlayers = world.purpurConfig.mobSpawningIgnoreCreativePlayers;
+        int i = 0;
+        for (final ServerPlayer p : players) {
+            if (!ignoreCreativePlayers || !p.isCreative()) {
+                pxl[i] = p.getX();
+                pyl[i] = p.getY();
+                pzl[i] = p.getZ();
+                i++;
+            }
+        }
+        final int[] indices = new int[i];
+        for (int j = 0; j < i; j++) {
+            indices[j] = j;
+        }
+        tree.build(new double[][]{pxl, pzl, pyl}, indices);
+    }
+
+    public double nearest(double x, double y, double z) {
+        return tree.nearestSqr(x, z, y, 16384.0);
     }
 
     private void buildBy(int index) {
@@ -78,36 +111,32 @@ public final class NatureSpawnChunkMap {
             return;
         }
         long[] centersRaw = list.elements();
-        long cachedKey = ChunkPos.asLong(ChunkPos.getX(centersRaw[0]) >> REGION_SHIFT, ChunkPos.getZ(centersRaw[0]) >> REGION_SHIFT);
+        long packed = centersRaw[0];
+        long cachedKey = CoordinateUtils.getChunkKey(CoordinateUtils.getChunkX(packed) >> REGION_SHIFT, CoordinateUtils.getChunkZ(packed) >> REGION_SHIFT);
         long cachedVal = this.regionBitSets.get(cachedKey);
         long[] offsets = TABLE_BFS[index];
         for (int i = 0; i < centersSize; i++) {
             long center = centersRaw[i];
-            int cx = ChunkPos.getX(center);
-            int cz = ChunkPos.getZ(center);
+            int cx = CoordinateUtils.getChunkX(center);
+            int cz = CoordinateUtils.getChunkZ(center);
 
             for (long packedOffset : offsets) {
-                int dx = ChunkPos.getX(packedOffset);
-                int dz = ChunkPos.getZ(packedOffset);
+                int dx = CoordinateUtils.getChunkX(packedOffset);
+                int dz = CoordinateUtils.getChunkZ(packedOffset);
                 int chunkX = cx + dx;
                 int chunkZ = cz + dz;
-
-                int regionX = chunkX >> REGION_SHIFT;
-                int regionZ = chunkZ >> REGION_SHIFT;
-                long regionKey = ChunkPos.asLong(regionX, regionZ);
-
-                int localX = chunkX & REGION_MASK;
-                int localZ = chunkZ & REGION_MASK;
-                int bitIndex = (localZ << REGION_SHIFT) | localX;
-                long bitMask = 1L << bitIndex;
-
+                long regionKey = CoordinateUtils.getChunkKey(chunkX >> REGION_SHIFT, chunkZ >> REGION_SHIFT);
                 if (regionKey != cachedKey) {
                     this.regionBitSets.put(cachedKey, cachedVal);
                     cachedKey = regionKey;
                     cachedVal = this.regionBitSets.get(regionKey);
                 }
 
-                cachedVal |= bitMask;
+                int localZ = chunkZ & REGION_MASK;
+                int localX = chunkX & REGION_MASK;
+                int bitIndex = (localZ << REGION_SHIFT) | localX;
+                long bit = 1L << bitIndex;
+                cachedVal |= bit;
             }
         }
 
@@ -116,7 +145,7 @@ public final class NatureSpawnChunkMap {
         }
     }
 
-    private int deduplicate(LongArrayList list) {
+    private static int deduplicate(LongArrayList list) {
         int n = list.size();
         if (n == 0) {
             return 0;
@@ -137,7 +166,9 @@ public final class NatureSpawnChunkMap {
 
     public void collectSpawningChunks(ReferenceList<LevelChunk> chunks, List<LevelChunk> out) {
         LevelChunk[] raw = chunks.getRawDataUnchecked();
-        for (int i = 0, length = chunks.size(); i < length; i++) {
+        int size = chunks.size();
+        java.util.Objects.checkFromToIndex(0, size, raw.length);
+        for (int i = 0; i < size; i++) {
             LevelChunk chunk = raw[i];
             if (contains(chunk.locX, chunk.locZ)) {
                 out.add(chunk);
@@ -145,10 +176,9 @@ public final class NatureSpawnChunkMap {
         }
     }
 
-    public boolean contains(int chunkX, int chunkZ) {
-        int regionX = chunkX >> REGION_SHIFT;
-        int regionZ = chunkZ >> REGION_SHIFT;
-        long bitset = this.regionBitSets.get(ChunkPos.asLong(regionX, regionZ));
-        return bitset != 0 && (bitset & (1L << (((chunkZ & REGION_MASK) << REGION_SHIFT) | (chunkX & REGION_MASK)))) != 0L;
+    private boolean contains(int chunkX, int chunkZ) {
+        long bitset = this.regionBitSets.get(CoordinateUtils.getChunkKey(chunkX >> REGION_SHIFT, chunkZ >> REGION_SHIFT));
+        int local = ((chunkZ & REGION_MASK) << REGION_SHIFT) | (chunkX & REGION_MASK);
+        return (bitset & (1L << local)) != 0L;
     }
 }


### PR DESCRIPTION
#479 #454

cache ChunkGenerator
some world generator plugin change the method

raw array iteration `List<MobCategory>` to `MobCategory[]`

avoid Optional (un)boxing in `getRandomSpawnMobAt`

fix some async mob spawning with per-player-spawn off

use KDTree to find nearest player