### PR TITLE
Fix MC-17876

### DIFF
--- a/leaf-server/minecraft-patches/features/0305-Fix-MC-17876.patch
+++ b/leaf-server/minecraft-patches/features/0305-Fix-MC-17876.patch
@@ -1,0 +1,93 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Fix MC-17876
+
+Related MC issue: https://bugs.mojang.com/browse/MC/issues/MC-17876
+
+diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
+index 2f4f74dafaca83c8c3e6e3234565faceddc8c81a..dfbda019b688aeb0bcbcd2cb5e470e03ae83ad72 100644
+--- a/net/minecraft/world/entity/LivingEntity.java
++++ b/net/minecraft/world/entity/LivingEntity.java
+@@ -894,7 +894,7 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+             this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(maxHealth);
+         });
+         // CraftBukkit end
+-        this.setHealth(input.getFloatOr("Health", this.getMaxHealth()));
++        //this.setHealth(input.getFloatOr("Health", this.getMaxHealth())); // Leaf - Fix MC-17876 - move down
+         this.hurtTime = input.getShortOr("HurtTime", (short)0);
+         this.deathTime = input.getShortOr("DeathTime", (short)0);
+         this.lastHurtByMobTimestamp = input.getIntOr("HurtByTimestamp", 0);
+@@ -925,6 +925,12 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+         this.lastHurtByMobTimestamp = input.getIntOr("ticks_since_last_hurt_by_mob", 0) + this.tickCount;
+         this.equipment.setAll(input.read("equipment", EntityEquipment.CODEC).orElseGet(EntityEquipment::new));
+         this.locatorBarIcon = input.read("locator_bar_icon", Waypoint.Icon.CODEC).orElseGet(Waypoint.Icon::new);
++        // Leaf start - Fix MC-17876
++        if (!(this instanceof Player)) {
++            this.loadEquipmentAttributeChanges();
++            this.setHealth(input.getFloatOr("Health", this.getMaxHealth())); // Leaf - moved from above
++        }
++        // Leaf end - Fix MC-17876
+     }
+ 
+     // CraftBukkit start
+@@ -3497,6 +3503,44 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+         }
+     }
+ 
++    // Leaf start - Fix MC-17876 - Extracted from collectEquipmentChanges
++    protected final void loadEquipmentAttributeChanges() {
++        // Leaf start - Lithium - equipment tracking
++        final boolean isArmorStandUpdateNoTick = this instanceof net.minecraft.world.entity.decoration.ArmorStand stand && !stand.canTick && stand.noTickEquipmentDirty;
++        if (!isArmorStandUpdateNoTick && !this.equipment.lithium$hasUnsentEquipmentChanges()) return;
++        // Leaf end - Lithium - equipment tracking
++        Map<EquipmentSlot, ItemStack> map = null;
++
++        for (EquipmentSlot equipmentSlot : EquipmentSlot.VALUES_ARRAY) { // Gale - JettPack - reduce array allocations
++            ItemStack itemStack = this.lastEquipmentItems.get(equipmentSlot);
++            ItemStack itemBySlot = this.getItemBySlot(equipmentSlot);
++            if (this.equipmentHasChanged(itemStack, itemBySlot)) {
++                if (map == null) {
++                    map = Maps.newEnumMap(EquipmentSlot.class);
++                }
++
++                map.put(equipmentSlot, itemBySlot);
++            }
++        }
++
++        if (map != null) {
++            for (Entry<EquipmentSlot, ItemStack> entry : map.entrySet()) {
++                EquipmentSlot equipmentSlot1 = entry.getKey();
++                ItemStack itemBySlot = entry.getValue();
++                if (!itemBySlot.isEmpty() && !itemBySlot.isBroken()) {
++                    itemBySlot.forEachModifier(equipmentSlot1, (holder, attributeModifier) -> {
++                        AttributeInstance instance = this.attributes.getInstance(holder);
++                        if (instance != null) {
++                            instance.removeModifier(attributeModifier.id());
++                            instance.addTransientModifier(attributeModifier);
++                        }
++                    });
++                }
++            }
++        }
++    }
++    // Leaf end - Fix MC-17876 - Extracted from collectEquipmentChanges
++
+     @Nullable
+     private Map<EquipmentSlot, ItemStack> collectEquipmentChanges() {
+         // Leaf start - Lithium - equipment tracking
+diff --git a/net/minecraft/world/entity/player/Player.java b/net/minecraft/world/entity/player/Player.java
+index 108ef0759e4060fc02d517175731f413c7e2532f..13af7b603c79036f7a6e0b7f8891aa52bb2683e3 100644
+--- a/net/minecraft/world/entity/player/Player.java
++++ b/net/minecraft/world/entity/player/Player.java
+@@ -885,6 +885,10 @@ public abstract class Player extends LivingEntity {
+         this.currentImpulseImpactPos = input.read("current_explosion_impact_pos", Vec3.CODEC).orElse(null);
+         this.ignoreFallDamageFromCurrentImpulse = input.getBooleanOr("ignore_fall_damage_from_current_explosion", false);
+         this.currentImpulseContextResetGraceTime = input.getIntOr("current_impulse_context_reset_grace_time", 0);
++        // Leaf start - Fix MC-17876
++        this.loadEquipmentAttributeChanges();
++        this.setHealth(input.getFloatOr("Health", this.getMaxHealth()));
++        // Leaf end - Fix MC-17876
+     }
+ 
+     @Override


### PR DESCRIPTION
This pull request addresses [MC-17876](https://bugs.mojang.com/browse/MC/issues/MC-17876), which causes attribute modifiers of equipments are applied after the entity health is set, leading to health loss on reload/rejoin.

This PR fixed the issue by loading equipment attributes before the max health is determined to prevent the health from being clamped to base value.

### To reproduce

Type command `/item replace entity @s armor.head with iron_helmet[minecraft:attribute_modifiers=[ {id:"test",type:"max_health",amount:6,operation:"add_value"}]]`, quit the server after health regen, the extra health will lost upon rejoin without this fix.