### PR TITLE
fix(replay): run ServerPhotographer player ops on main thread

### DIFF
--- a/leaf-server/src/main/java/org/leavesmc/leaves/replay/ServerPhotographer.java
+++ b/leaf-server/src/main/java/org/leavesmc/leaves/replay/ServerPhotographer.java
@@ -62,7 +62,14 @@ public class ServerPhotographer extends ServerPlayer {
         photographer.createState = state;
 
         photographer.recorder.start();
-        MinecraftServer.getServer().getPlayerList().placeNewPhotographer(photographer.recorder, photographer, world);
+        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && !server.isSameThread()) {
+            server.submit(() -> {
+                MinecraftServer.getServer().getPlayerList().placeNewPhotographer(photographer.recorder, photographer, world);
+            });
+        } else {
+            MinecraftServer.getServer().getPlayerList().placeNewPhotographer(photographer.recorder, photographer, world);
+        }
+
         photographer.level().chunkSource.move(photographer);
         photographer.setInvisible(true);
         photographers.add(photographer);
@@ -85,11 +92,24 @@ public class ServerPhotographer extends ServerPlayer {
 
         if (this.followPlayer != null) {
             if (this.getCamera() == this || this.getCamera().level() != this.level()) {
-                this.getBukkitPlayer().teleport(this.getCamera().getBukkitEntity().getLocation());
-                this.setCamera(followPlayer);
+                if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
+                    this.getBukkitEntity().taskScheduler.schedule(entity -> {
+                        ((ServerPhotographer) entity).getBukkitPlayer().teleport(((ServerPhotographer) entity).getCamera().getBukkitEntity().getLocation());
+                        ((ServerPhotographer) entity).setCamera(((ServerPhotographer) entity).followPlayer);
+                    }, entity -> {}, 0);
+                } else {
+                    this.getBukkitPlayer().teleport(this.getCamera().getBukkitEntity().getLocation());
+                    this.setCamera(followPlayer);
+                }
             }
             if (lastPos.distanceToSqr(this.position()) > 1024D) {
-                this.getBukkitPlayer().teleport(this.getCamera().getBukkitEntity().getLocation());
+                if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
+                    this.getBukkitEntity().taskScheduler.schedule(entity -> {
+                        ((ServerPhotographer) entity).getBukkitPlayer().teleport(((ServerPhotographer) entity).getCamera().getBukkitEntity().getLocation());
+                    }, entity -> {}, 0);
+                } else {
+                    this.getBukkitPlayer().teleport(this.getCamera().getBukkitEntity().getLocation());
+                }
             }
         }
 
@@ -130,7 +150,14 @@ public class ServerPhotographer extends ServerPlayer {
         super.remove(RemovalReason.KILLED);
         photographers.remove(this);
         this.recorder.stop();
-        this.getServer().getPlayerList().removePhotographer(this);
+
+        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
+            this.getServer().submit(() -> {
+                this.getServer().getPlayerList().removePhotographer(this);
+            });
+        } else {
+            this.getServer().getPlayerList().removePhotographer(this);
+        }
 
         LeavesLogger.LOGGER.info("Photographer " + createState.id + " removed");
 

--- a/leaf-server/src/main/java/org/leavesmc/leaves/replay/ServerPhotographer.java
+++ b/leaf-server/src/main/java/org/leavesmc/leaves/replay/ServerPhotographer.java
@@ -62,6 +62,7 @@ public class ServerPhotographer extends ServerPlayer {
         photographer.createState = state;
 
         photographer.recorder.start();
+        // Leaf start - SparklyPaper - parallel world ticking mod (make configurable)
         if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && !server.isSameThread()) {
             server.submit(() -> {
                 MinecraftServer.getServer().getPlayerList().placeNewPhotographer(photographer.recorder, photographer, world);
@@ -69,6 +70,7 @@ public class ServerPhotographer extends ServerPlayer {
         } else {
             MinecraftServer.getServer().getPlayerList().placeNewPhotographer(photographer.recorder, photographer, world);
         }
+        // Leaf end - SparklyPaper - parallel world ticking mod (make configurable)
 
         photographer.level().chunkSource.move(photographer);
         photographer.setInvisible(true);
@@ -92,6 +94,7 @@ public class ServerPhotographer extends ServerPlayer {
 
         if (this.followPlayer != null) {
             if (this.getCamera() == this || this.getCamera().level() != this.level()) {
+                // Leaf start - SparklyPaper - parallel world ticking mod (make configurable)
                 if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
                     this.getBukkitEntity().taskScheduler.schedule(entity -> {
                         ((ServerPhotographer) entity).getBukkitPlayer().teleport(((ServerPhotographer) entity).getCamera().getBukkitEntity().getLocation());
@@ -101,8 +104,10 @@ public class ServerPhotographer extends ServerPlayer {
                     this.getBukkitPlayer().teleport(this.getCamera().getBukkitEntity().getLocation());
                     this.setCamera(followPlayer);
                 }
+                // Leaf end - SparklyPaper - parallel world ticking mod (make configurable)
             }
             if (lastPos.distanceToSqr(this.position()) > 1024D) {
+                // Leaf start - SparklyPaper - parallel world ticking mod (make configurable)
                 if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
                     this.getBukkitEntity().taskScheduler.schedule(entity -> {
                         ((ServerPhotographer) entity).getBukkitPlayer().teleport(((ServerPhotographer) entity).getCamera().getBukkitEntity().getLocation());
@@ -110,6 +115,7 @@ public class ServerPhotographer extends ServerPlayer {
                 } else {
                     this.getBukkitPlayer().teleport(this.getCamera().getBukkitEntity().getLocation());
                 }
+                // Leaf end - SparklyPaper - parallel world ticking mod (make configurable)
             }
         }
 
@@ -151,6 +157,7 @@ public class ServerPhotographer extends ServerPlayer {
         photographers.remove(this);
         this.recorder.stop();
 
+        // Leaf start - SparklyPaper - parallel world ticking mod (make configurable)
         if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
             this.getServer().submit(() -> {
                 this.getServer().getPlayerList().removePhotographer(this);
@@ -158,6 +165,7 @@ public class ServerPhotographer extends ServerPlayer {
         } else {
             this.getServer().getPlayerList().removePhotographer(this);
         }
+        // Leaf end - SparklyPaper - parallel world ticking mod (make configurable)
 
         LeavesLogger.LOGGER.info("Photographer " + createState.id + " removed");
 


### PR DESCRIPTION
Adjust ServerPhotographer to schedule player placement, teleport, and
removal on the main thread when parallel ticking is enabled.

The change was based on TickThread error logs. The related issue did not
include concrete reproduction steps and the problem is hard to reproduce,
so the fix was derived from the stack trace.

Link: https://github.com/Winds-Studio/Leaf/issues/496