### PR TITLE
Fix async tracker thread-safe issues

### DIFF
--- a/leaf-server/minecraft-patches/features/0289-Multithreaded-Tracker.patch
+++ b/leaf-server/minecraft-patches/features/0289-Multithreaded-Tracker.patch
@@ -3,10 +3,10 @@ From: peaches94 <peachescu94@gmail.com>
 Date: Sat, 2 Jul 2022 00:35:56 -0500
 Subject: [PATCH] Multithreaded Tracker
 
-Original license: GPL v3
+Original license: GPL-3.0
 Original project: https://github.com/Bloom-host/Petal
 
-Original license: GPL v3
+Original license: GPL-3.0
 Original project: https://github.com/TECHNOVE/Airplane-Experimental
 
 Co-authored-by: Paul Sauve <paul@technove.co>
@@ -159,7 +159,7 @@ index 273bdde6b995e9167d66f228c07f5486414e550d..13ef347e24642b0a7c9ce0536c60118a
      }
      // CraftBukkit end
 diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
-index 21340bd7fd7a90dfef705c3819a391763a835e3e..d5e1ef4b6b3a882c6f05f3be35d1681bf30b485c 100644
+index 21340bd7fd7a90dfef705c3819a391763a835e3e..21cbdbb67686cb67be66ea5f0e695b47c92823a9 100644
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
 @@ -1076,6 +1076,13 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
@@ -425,7 +425,7 @@ index 21340bd7fd7a90dfef705c3819a391763a835e3e..d5e1ef4b6b3a882c6f05f3be35d1681b
 +                        && player.getBukkitEntity().canSeeChunkMapUpdatePlayer(this.entity.getBukkitEntity());
 +                    if (flag) {
 +                        if (this.seenBy.add(player.connection)) {
-+                            ctx.startSeenByPlayer(player.connection, this.serverEntity.entity);
++                            ctx.startSeenByPlayer(player.connection, this.serverEntity.entity, this.seenBy.size() == 1);
 +                            this.serverEntity.onPlayerAdd();
 +                            updated = true;
 +                        }
@@ -554,7 +554,7 @@ index f106373ef3ac4a8685c2939c9e8361688a285913..cb516acac856f30ad0e2d24648bbfd86
          if (!this.players.isEmpty()) {
              for (ServerPlayer serverPlayer : Lists.newArrayList(this.players)) {
 diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server/level/ServerEntity.java
-index 5e7f0429f8e6441b21994e92c4ecc67a4b71abd7..cfdf7d4ca6cb3c760e1f8f9a6b240edbdc1508da 100644
+index 5e7f0429f8e6441b21994e92c4ecc67a4b71abd7..057e38b58454a53af3d4bb26dfe95a10231c9456 100644
 --- a/net/minecraft/server/level/ServerEntity.java
 +++ b/net/minecraft/server/level/ServerEntity.java
 @@ -53,11 +53,11 @@ public class ServerEntity {
@@ -874,7 +874,7 @@ index 5e7f0429f8e6441b21994e92c4ecc67a4b71abd7..cfdf7d4ca6cb3c760e1f8f9a6b240edb
                  // CraftBukkit start - Send scaled max health
                  if (this.entity instanceof ServerPlayer serverPlayer) {
                      serverPlayer.getBukkitEntity().injectScaledMaxHealth(attributesToSync, false);
-@@ -437,6 +442,234 @@ public class ServerEntity {
+@@ -437,6 +442,235 @@ public class ServerEntity {
          }
      }
  
@@ -1058,6 +1058,7 @@ index 5e7f0429f8e6441b21994e92c4ecc67a4b71abd7..cfdf7d4ca6cb3c760e1f8f9a6b240edb
 +    }
 +
 +    public boolean leaf$sendPairingData(List<Packet<? super ClientGamePacketListener>> consumer) {
++        this.entity.updateDataBeforeSync();
 +        if (this.entity.isRemoved()) {
 +            // CraftBukkit start - Remove useless error spam, just return
 +            // LOGGER.warn("Fetching packet for removed entity {}", this.entity);

--- a/leaf-server/minecraft-patches/features/0289-Multithreaded-Tracker.patch
+++ b/leaf-server/minecraft-patches/features/0289-Multithreaded-Tracker.patch
@@ -554,7 +554,7 @@ index f106373ef3ac4a8685c2939c9e8361688a285913..cb516acac856f30ad0e2d24648bbfd86
          if (!this.players.isEmpty()) {
              for (ServerPlayer serverPlayer : Lists.newArrayList(this.players)) {
 diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server/level/ServerEntity.java
-index 5e7f0429f8e6441b21994e92c4ecc67a4b71abd7..315792310b7e982aa495cdf98390a74cd66b0023 100644
+index 5e7f0429f8e6441b21994e92c4ecc67a4b71abd7..cfdf7d4ca6cb3c760e1f8f9a6b240edbdc1508da 100644
 --- a/net/minecraft/server/level/ServerEntity.java
 +++ b/net/minecraft/server/level/ServerEntity.java
 @@ -53,11 +53,11 @@ public class ServerEntity {
@@ -890,7 +890,7 @@ index 5e7f0429f8e6441b21994e92c4ecc67a4b71abd7..315792310b7e982aa495cdf98390a74c
 +            this.teleportDelay = 9999;
 +        }
 +        // Paper end - optimise collisions
-+        this.entity.updateDataBeforeSync();
++        //this.entity.updateDataBeforeSync(); // Move to AsyncTracker#handlePlayer
 +        List<Entity> passengers = this.entity.getPassengers();
 +        if (!passengers.equals(this.lastPassengers)) {
 +            ctx.sendToTrackingPlayersFiltered(

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/AsyncTracker.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/AsyncTracker.java
@@ -47,7 +47,7 @@ public final class AsyncTracker {
     }
 
     public void tick(ServerLevel world) {
-        handlePlayerVelocity(world);
+        handlePlayer(world);
         ServerEntityLookup entityLookup = (ServerEntityLookup) world.moonrise$getEntityLookup();
         ca.spottedleaf.moonrise.common.list.ReferenceList<Entity> trackerEntities = entityLookup.trackerEntities;
         int trackerEntitiesSize = trackerEntities.size();
@@ -68,8 +68,10 @@ public final class AsyncTracker {
         this.fut = futures;
     }
 
-    private static void handlePlayerVelocity(ServerLevel world) {
+    private static void handlePlayer(ServerLevel world) {
         for (ServerPlayer player : world.players()) {
+            player.updateDataBeforeSync();
+
             if (!player.hurtMarked) {
                 continue;
             }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
@@ -50,6 +50,7 @@ public final class TrackerCtx {
     private final ObjectArrayList<ChunkMap.TrackedEntity> resync = new ObjectArrayList<>();
     private final ObjectArrayList<ChunkMap.TrackedEntity> pluginEntity = new ObjectArrayList<>();
     private final ObjectArrayList<ChunkMap.TrackedEntity> syncAttributes = new ObjectArrayList<>();
+    private final ObjectArrayList<Entity> debugRegistration = new ObjectArrayList<>();
 
     private record BossEvent(WitherBoss witherBoss,
                              ObjectArrayList<ServerPlayer> add,
@@ -93,6 +94,9 @@ public final class TrackerCtx {
                 witherBosses.add(new BossEvent(witherBoss, new ObjectArrayList<>(), new ObjectArrayList<>()));
             }
             witherBosses.getLast().add.add(connection.getPlayer());
+        }
+        if (flag) {
+            debugRegistration.add(entity);
         }
     }
 
@@ -142,6 +146,7 @@ public final class TrackerCtx {
         pluginEntity.addAll(other.pluginEntity);
         resync.addAll(other.resync);
         syncAttributes.addAll(other.syncAttributes);
+        debugRegistration.addAll(other.debugRegistration);
         return other.packets;
     }
 
@@ -153,6 +158,7 @@ public final class TrackerCtx {
         pluginEntity.clear();
         resync.clear();
         syncAttributes.clear();
+        debugRegistration.clear();
         packets.clear();
     }
 
@@ -165,6 +171,11 @@ public final class TrackerCtx {
 
         if (!startSeen.isEmpty()) {
             boolean callEvent = PlayerTrackEntityEvent.getHandlerList().getRegisteredListeners().length != 0;
+            for (Entity entity : debugRegistration) {
+                if (entity.moonrise$getTrackedEntity() != null && !entity.isRemoved()) {
+                    world.debugSynchronizers().registerEntity(entity);
+                }
+            }
             for (StartSeen startSeen : startSeen) {
                 handleStartTrack(startSeen, callEvent);
             }
@@ -271,17 +282,21 @@ public final class TrackerCtx {
                 player.getBukkitEntity(),
                 startSeen.e.getBukkitEntity()
             ).callEvent()) {
-            } else if (player.level() == world) {
-                ClientboundBundlePacket toSend;
-                if (flag && player == startSeen.e) {
-                    ObjectArrayList<Packet<? super ClientGamePacketListener>> copy = new ObjectArrayList<>(list);
-                    copy.add(new ClientboundUpdateAttributesPacket(startSeen.e.getId(), List.of(player.getBukkitEntity().getScaledMaxHealth())));
-                    toSend = new ClientboundBundlePacket(copy);
-                } else {
-                    toSend = packet;
-                }
-                connection.send(toSend);
+                continue;
+            } else if (player.level() != world) {
+                // do not send old entities if it changed dimension
+                continue;
             }
+            ClientboundBundlePacket toSend;
+            if (flag && player == startSeen.e) {
+                ObjectArrayList<Packet<? super ClientGamePacketListener>> copy = new ObjectArrayList<>(list);
+                copy.add(new ClientboundUpdateAttributesPacket(startSeen.e.getId(), List.of(player.getBukkitEntity().getScaledMaxHealth())));
+                toSend = new ClientboundBundlePacket(copy);
+            } else {
+                toSend = packet;
+            }
+            connection.send(toSend); // #startTrackingEntity call after #send
+            world.debugSynchronizers().startTrackingEntity(player, startSeen.e);
         }
     }
 
@@ -295,6 +310,7 @@ public final class TrackerCtx {
                 ).callEvent();
             }
             if (tracker == null || !tracker.seenBy.contains(player.connection)) {
+                // client side will clean entities if it has changed dimension
                 send(player.connection, new ClientboundRemoveEntitiesPacket(untrack.e.getId()));
             }
         }

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/tracker/TrackerCtx.java
@@ -36,7 +36,6 @@ import org.dreeam.leaf.util.map.AttributeInstanceArrayMap;
 
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Predicate;
 
 public final class TrackerCtx {
@@ -84,7 +83,7 @@ public final class TrackerCtx {
         }
     }
 
-    public void startSeenByPlayer(ServerPlayerConnection connection, Entity entity) {
+    public void startSeenByPlayer(ServerPlayerConnection connection, Entity entity, boolean flag) {
         if (startSeen.isEmpty() || !startSeen.getLast().e.equals(entity)) {
             startSeen.add(new StartSeen(entity, new ObjectArrayList<>()));
         }
@@ -164,16 +163,12 @@ public final class TrackerCtx {
             }
         }
 
-        Object2ObjectOpenHashMap<ServerPlayerConnection, ObjectArrayList<Packet<?>>> prior = new Object2ObjectOpenHashMap<>();
-
         if (!startSeen.isEmpty()) {
             boolean callEvent = PlayerTrackEntityEvent.getHandlerList().getRegisteredListeners().length != 0;
             for (StartSeen startSeen : startSeen) {
-                handleStartTrack(startSeen, prior, callEvent);
+                handleStartTrack(startSeen, callEvent);
             }
         }
-
-        flush(world, prior);
 
         for (Object2ObjectOpenHashMap<ServerPlayerConnection, ObjectArrayList<Packet<?>>> otherPackets : other) {
             flush(world, otherPackets);
@@ -195,20 +190,7 @@ public final class TrackerCtx {
         if (!stopSeen.isEmpty()) {
             boolean callEvent = PlayerUntrackEntityEvent.getHandlerList().getRegisteredListeners().length != 0;
             for (StopSeen untrack : stopSeen) {
-                for (ServerPlayer player : untrack.q) {
-                    if (world == player.level()) {
-                        if (callEvent) {
-                            new PlayerUntrackEntityEvent(
-                                player.getBukkitEntity(),
-                                untrack.e.getBukkitEntity()
-                            ).callEvent();
-                        }
-                        ChunkMap.TrackedEntity tracker = untrack.e.moonrise$getTrackedEntity();
-                        if (tracker == null || !tracker.seenBy.contains(player.connection)) {
-                            send(player.connection, new ClientboundRemoveEntitiesPacket(untrack.e.getId()));
-                        }
-                    }
-                }
+                handleStopTrack(untrack, callEvent);
             }
         }
 
@@ -273,7 +255,7 @@ public final class TrackerCtx {
         }
     }
 
-    private void handleStartTrack(StartSeen startSeen, Object2ObjectOpenHashMap<ServerPlayerConnection, ObjectArrayList<Packet<?>>> prior, boolean callEvent) {
+    private void handleStartTrack(StartSeen startSeen, boolean callEvent) {
         ChunkMap.TrackedEntity tracker = startSeen.e.moonrise$getTrackedEntity();
         ObjectArrayList<Packet<? super ClientGamePacketListener>> list = new ObjectArrayList<>(4);
         if (tracker == null) {
@@ -283,20 +265,41 @@ public final class TrackerCtx {
         boolean flag = tracker.serverEntity.leaf$sendPairingData(list);
         ClientboundBundlePacket packet = new ClientboundBundlePacket(list);
         for (ServerPlayerConnection connection : startSeen.q) {
+            ServerPlayer player = connection.getPlayer();
             if (callEvent
                 && !new PlayerTrackEntityEvent(
-                connection.getPlayer().getBukkitEntity(),
+                player.getBukkitEntity(),
                 startSeen.e.getBukkitEntity()
             ).callEvent()) {
-                send(connection, new ClientboundRemoveEntitiesPacket(startSeen.e.getId()));
-            } else if (flag && connection.getPlayer() == startSeen.e) {
-                var copy = new ObjectArrayList<>(list);
-                copy.add(new ClientboundUpdateAttributesPacket(startSeen.e.getId(), List.of(connection.getPlayer().getBukkitEntity().getScaledMaxHealth())));
-                var modified = new ClientboundBundlePacket(copy);
-                prior.computeIfAbsent(connection, INIT_PACKET_LIST).add(modified);
-            } else {
-                prior.computeIfAbsent(connection, INIT_PACKET_LIST).add(packet);
+            } else if (player.level() == world) {
+                ClientboundBundlePacket toSend;
+                if (flag && player == startSeen.e) {
+                    ObjectArrayList<Packet<? super ClientGamePacketListener>> copy = new ObjectArrayList<>(list);
+                    copy.add(new ClientboundUpdateAttributesPacket(startSeen.e.getId(), List.of(player.getBukkitEntity().getScaledMaxHealth())));
+                    toSend = new ClientboundBundlePacket(copy);
+                } else {
+                    toSend = packet;
+                }
+                connection.send(toSend);
             }
+        }
+    }
+
+    private void handleStopTrack(StopSeen untrack, boolean callEvent) {
+        ChunkMap.TrackedEntity tracker = untrack.e.moonrise$getTrackedEntity();
+        for (ServerPlayer player : untrack.q) {
+            if (callEvent) {
+                new PlayerUntrackEntityEvent(
+                    player.getBukkitEntity(),
+                    untrack.e.getBukkitEntity()
+                ).callEvent();
+            }
+            if (tracker == null || !tracker.seenBy.contains(player.connection)) {
+                send(player.connection, new ClientboundRemoveEntitiesPacket(untrack.e.getId()));
+            }
+        }
+        if (tracker == null || tracker.seenBy.isEmpty()) {
+            world.debugSynchronizers().dropEntity(untrack.e);
         }
     }
 


### PR DESCRIPTION
Player#updateDataBeforeSync is introduced in 1.21.11, and player effects storage is not thread-safe, so just run it before sending changes asynchronously.

Changes:
- Run player's effect status update before sync on main to fix the crash caused by thread-safe issue.
- Add missing `Player#updateDataBeforeSync` in async tracker's sendPairingData
- Cleanup

Error:
```
[09:11:10] [Server thread/ERROR]: Encountered an unexpected exception
net.minecraft.ReportedException: Exception ticking world
	at net.minecraft.server.MinecraftServer.tickLevel(MinecraftServer.java:1877) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1968) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1717) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:492) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1774) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1438) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:429) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
Caused by: java.lang.RuntimeException: java.util.concurrent.ExecutionException: java.util.ConcurrentModificationException
	at org.dreeam.leaf.async.tracker.AsyncTracker.handle(AsyncTracker.java:143) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at org.dreeam.leaf.async.tracker.AsyncTracker.onEntitiesTickEnd(AsyncTracker.java:111) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:1065) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.server.MinecraftServer.tickLevel(MinecraftServer.java:1865) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	... 7 more
Caused by: java.util.concurrent.ExecutionException: java.util.ConcurrentModificationException
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:124) ~[?:?]
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:193) ~[?:?]
	at org.dreeam.leaf.async.tracker.AsyncTracker.handle(AsyncTracker.java:136) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	... 10 more
Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1606) ~[?:?]
	at java.base/java.util.HashMap$ValueIterator.next(HashMap.java:1634) ~[?:?]
	at net.minecraft.world.entity.LivingEntity.areAllEffectsAmbient(LivingEntity.java:1124) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.world.entity.LivingEntity.updateSynchronizedMobEffectParticles(LivingEntity.java:1052) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.world.entity.LivingEntity.updateInvisibilityStatus(LivingEntity.java:1036) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.world.entity.LivingEntity.updateDirtyEffects(LivingEntity.java:1024) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.world.entity.LivingEntity.updateDataBeforeSync(LivingEntity.java:940) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at net.minecraft.server.level.ServerEntity.leaf$sendChanges(ServerEntity.java:457) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at org.dreeam.leaf.async.tracker.TrackerTask.call(TrackerTask.java:39) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at org.dreeam.leaf.async.tracker.TrackerTask.call(TrackerTask.java:14) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:328) ~[?:?]
	at org.dreeam.leaf.async.FixedThreadExecutor$Worker.run(FixedThreadExecutor.java:78) ~[leaf-1.21.11.jar:1.21.11-DEV-821cb72]
	... 1 more
[09:11:10] [Server thread/ERROR]: This crash report has been saved to: /minecraft/survival/crash-reports/crash-2026-01-19_09.11.10-server.txt
[09:11:10] [Server thread/INFO]: Stopping server
```
