### PR TITLE
Cache world border

### DIFF
--- a/leaf-server/minecraft-patches/features/0293-Cache-world-border.patch
+++ b/leaf-server/minecraft-patches/features/0293-Cache-world-border.patch
@@ -3,29 +3,33 @@ From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 Date: Tue, 9 Nov 2077 00:00:00 +0800
 Subject: [PATCH] Cache world border
 
+The world border is only initialized once when the level is created.
+Lookup from data storage map multiple time is quite unnecessary and expensive.
 
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index e41087a52c5c0521728357431afd182080ab1291..d1164dcb0a7381ab84a08bfadc9f07b6f65aef01 100644
+index e41087a52c5c0521728357431afd182080ab1291..da4a07988709cac2692791f0114c4a1846e53a93 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -237,6 +237,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
      private final alternate.current.wire.WireHandler wireHandler = new alternate.current.wire.WireHandler(this); // Paper - optimize redstone (Alternate Current)
      public boolean hasRidableMoveEvent = false; // Purpur - Ridables
      public final org.dreeam.leaf.async.tracker.AsyncTracker leaf$asyncTracker = new org.dreeam.leaf.async.tracker.AsyncTracker(this); // Leaf - Multithreaded tracker
-+    private @Nullable WorldBorder worldBorder; // Leaf - Cache worldborder
++    private @Nullable WorldBorder worldBorder; // Leaf - Cache world border
  
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
-@@ -2517,8 +2518,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+@@ -2517,8 +2518,14 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
  
      @Override
      public WorldBorder getWorldBorder() {
++        // Leaf start - Cache world border
 +        if (this.worldBorder != null) {
 +            return this.worldBorder;
 +        }
++        // Leaf end - Cache world border
          WorldBorder worldBorder = this.getDataStorage().computeIfAbsent(WorldBorder.TYPE);
          worldBorder.applyInitialSettings(this.levelData.getGameTime());
-+        this.worldBorder = worldBorder;
++        this.worldBorder = worldBorder; // Leaf - Cache world border
          return worldBorder;
      }
  

--- a/leaf-server/minecraft-patches/features/0293-Cache-world-border.patch
+++ b/leaf-server/minecraft-patches/features/0293-Cache-world-border.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Cache world border
+
+
+diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
+index e41087a52c5c0521728357431afd182080ab1291..d1164dcb0a7381ab84a08bfadc9f07b6f65aef01 100644
+--- a/net/minecraft/server/level/ServerLevel.java
++++ b/net/minecraft/server/level/ServerLevel.java
+@@ -237,6 +237,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+     private final alternate.current.wire.WireHandler wireHandler = new alternate.current.wire.WireHandler(this); // Paper - optimize redstone (Alternate Current)
+     public boolean hasRidableMoveEvent = false; // Purpur - Ridables
+     public final org.dreeam.leaf.async.tracker.AsyncTracker leaf$asyncTracker = new org.dreeam.leaf.async.tracker.AsyncTracker(this); // Leaf - Multithreaded tracker
++    private @Nullable WorldBorder worldBorder; // Leaf - Cache worldborder
+ 
+     @Override
+     public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
+@@ -2517,8 +2518,12 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+ 
+     @Override
+     public WorldBorder getWorldBorder() {
++        if (this.worldBorder != null) {
++            return this.worldBorder;
++        }
+         WorldBorder worldBorder = this.getDataStorage().computeIfAbsent(WorldBorder.TYPE);
+         worldBorder.applyInitialSettings(this.levelData.getGameTime());
++        this.worldBorder = worldBorder;
+         return worldBorder;
+     }
+ 


### PR DESCRIPTION
The world border is only initialized once when the level is created. Lookup from data storage map multiple time is quite unnecessary and expensive.