### PR TITLE
Fix MC-299642

### DIFF
--- a/leaf-server/minecraft-patches/features/0300-Fix-MC-299642.patch
+++ b/leaf-server/minecraft-patches/features/0300-Fix-MC-299642.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Fix MC-299642
+
+Related MC issue: https://bugs.mojang.com/browse/MC/issues/MC-299642
+
+This is more likely a temp fix without changing more code.
+
+diff --git a/net/minecraft/world/entity/animal/Turtle.java b/net/minecraft/world/entity/animal/Turtle.java
+index 59800c502c46c82cedde0f67e3848d7ba02cc479..0b5720532d93bf8ac412f1c9b5c3196a0c567be7 100644
+--- a/net/minecraft/world/entity/animal/Turtle.java
++++ b/net/minecraft/world/entity/animal/Turtle.java
+@@ -584,7 +584,7 @@ public class Turtle extends Animal {
+                     this.turtle.yBodyRot = this.turtle.getYRot();
+                     float f1 = (float)(this.getSpeedModifier() * this.turtle.getAttributeValue(Attributes.MOVEMENT_SPEED)); // Purpur - Ridables
+                     this.turtle.setSpeed(Mth.lerp(0.125F, this.turtle.getSpeed(), f1));
+-                    this.turtle.setDeltaMovement(this.turtle.getDeltaMovement().add(0.0, this.turtle.getSpeed() * d1 * 0.1, 0.0));
++                    if (!this.turtle.isNoGravity() || this.turtle.isInWater()) this.turtle.setDeltaMovement(this.turtle.getDeltaMovement().add(0.0, this.turtle.getSpeed() * d1 * 0.1, 0.0)); // Leaf - Fix MC-299642
+                 }
+             } else {
+                 this.turtle.setSpeed(0.0F);

--- a/leaf-server/minecraft-patches/features/0300-Fix-MC-299642.patch
+++ b/leaf-server/minecraft-patches/features/0300-Fix-MC-299642.patch
@@ -5,7 +5,8 @@ Subject: [PATCH] Fix MC-299642
 
 Related MC issue: https://bugs.mojang.com/browse/MC/issues/MC-299642
 
-This is more likely a temp fix without changing more code.
+Minecraft uses 3D movement control for turtles to move in water, which makes them fall even NoGravity tag is set to true.
+This direct manipulation of deltaMovement bypasses the standard move logic where the NoGravity tag is checked and applied.
 
 diff --git a/net/minecraft/world/entity/animal/Turtle.java b/net/minecraft/world/entity/animal/Turtle.java
 index 59800c502c46c82cedde0f67e3848d7ba02cc479..0b5720532d93bf8ac412f1c9b5c3196a0c567be7 100644


### PR DESCRIPTION
Mojira link: https://bugs.mojang.com/browse/MC/issues/MC-299642

Minecraft uses 3D movement control for turtles to move in water, which makes them fall even NoGravity tag is set to true.

This direct modification of deltaMovement bypasses the standard move logic where the NoGravity tag is checked and applied.