### PR TITLE
Skip saving entities if they should despawn

### DIFF
--- a/leaf-server/minecraft-patches/features/0304-Rewrite-entity-despawn-time.patch
+++ b/leaf-server/minecraft-patches/features/0304-Rewrite-entity-despawn-time.patch
@@ -40,7 +40,7 @@ index f58b91b277ba85fa7c0e7ad10157ecbf10023065..b7f9f22abf60c75bc09126d9168fda9a
              for (Entity entity : passengerEntity.getPassengers()) {
                  this.tickPassenger(passengerEntity, entity, isActive); // Paper - EAR 2
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index f6d619709d4e5b0e6d1b943226579d7388835cdb..bd7944f16e2f3db7c04409fcb19a7bff33f248d3 100644
+index f6d619709d4e5b0e6d1b943226579d7388835cdb..0c35f5f5a9d9afad457e2ab723f90feeefe5413d 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -373,6 +373,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -126,6 +126,15 @@ index f6d619709d4e5b0e6d1b943226579d7388835cdb..bd7944f16e2f3db7c04409fcb19a7bff
              output.putInt("Spigot.ticksLived", this.totalEntityAge); // Paper
              // CraftBukkit end
              output.storeNullable("CustomName", ComponentSerialization.CODEC, this.getCustomName());
+@@ -2721,7 +2760,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+ 
+             // CraftBukkit start
+             // Spigot start
+-            if (this instanceof net.minecraft.world.entity.LivingEntity) {
++            if (true || this instanceof net.minecraft.world.entity.LivingEntity) { // Leaf - Rewrite entity despawn time
+                 this.totalEntityAge = input.getIntOr("Spigot.ticksLived", 0); // Paper
+             }
+             // Spigot end
 @@ -5327,9 +5366,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
  
      @Override

--- a/leaf-server/minecraft-patches/features/0304-Rewrite-entity-despawn-time.patch
+++ b/leaf-server/minecraft-patches/features/0304-Rewrite-entity-despawn-time.patch
@@ -40,7 +40,7 @@ index f58b91b277ba85fa7c0e7ad10157ecbf10023065..b7f9f22abf60c75bc09126d9168fda9a
              for (Entity entity : passengerEntity.getPassengers()) {
                  this.tickPassenger(passengerEntity, entity, isActive); // Paper - EAR 2
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index f6d619709d4e5b0e6d1b943226579d7388835cdb..137ec39c1458e6adc854df24807f0e26770d95da 100644
+index f6d619709d4e5b0e6d1b943226579d7388835cdb..b9679b3cf4f3e052049aa99f4666b8a7b1d4f6ae 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -373,6 +373,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -67,7 +67,7 @@ index f6d619709d4e5b0e6d1b943226579d7388835cdb..137ec39c1458e6adc854df24807f0e26
      }
  
      public boolean isColliding(BlockPos pos, BlockState state) {
-@@ -887,15 +890,46 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -887,15 +890,50 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
      }
  
      public void tick() {
@@ -89,11 +89,8 @@ index f6d619709d4e5b0e6d1b943226579d7388835cdb..137ec39c1458e6adc854df24807f0e26
  
 +    // Leaf start - Rewrite entity despawn time
 +    protected final boolean detectDespawnTime() {
++        this.syncEntityAge();
 +        if (this.despawnTime >= 0) {
-+            int missedTicks = this.calculateMissedTicks();
-+            if (missedTicks > 1) {
-+                this.totalEntityAge += missedTicks;
-+            }
 +            if (this.totalEntityAge >= this.despawnTime) {
 +                this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN);
 +                return true;
@@ -106,6 +103,13 @@ index f6d619709d4e5b0e6d1b943226579d7388835cdb..137ec39c1458e6adc854df24807f0e26
 +        return net.minecraft.server.MinecraftServer.currentTick - this.lastTickTime;
 +    }
 +
++    private void syncEntityAge() {
++        int missedTicks = this.calculateMissedTicks();
++        if (missedTicks > 1) {
++            this.totalEntityAge += missedTicks;
++        }
++    }
++
 +    public void updateLastTick() {
 +        this.lastTickTime = net.minecraft.server.MinecraftServer.currentTick;
 +    }
@@ -114,19 +118,26 @@ index f6d619709d4e5b0e6d1b943226579d7388835cdb..137ec39c1458e6adc854df24807f0e26
      // CraftBukkit start
      public void postTick() {
          // No clean way to break out of ticking once the entity has been copied to a new world, so instead we move the portalling later in the tick cycle
-@@ -2564,6 +2598,12 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+@@ -2564,6 +2602,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
              if (this.maxAirTicks != this.getDefaultMaxAirSupply()) {
                  output.putInt("Bukkit.MaxAirSupply", this.getMaxAirSupply());
              }
-+            // Leaf start - Rewrite entity despawn time
-+            int missedTicks = this.calculateMissedTicks();
-+            if (missedTicks > 1) {
-+                this.totalEntityAge += missedTicks;
-+            }
-+            // Leaf end - Rewrite entity despawn time
++            this.syncEntityAge();// Leaf - Rewrite entity despawn time
              output.putInt("Spigot.ticksLived", this.totalEntityAge); // Paper
              // CraftBukkit end
              output.storeNullable("CustomName", ComponentSerialization.CODEC, this.getCustomName());
+@@ -5327,9 +5366,10 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
+ 
+     @Override
+     public boolean shouldBeSaved() {
++        this.syncEntityAge(); // Leaf - Rewrite entity despawn time
+         return (this.removalReason == null || this.removalReason.shouldSave())
+             && !this.isPassenger()
+-            && (!this.isVehicle() || !((ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity)this).moonrise$hasAnyPlayerPassengers()); // Paper - rewrite chunk system
++            && (!this.isVehicle() || !((ca.spottedleaf.moonrise.patches.chunk_system.entity.ChunkSystemEntity)this).moonrise$hasAnyPlayerPassengers()) && (this.despawnTime < 0 || this.totalEntityAge < this.despawnTime); // Paper - rewrite chunk system // Leaf - Rewrite entity despawn time
+     }
+ 
+     @Override
 diff --git a/net/minecraft/world/entity/projectile/ThrowableProjectile.java b/net/minecraft/world/entity/projectile/ThrowableProjectile.java
 index 4c61f4552dc64b1347c7b8dfe9502aac11c75888..be0ebc017bfe92fb2916a9e40971ad19614a33b4 100644
 --- a/net/minecraft/world/entity/projectile/ThrowableProjectile.java

--- a/leaf-server/minecraft-patches/features/0304-Rewrite-entity-despawn-time.patch
+++ b/leaf-server/minecraft-patches/features/0304-Rewrite-entity-despawn-time.patch
@@ -40,7 +40,7 @@ index f58b91b277ba85fa7c0e7ad10157ecbf10023065..b7f9f22abf60c75bc09126d9168fda9a
              for (Entity entity : passengerEntity.getPassengers()) {
                  this.tickPassenger(passengerEntity, entity, isActive); // Paper - EAR 2
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index f6d619709d4e5b0e6d1b943226579d7388835cdb..b9679b3cf4f3e052049aa99f4666b8a7b1d4f6ae 100644
+index f6d619709d4e5b0e6d1b943226579d7388835cdb..bd7944f16e2f3db7c04409fcb19a7bff33f248d3 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -373,6 +373,7 @@ public abstract class Entity implements SyncedDataHolder, Nameable, EntityAccess
@@ -122,7 +122,7 @@ index f6d619709d4e5b0e6d1b943226579d7388835cdb..b9679b3cf4f3e052049aa99f4666b8a7
              if (this.maxAirTicks != this.getDefaultMaxAirSupply()) {
                  output.putInt("Bukkit.MaxAirSupply", this.getMaxAirSupply());
              }
-+            this.syncEntityAge();// Leaf - Rewrite entity despawn time
++            this.syncEntityAge(); // Leaf - Rewrite entity despawn time
              output.putInt("Spigot.ticksLived", this.totalEntityAge); // Paper
              // CraftBukkit end
              output.storeNullable("CustomName", ComponentSerialization.CODEC, this.getCustomName());


### PR DESCRIPTION
Call syncEntityAge() even if despawn time is disabled, as this may be enabled in the future by users.