### PR TITLE
Fix MC-270656

### DIFF
--- a/leaf-server/minecraft-patches/features/0295-Fix-MC-270656.patch
+++ b/leaf-server/minecraft-patches/features/0295-Fix-MC-270656.patch
@@ -3,6 +3,7 @@ From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 Date: Tue, 9 Nov 2077 00:00:00 +0800
 Subject: [PATCH] Fix MC-270656
 
+Related MC issue: https://mojira.dev/MC-270656
 
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
 index cf22a560c331f08f7c1729ad5a40d966e1726a96..1aa47d5f25de08114abd9a179999b9993e3f0ef4 100644

--- a/leaf-server/minecraft-patches/features/0295-Fix-MC-270656.patch
+++ b/leaf-server/minecraft-patches/features/0295-Fix-MC-270656.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Fix MC-270656
+
+
+diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
+index cf22a560c331f08f7c1729ad5a40d966e1726a96..1aa47d5f25de08114abd9a179999b9993e3f0ef4 100644
+--- a/net/minecraft/server/level/ServerPlayer.java
++++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -1090,6 +1090,13 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+     }
+ 
+     public void trackStartFallingPosition() {
++        // Leaf start - Fix MC-270656
++        if (org.dreeam.leaf.config.modules.fixes.MCBugFix.mc270656) {
++            if (this.currentImpulseImpactPos != null && (this.getAbilities().flying || this.isFallFlying())) {
++                this.currentImpulseImpactPos = null;
++            }
++        }
++        // Leaf end - Fix MC-270656
+         if (this.fallDistance > 0.0 && this.startingToFallPosition == null) {
+             this.startingToFallPosition = this.position();
+             if (this.currentImpulseImpactPos != null && this.currentImpulseImpactPos.y <= this.startingToFallPosition.y) {

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/MCBugFix.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/MCBugFix.java
@@ -6,7 +6,7 @@ import org.dreeam.leaf.config.EnumConfigCategory;
 public class MCBugFix extends ConfigModules {
 
     public String getBasePath() {
-        return EnumConfigCategory.GAMEPLAY.getBaseKeyName() + ".vanilla-bug-fix";
+        return EnumConfigCategory.FIXES.getBaseKeyName() + ".vanilla-bug-fix";
     }
 
     public static boolean mc270656 = false;

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/MCBugFix.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/MCBugFix.java
@@ -1,0 +1,29 @@
+package org.dreeam.leaf.config.modules.fixes;
+
+import org.dreeam.leaf.config.ConfigModules;
+import org.dreeam.leaf.config.EnumConfigCategory;
+
+public class MCBugFix extends ConfigModules {
+
+    public String getBasePath() {
+        return EnumConfigCategory.GAMEPLAY.getBaseKeyName() + ".vanilla-bug-fix";
+    }
+
+    public static boolean mc270656 = false;
+
+    @Override
+    public void onLoaded() {
+        config.addCommentRegionBased(getBasePath(),
+            "Fixes for vanilla Minecraft bugs.",
+            "针对 Minecraft 原版的漏洞修复."
+        );
+        mc270656 = config.getBoolean(getBasePath() + ".mc-270656", mc270656, config.pickStringRegionBased(
+            """
+                Who needs rockets? advancement is being granted incorrectly.
+                Mojira link: https://mojira.dev/MC-270656""",
+            """
+                还要啥火箭啊? 进度触发器检查逻辑漏洞.
+                漏洞跟踪器链接: https://mojira.dev/MC-270656"""
+        ));
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/MCBugFix.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/fixes/MCBugFix.java
@@ -15,15 +15,15 @@ public class MCBugFix extends ConfigModules {
     public void onLoaded() {
         config.addCommentRegionBased(getBasePath(),
             "Fixes for vanilla Minecraft bugs.",
-            "针对 Minecraft 原版的漏洞修复."
+            "针对 Minecraft 原版的漏洞修复。"
         );
         mc270656 = config.getBoolean(getBasePath() + ".mc-270656", mc270656, config.pickStringRegionBased(
             """
-                Who needs rockets? advancement is being granted incorrectly.
+                Whether to fix incorrect granting of 'Who needs rockets?' advancement.
                 Mojira link: https://mojira.dev/MC-270656""",
             """
-                还要啥火箭啊? 进度触发器检查逻辑漏洞.
-                漏洞跟踪器链接: https://mojira.dev/MC-270656"""
+                是否修复“还要啥火箭啊？”进度触发的错误检查逻辑。
+                漏洞跟踪器链接：https://mojira.dev/MC-270656"""
         ));
     }
 }


### PR DESCRIPTION
Mojira link: https://mojira.dev/MC-270656

Cause: currentImpulseImpactPos is not getting reset on flying or elytra gliding.