### PR TITLE
Fix async mob spawn counting race in 0244 patch

### DIFF
--- a/leaf-server/minecraft-patches/features/0244-optimize-mob-spawning.patch
+++ b/leaf-server/minecraft-patches/features/0244-optimize-mob-spawning.patch
@@ -82,7 +82,7 @@ index 908cd08e33fed1c4cd4bd34c3e63cbbe84ffead4..f5b58c181726536bedabd4b6f64769e3
                  // Paper start - per player mob spawning backoff
                  for (int ii = 0; ii < ServerPlayer.MOBCATEGORY_TOTAL_ENUMS; ii++) {
                      player.mobCounts[ii] = 0;
-@@ -525,34 +542,27 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+@@ -525,13 +542,34 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
                      player.mobBackoffCounts[ii] = newBackoff;
                  }
                  // Paper end - per player mob spawning backoff
@@ -92,43 +92,29 @@ index 908cd08e33fed1c4cd4bd34c3e63cbbe84ffead4..f5b58c181726536bedabd4b6f64769e3
                  firstRunSpawnCounts = false;
                  _pufferfish_spawnCountsReady.set(true);
              }
-             if (_pufferfish_spawnCountsReady.getAndSet(false)) {
+            if (_pufferfish_spawnCountsReady.getAndSet(false)) {
 +                final int mapped = distanceManager.getNaturalSpawnChunkCount();
-+                final Iterable<Entity> entities = this.level.getAllEntities();
                  net.minecraft.server.MinecraftServer.getServer().mobSpawnExecutor.submit(() -> {
--                    int mapped = distanceManager.getNaturalSpawnChunkCount();
--                    ca.spottedleaf.moonrise.common.list.IteratorSafeOrderedReferenceSet.Iterator<Entity> objectiterator =
--                        level.entityTickList.entities.iterator(ca.spottedleaf.moonrise.common.list.IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS);
--                    try {
--                        gg.pufferfish.pufferfish.util.IterableWrapper<Entity> wrappedIterator =
--                            new gg.pufferfish.pufferfish.util.IterableWrapper<>(objectiterator);
--                        // Fix: Use proper mob cap calculator based on configuration
--                        LocalMobCapCalculator mobCapCalculator = !level.paperConfig().entities.spawning.perPlayerMobSpawns ?
--                            new LocalMobCapCalculator(chunkMap) : null;
--
--                        // This ensures the caps are properly enforced by using the correct calculator
--                        lastSpawnState = NaturalSpawner.createState(
--                            mapped,
--                            wrappedIterator,
--                            ServerChunkCache.this::getFullChunk,
--                            mobCapCalculator,  // This is the key fix - was previously null
--                            level.paperConfig().entities.spawning.perPlayerMobSpawns
--                        );
--                    } finally {
--                        objectiterator.finishedIterating();
--                    }
-+                    // Fix: Use proper mob cap calculator based on configuration
-+                    LocalMobCapCalculator mobCapCalculator = !level.paperConfig().entities.spawning.perPlayerMobSpawns ?
-+                        new LocalMobCapCalculator(chunkMap) : null;
++                    ca.spottedleaf.moonrise.common.list.IteratorSafeOrderedReferenceSet.Iterator<Entity> objectiterator =
++                        level.entityTickList.entities.iterator(ca.spottedleaf.moonrise.common.list.IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS);
++                    try {
++                        gg.pufferfish.pufferfish.util.IterableWrapper<Entity> wrappedIterator =
++                            new gg.pufferfish.pufferfish.util.IterableWrapper<>(objectiterator);
++                        // Fix: Use proper mob cap calculator based on configuration
++                        LocalMobCapCalculator mobCapCalculator = !level.paperConfig().entities.spawning.perPlayerMobSpawns ?
++                            new LocalMobCapCalculator(chunkMap) : null;
 +
-+                    // This ensures the caps are properly enforced by using the correct calculator
-+                    lastSpawnState = NaturalSpawner.createState1( // Leaf - optimize mob spawning
-+                        mapped,
-+                        entities,
-+                        this.level, // Leaf - optimize mob spawning
-+                        mobCapCalculator,  // This is the key fix - was previously null
-+                        level.paperConfig().entities.spawning.perPlayerMobSpawns
-+                    );
++                        // This ensures the caps are properly enforced by using the correct calculator
++                        lastSpawnState = NaturalSpawner.createState1( // Leaf - optimize mob spawning
++                            mapped,
++                            wrappedIterator,
++                            this.level, // Leaf - optimize mob spawning
++                            mobCapCalculator,  // This is the key fix - was previously null
++                            level.paperConfig().entities.spawning.perPlayerMobSpawns
++                        );
++                    } finally {
++                        objectiterator.finishedIterating();
++                    }
                      _pufferfish_spawnCountsReady.set(true);
                  });
              }


### PR DESCRIPTION
Switch async mob counting back to the iterator‑safe entity list and ensure iteration is properly finalized to avoid undercounting. Pass a stable iterable into createState1 and keep per‑player caps consistent so mobcaps don’t slowly drift. This keeps async spawning while restoring accurate counts and avoids thread‑unsafe access to getAllEntities.