### PR TITLE
Fix profile username validation for `enforceSkullValidation`

### DIFF
--- a/leaf-server/minecraft-patches/features/0092-Configurable-vanilla-username-check.patch
+++ b/leaf-server/minecraft-patches/features/0092-Configurable-vanilla-username-check.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable vanilla username check
 
 
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 1bfbc8d4c1475a85d2f044121f98af7b580aeede..0c1692022989e0ea05e6e349d91e56a2c689af83 100644
+index d874a58e9e815faad02fe1f2777f4375289b17ac..b82ef9485e24577a238b08249e09c87388768e9a 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -2620,7 +2620,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -137,28 +137,73 @@ index da0018214439511288a43ca665abec6f01441f47..d21806680b1a4c1293ee1aed6c3cc9d2
              return false;
          }
 diff --git a/net/minecraft/world/item/component/ResolvableProfile.java b/net/minecraft/world/item/component/ResolvableProfile.java
-index 8dbdb40095321cfb2164026f5ca7e0d0c8f1914f..b32dd189e384680b7d1164d044ea0f3b361d07de 100644
+index 8dbdb40095321cfb2164026f5ca7e0d0c8f1914f..16ea3364aa60ed404752be40cfdf08cc676caa50 100644
 --- a/net/minecraft/world/item/component/ResolvableProfile.java
 +++ b/net/minecraft/world/item/component/ResolvableProfile.java
-@@ -68,6 +68,12 @@ public abstract sealed class ResolvableProfile implements TooltipProvider permit
+@@ -68,6 +68,30 @@ public abstract sealed class ResolvableProfile implements TooltipProvider permit
  
      public abstract Either<GameProfile, ResolvableProfile.Partial> unpack();
  
 +    // Leaf start - Configurable vanilla username check - Enforce skull validation
-+    private static String sanitizePlayerName(String name) {
-+        return org.dreeam.leaf.config.modules.misc.VanillaUsernameCheck.enforceSkullValidation && !net.minecraft.util.StringUtil.isValidPlayerNameVanilla(name) ? "INVALID_OWNER" : name;
++    private static Either<String, UUID> sanitizeDynamicPlayerName(Either<String, UUID> nameOrId) {
++        if (nameOrId.left().isEmpty()) {
++            return nameOrId;
++        }
++        return org.dreeam.leaf.config.modules.misc.VanillaUsernameCheck.enforceSkullValidation && !net.minecraft.util.StringUtil.isValidPlayerNameVanilla(nameOrId.left().get()) ? Either.left("INVALID_OWNER") : nameOrId;
++    }
++
++    private static Optional<String> sanitizePartialPlayerName(Optional<String> name) {
++        if (name.isEmpty()) {
++            return name;
++        }
++        return org.dreeam.leaf.config.modules.misc.VanillaUsernameCheck.enforceSkullValidation && !net.minecraft.util.StringUtil.isValidPlayerNameVanilla(name.get()) ? Optional.of("INVALID_OWNER") : name;
++    }
++
++    private static Either<GameProfile, ResolvableProfile.Partial> sanitizeStaticPlayerName(Either<GameProfile, ResolvableProfile.Partial> contents) {
++        if (contents.left().isEmpty()) {
++            return contents;
++        }
++        GameProfile gameProfile = contents.left().get();
++        return org.dreeam.leaf.config.modules.misc.VanillaUsernameCheck.enforceSkullValidation && !net.minecraft.util.StringUtil.isValidPlayerNameVanilla(gameProfile.name()) ? Either.left(new GameProfile(gameProfile.id(), "INVALID_OWNER", gameProfile.properties())) : contents;
 +    }
 +    // Leaf end - Configurable vanilla username check - Enforce skull validation
 +
      protected ResolvableProfile(GameProfile partialProfile, PlayerSkin.Patch skinPatch) {
          this.partialProfile = partialProfile;
          this.skinPatch = skinPatch;
-@@ -84,7 +90,7 @@ public abstract sealed class ResolvableProfile implements TooltipProvider permit
+@@ -96,6 +120,11 @@ public abstract sealed class ResolvableProfile implements TooltipProvider permit
+         private final Either<String, UUID> nameOrId;
+ 
+         public Dynamic(Either<String, UUID> nameOrId, PlayerSkin.Patch skinPatch) {
++            // Leaf start - Configurable vanilla username check
++            this(sanitizeDynamicPlayerName(nameOrId), skinPatch, false);
++        }
++        public Dynamic(Either<String, UUID> nameOrId, PlayerSkin.Patch skinPatch, boolean dummy) {
++            // Leaf end - Configurable vanilla username check
+             super(ResolvableProfile.createPartialProfile(nameOrId.left(), nameOrId.right(), PropertyMap.EMPTY), skinPatch);
+             this.nameOrId = nameOrId;
+         }
+@@ -134,6 +163,11 @@ public abstract sealed class ResolvableProfile implements TooltipProvider permit
      }
  
-     static GameProfile createPartialProfile(Optional<String> name, Optional<UUID> id, PropertyMap properties) {
--        String string = name.orElse("");
-+        String string = name.map(ResolvableProfile::sanitizePlayerName).orElse(""); // Leaf - Configurable vanilla username check - Enforce skull validation
-         UUID uuid = id.orElseGet(() -> name.map(UUIDUtil::createOfflinePlayerUUID).orElse(Util.NIL_UUID));
-         return new GameProfile(uuid, string, properties);
-     }
+     public record Partial(Optional<String> name, Optional<UUID> id, PropertyMap properties) {
++        // Leaf start - Configurable vanilla username check
++        public Partial {
++            name = ResolvableProfile.sanitizePartialPlayerName(name);
++        }
++        // Leaf end - Configurable vanilla username check
+         public static final ResolvableProfile.Partial EMPTY = new ResolvableProfile.Partial(Optional.empty(), Optional.empty(), PropertyMap.EMPTY);
+         public static final MapCodec<ResolvableProfile.Partial> MAP_CODEC = RecordCodecBuilder.mapCodec(
+             instance -> instance.group(
+@@ -164,6 +198,11 @@ public abstract sealed class ResolvableProfile implements TooltipProvider permit
+         private final Either<GameProfile, ResolvableProfile.Partial> contents;
+ 
+         public Static(Either<GameProfile, ResolvableProfile.Partial> contents, PlayerSkin.Patch skinPatch) {
++            // Leaf start - Configurable vanilla username check
++            this(sanitizeStaticPlayerName(contents), skinPatch, false);
++        }
++        public Static(Either<GameProfile, ResolvableProfile.Partial> contents, PlayerSkin.Patch skinPatch, boolean dummy) {
++            // Leaf end - Configurable vanilla username check
+             super(contents.map(gameProfile -> (GameProfile)gameProfile, ResolvableProfile.Partial::createProfile), skinPatch);
+             this.contents = contents;
+         }


### PR DESCRIPTION
Added username sanitization in the constructors of Dynamic, Static, and Partial

In the sanitization, if the name is empty, directly return, to let `name.orElse("");` in createPartialProfile` method to handle it (original behavior).

Supersede https://github.com/Winds-Studio/Leaf/pull/583