### PR TITLE
新增update应用插件更新的自动备份功能

### DIFF
--- a/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
+++ b/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
@@ -1,130 +1,44 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Claude <noreply@anthropic.com>
-Date: Fri, 13 Dec 2025 22:38:00 +0800
+Date: Fri, 13 Dec 2025 23:38:00 +0800
 Subject: [PATCH] plugin backup before update
 
 This patch adds functionality to backup plugins before updating from the update folder.
 It creates a timestamped backup of the existing plugin in the pluginsBackup folder
 to prevent data loss in case of plugin incompatibilities.
 
-diff --git a/src/main/java/org/bukkit/craftbukkit/plugin/JavaPluginLoader.java b/src/main/java/org/bukkit/craftbukkit/plugin/JavaPluginLoader.java
-index d2d16055df7ca3c625a720dfca5b4cd090e2972e..db43329d57144471d0c9ce0eed92d2f1bd05f120 100644
---- a/src/main/java/org/bukkit/craftbukkit/plugin/JavaPluginLoader.java
-+++ b/src/main/java/org/bukkit/craftbukkit/plugin/JavaPluginLoader.java
-@@ -35,6 +35,7 @@ public class JavaPluginLoader implements PluginLoader {
-     private static final Logger LOGGER = Logger.getLogger(JavaPluginLoader.class.getCanonicalName());
-     private final Server server;
-     private final File updateFolder;
-+    private File backupFolder; // Leaf - plugin backup before update
-     private final File pluginsFolder;
-     private final List<Plugin> plugins = new CopyOnWriteArrayList<>();
-
-@@ -44,6 +45,13 @@ public class JavaPluginLoader implements PluginLoader {
-         this.server = server;
-         this.pluginsFolder = new File("plugins");
-         this.updateFolder = new File("plugins", "updates");
-+
-+        // Leaf start - plugin backup before update
-+        if (org.dreeam.leaf.config.modules.misc.PluginBackup.enabled) {
-+            String backupFolderName = org.dreeam.leaf.config.modules.misc.PluginBackup.backupFolderName;
-+            this.backupFolder = new File(backupFolderName);
-+            this.backupFolder.mkdirs();
-+        }
-+        // Leaf end - plugin backup before update
-     }
-
-     @NotNull
-@@ -62,6 +70,7 @@ public class JavaPluginLoader implements PluginLoader {
-         return pluginsFolder;
-     }
-
-+    // Leaf start - plugin backup before update
-     @Override
-     public void enablePlugins(@NotNull PluginLoadOrder loadOrder) {
-         if (loadOrder == PluginLoadOrder.POSTWORLD) {
-@@ -70,27 +79,27 @@ public class JavaPluginLoader implements PluginLoader {
-         }
-
-         if (this.updateFolder.isDirectory()) {
--            this.updatePlugins();
-+            this.updatePluginsWithBackup(); // Leaf - plugin backup before update
-         }
-
-         this.loadPlugins(loadOrder);
-     }
-+    // Leaf end - plugin backup before update
-
--    private void updatePlugins() {
-+    private void updatePluginsWithBackup() { // Leaf - plugin backup before update
-         String[] files = this.updateFolder.list((dir, name) -> name.endsWith(".jar"));
-         if (files == null) {
-             return;
-         }
-@@ -102,19 +111,74 @@ public class JavaPluginLoader implements PluginLoader {
-         String[] arrstring = files;
-         int n = arrstring.length;
-         for (int i = 0; i < n; ++i) {
--            File file = new File(this.updateFolder, arrstring[i]);
--            File pluginFile = new File(this.pluginsFolder, arrstring[i]);
--            InputStream inputStream = new FileInputStream(file);
--            JarFile jarFile = new JarFile(file);
-+            File updateFile = new File(this.updateFolder, arrstring[i]);
-+            File pluginFile = new File(this.pluginsFolder, arrstring[i]);
-+
-+            // Leaf start - plugin backup before update
-+            if (org.dreeam.leaf.config.modules.misc.PluginBackup.enabled && pluginFile.exists()) {
+diff --git a/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java b/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
+index 87d5b73..1a2b3c4 100644
+--- a/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
++++ b/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
+@@ -114,6 +114,30 @@ public class FileProviderSource implements ProviderSource<Path, Path> {
+             if (visitor.getValidPlugin() != null) {
+                 Path updateLocation = visitor.getValidPlugin();
+ 
++                // Leaf start - plugin backup before update
 +                // Backup existing plugin before overwriting
-+                try {
-+                    String pluginName = arrstring[i];
-+                    if (pluginName.endsWith(".jar")) {
-+                        pluginName = pluginName.substring(0, pluginName.length() - 4);
++                if (org.dreeam.leaf.config.modules.misc.PluginBackup.enabled && Files.exists(file)) {
++                    try {
++                        String timestamp = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss").format(new java.util.Date());
++                        String backupFileName = pluginName + "_" + timestamp + ".jar";
++
++                        // Get backup directory
++                        String backupFolderName = org.dreeam.leaf.config.modules.misc.PluginBackup.backupFolderName;
++                        Path backupDirectory = file.getParent().getParent().resolve(backupFolderName);
++                        Files.createDirectories(backupDirectory);
++
++                        Path backupFile = backupDirectory.resolve(backupFileName);
++
++                        // Copy existing plugin to backup
++                        Files.copy(file, backupFile, StandardCopyOption.REPLACE_EXISTING);
++
++                        LOGGER.info("Backed up existing plugin {} to {}", pluginName, backupFileName);
++                    } catch (Exception e) {
++                        LOGGER.warn("Failed to backup plugin {} before update", pluginName, e);
 +                    }
-+                    String timestamp = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss").format(new java.util.Date());
-+                    String backupFileName = pluginName + "_" + timestamp + ".jar";
-+                    File backupFile = new File(this.backupFolder, backupFileName);
-+
-+                    // Copy existing plugin to backup
-+                    copyFile(pluginFile, backupFile);
-+
-+                    LOGGER.log(Level.INFO, "Backed up existing plugin " + pluginName + " to " + backupFileName);
-+                } catch (Exception e) {
-+                    LOGGER.log(Level.WARNING, "Failed to backup plugin " + arrstring[i], e);
 +                }
-+            }
-+            // Leaf end - plugin backup before update
++                // Leaf end - plugin backup before update
 +
-+            InputStream inputStream = new FileInputStream(updateFile); // Leaf - rename variable for clarity
-+            JarFile jarFile = new JarFile(updateFile);
-             Manifest manifest = jarFile.getManifest();
-             jarFile.close();
-             inputStream.close();
-             if (manifest == null) {
-                 LOGGER.log(Level.WARNING, "Plugin " + arrstring[i] + " has a malformed plugin.yml - no valid manifest found. Skipping.");
-             } else {
--                FileInputStream fis = new FileInputStream(file);
--                String hash = this.fileToHex(fis, MessageDigest.getInstance("SHA-256"));
--                fis.close();
-+                FileInputStream fis = new FileInputStream(updateFile);
-+                String hash = this.fileToHex(fis, MessageDigest.getInstance("SHA-256"));
-+                fis.close();
-                 if (!pluginFile.exists()) {
--                    Files.copy(file.toPath(), pluginFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-+                    Files.copy(updateFile.toPath(), pluginFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                 }
-                 LOGGER.log(Level.INFO, "Updating plugin " + manifest.getMainAttributes().getValue("Name") + " from " + arrstring[i] + " (new version: " + hash + ")");
-             }
-         }
-     }
-+
-+    // Leaf start - plugin backup before update
-+    /**
-+     * Copy a file to another location
-+     */
-+    private void copyFile(@NotNull File source, @NotNull File destination) throws IOException {
-+        if (!destination.getParentFile().exists()) {
-+            destination.getParentFile().mkdirs();
-+        }
-+
-+        Files.copy(source.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
-+    }
-+    // Leaf end - plugin backup before update
+                 try {
+                     Files.copy(updateLocation, file, StandardCopyOption.REPLACE_EXISTING);
+                 } catch (IOException exception) {

--- a/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
+++ b/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
@@ -7,8 +7,12 @@ This patch adds functionality to backup plugins before updating from the update 
 It creates a timestamped backup of the existing plugin in the pluginsBackup folder
 to prevent data loss in case of plugin incompatibilities.
 
+---
+ .../provider/source/FileProviderSource.java   | 24 +++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
 diff --git a/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java b/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
-index 87d5b73..1a2b3c4 100644
+index a0b8453..61b4b57 100644
 --- a/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
 +++ b/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
 @@ -114,6 +114,30 @@ public class FileProviderSource implements ProviderSource<Path, Path> {
@@ -42,3 +46,5 @@ index 87d5b73..1a2b3c4 100644
                  try {
                      Files.copy(updateLocation, file, StandardCopyOption.REPLACE_EXISTING);
                  } catch (IOException exception) {
+--
+2.45.1.windows.1

--- a/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
+++ b/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
@@ -1,15 +1,20 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: NeglectDream <dream@mcd7.cn>
+From: NeglectDream <neglectdream@qq.com>
 Date: Fri, 13 Dec 2025 23:38:00 +0800
 Subject: [PATCH] plugin backup before update
 
-This patch adds functionality to backup plugins before updating from the update folder.
-It creates a timestamped backup of the existing plugin in the pluginsBackup folder
-to prevent data loss in case of plugin incompatibilities.
+leaf-global.yml 的示例新增配置如下
+```
+ misc:
+  plugin-backup:
+    # 在从 update 文件夹更新插件之前启用插件备份.
+    enabled: true
+    # 用于存储旧插件的备份文件夹名称.
+    backup-folder-name: pluginsBackup
+```
 
----
- .../provider/source/FileProviderSource.java   | 24 +++++++++++++++++++
- 1 file changed, 24 insertions(+)
+此补丁增加了插件在从update文件夹启用前添加原插件的备份
+以防止新版插件覆盖老版本插件后因不兼容无法快捷启用老版本插件的问题
 
 diff --git a/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java b/paper-server/src/main/java/io/papermc/paper/plugin/provider/source/FileProviderSource.java
 index a0b8453..61b4b57 100644
@@ -26,17 +31,17 @@ index a0b8453..61b4b57 100644
 +                        String timestamp = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss").format(new java.util.Date());
 +                        String backupFileName = pluginName + "_" + timestamp + ".jar";
 +
-+                        // Get backup directory
++                        // Get backup directory - backup in plugins directory for safety
 +                        String backupFolderName = org.dreeam.leaf.config.modules.misc.PluginBackup.backupFolderName;
-+                        Path backupDirectory = file.getParent().getParent().resolve(backupFolderName);
-+                        Files.createDirectories(backupDirectory);
-+
-+                        Path backupFile = backupDirectory.resolve(backupFileName);
-+
-+                        // Copy existing plugin to backup
-+                        Files.copy(file, backupFile, StandardCopyOption.REPLACE_EXISTING);
-+
-+                        LOGGER.info("Backed up existing plugin {} to {}", pluginName, backupFileName);
++                        Path pluginsParentDir = file.getParent();
++                        if (pluginsParentDir != null) {
++                            // Create backup in plugins directory
++                            Path backupDirectory = pluginsParentDir.resolve(backupFolderName);
++                            Files.createDirectories(backupDirectory);
++                            Path backupFile = backupDirectory.resolve(backupFileName);
++                            Files.copy(file, backupFile, StandardCopyOption.REPLACE_EXISTING);
++                            LOGGER.info("Backed up existing plugin {} to {}", pluginName, backupFileName);
++                        }
 +                    } catch (Exception e) {
 +                        LOGGER.warn("Failed to backup plugin {} before update", pluginName, e);
 +                    }
@@ -46,5 +51,3 @@ index a0b8453..61b4b57 100644
                  try {
                      Files.copy(updateLocation, file, StandardCopyOption.REPLACE_EXISTING);
                  } catch (IOException exception) {
---
-2.45.1.windows.1

--- a/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
+++ b/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Claude <noreply@anthropic.com>
+From: NeglectDream <dream@mcd7.cn>
 Date: Fri, 13 Dec 2025 23:38:00 +0800
 Subject: [PATCH] plugin backup before update
 

--- a/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
+++ b/leaf-server/paper-patches/features/0061-Plugin-backup-before-update.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Fri, 13 Dec 2025 22:38:00 +0800
+Subject: [PATCH] plugin backup before update
+
+This patch adds functionality to backup plugins before updating from the update folder.
+It creates a timestamped backup of the existing plugin in the pluginsBackup folder
+to prevent data loss in case of plugin incompatibilities.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/plugin/JavaPluginLoader.java b/src/main/java/org/bukkit/craftbukkit/plugin/JavaPluginLoader.java
+index d2d16055df7ca3c625a720dfca5b4cd090e2972e..db43329d57144471d0c9ce0eed92d2f1bd05f120 100644
+--- a/src/main/java/org/bukkit/craftbukkit/plugin/JavaPluginLoader.java
++++ b/src/main/java/org/bukkit/craftbukkit/plugin/JavaPluginLoader.java
+@@ -35,6 +35,7 @@ public class JavaPluginLoader implements PluginLoader {
+     private static final Logger LOGGER = Logger.getLogger(JavaPluginLoader.class.getCanonicalName());
+     private final Server server;
+     private final File updateFolder;
++    private File backupFolder; // Leaf - plugin backup before update
+     private final File pluginsFolder;
+     private final List<Plugin> plugins = new CopyOnWriteArrayList<>();
+
+@@ -44,6 +45,13 @@ public class JavaPluginLoader implements PluginLoader {
+         this.server = server;
+         this.pluginsFolder = new File("plugins");
+         this.updateFolder = new File("plugins", "updates");
++
++        // Leaf start - plugin backup before update
++        if (org.dreeam.leaf.config.modules.misc.PluginBackup.enabled) {
++            String backupFolderName = org.dreeam.leaf.config.modules.misc.PluginBackup.backupFolderName;
++            this.backupFolder = new File(backupFolderName);
++            this.backupFolder.mkdirs();
++        }
++        // Leaf end - plugin backup before update
+     }
+
+     @NotNull
+@@ -62,6 +70,7 @@ public class JavaPluginLoader implements PluginLoader {
+         return pluginsFolder;
+     }
+
++    // Leaf start - plugin backup before update
+     @Override
+     public void enablePlugins(@NotNull PluginLoadOrder loadOrder) {
+         if (loadOrder == PluginLoadOrder.POSTWORLD) {
+@@ -70,27 +79,27 @@ public class JavaPluginLoader implements PluginLoader {
+         }
+
+         if (this.updateFolder.isDirectory()) {
+-            this.updatePlugins();
++            this.updatePluginsWithBackup(); // Leaf - plugin backup before update
+         }
+
+         this.loadPlugins(loadOrder);
+     }
++    // Leaf end - plugin backup before update
+
+-    private void updatePlugins() {
++    private void updatePluginsWithBackup() { // Leaf - plugin backup before update
+         String[] files = this.updateFolder.list((dir, name) -> name.endsWith(".jar"));
+         if (files == null) {
+             return;
+         }
+@@ -102,19 +111,74 @@ public class JavaPluginLoader implements PluginLoader {
+         String[] arrstring = files;
+         int n = arrstring.length;
+         for (int i = 0; i < n; ++i) {
+-            File file = new File(this.updateFolder, arrstring[i]);
+-            File pluginFile = new File(this.pluginsFolder, arrstring[i]);
+-            InputStream inputStream = new FileInputStream(file);
+-            JarFile jarFile = new JarFile(file);
++            File updateFile = new File(this.updateFolder, arrstring[i]);
++            File pluginFile = new File(this.pluginsFolder, arrstring[i]);
++
++            // Leaf start - plugin backup before update
++            if (org.dreeam.leaf.config.modules.misc.PluginBackup.enabled && pluginFile.exists()) {
++                // Backup existing plugin before overwriting
++                try {
++                    String pluginName = arrstring[i];
++                    if (pluginName.endsWith(".jar")) {
++                        pluginName = pluginName.substring(0, pluginName.length() - 4);
++                    }
++                    String timestamp = new java.text.SimpleDateFormat("yyyyMMdd-HHmmss").format(new java.util.Date());
++                    String backupFileName = pluginName + "_" + timestamp + ".jar";
++                    File backupFile = new File(this.backupFolder, backupFileName);
++
++                    // Copy existing plugin to backup
++                    copyFile(pluginFile, backupFile);
++
++                    LOGGER.log(Level.INFO, "Backed up existing plugin " + pluginName + " to " + backupFileName);
++                } catch (Exception e) {
++                    LOGGER.log(Level.WARNING, "Failed to backup plugin " + arrstring[i], e);
++                }
++            }
++            // Leaf end - plugin backup before update
++
++            InputStream inputStream = new FileInputStream(updateFile); // Leaf - rename variable for clarity
++            JarFile jarFile = new JarFile(updateFile);
+             Manifest manifest = jarFile.getManifest();
+             jarFile.close();
+             inputStream.close();
+             if (manifest == null) {
+                 LOGGER.log(Level.WARNING, "Plugin " + arrstring[i] + " has a malformed plugin.yml - no valid manifest found. Skipping.");
+             } else {
+-                FileInputStream fis = new FileInputStream(file);
+-                String hash = this.fileToHex(fis, MessageDigest.getInstance("SHA-256"));
+-                fis.close();
++                FileInputStream fis = new FileInputStream(updateFile);
++                String hash = this.fileToHex(fis, MessageDigest.getInstance("SHA-256"));
++                fis.close();
+                 if (!pluginFile.exists()) {
+-                    Files.copy(file.toPath(), pluginFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
++                    Files.copy(updateFile.toPath(), pluginFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                 }
+                 LOGGER.log(Level.INFO, "Updating plugin " + manifest.getMainAttributes().getValue("Name") + " from " + arrstring[i] + " (new version: " + hash + ")");
+             }
+         }
+     }
++
++    // Leaf start - plugin backup before update
++    /**
++     * Copy a file to another location
++     */
++    private void copyFile(@NotNull File source, @NotNull File destination) throws IOException {
++        if (!destination.getParentFile().exists()) {
++            destination.getParentFile().mkdirs();
++        }
++
++        Files.copy(source.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
++    }
++    // Leaf end - plugin backup before update

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/PluginBackup.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/PluginBackup.java
@@ -9,7 +9,7 @@ public class PluginBackup extends ConfigModules {
         return EnumConfigCategory.MISC.getBaseKeyName() + ".plugin-backup";
     }
 
-    public static boolean enabled = true;
+    public static boolean enabled = false;
     public static String backupFolderName = "pluginsBackup";
 
     @Override

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/PluginBackup.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/PluginBackup.java
@@ -1,0 +1,26 @@
+package org.dreeam.leaf.config.modules.misc;
+
+import org.dreeam.leaf.config.ConfigModules;
+import org.dreeam.leaf.config.EnumConfigCategory;
+
+public class PluginBackup extends ConfigModules {
+
+    public String getBasePath() {
+        return EnumConfigCategory.MISC.getBaseKeyName() + ".plugin-backup";
+    }
+
+    public static boolean enabled = true;
+    public static String backupFolderName = "pluginsBackup";
+
+    @Override
+    public void onLoaded() {
+        enabled = config.getBoolean(getBasePath() + ".enabled", enabled, config.pickStringRegionBased(
+                "Enable plugin backup before updating from the update folder.",
+                "在从 update 文件夹更新插件之前启用插件备份."
+            ));
+        backupFolderName = config.getString(getBasePath() + ".backup-folder-name", backupFolderName, config.pickStringRegionBased(
+                "The name of the backup folder where old plugins will be stored.",
+                "用于存储旧插件的备份文件夹名称."
+            ));
+    }
+}


### PR DESCRIPTION
在配置文件内新增配置文件
misc:
  plugin-backup:
    # 在从 update 文件夹更新插件之前启用插件备份.
    enabled: true
    # 用于存储旧插件的备份文件夹名称.
    backup-folder-name: pluginsBackup
选项开启后
服务器开服时进行update文件夹内的插件应用之前
将旧版本的插件备份到plugins/pluginsBackup文件夹下面
备份后的旧版本插件将按照日期和时间戳来保存
以确保在自动应用插件更新之后出现问题不便于回档旧版本插件的问题