### PR TITLE
Fix LithiumHashPalette

### DIFF
--- a/leaf-server/minecraft-patches/features/0294-Lithium-faster-hash-palette.patch
+++ b/leaf-server/minecraft-patches/features/0294-Lithium-faster-hash-palette.patch
@@ -3,17 +3,40 @@ From: Dreeam <61569423+Dreeam-qwq@users.noreply.github.com>
 Date: Sun, 18 Jan 2026 03:17:42 -0500
 Subject: [PATCH] Lithium: faster hash palette
 
-TODO: Needs to check compatibility with FAWE's //copy **//paste**
-data stored in LithiumHashPalette looks like exactly same with in HashMapPalette
-And it can work well on WorldEdit, but not on FAWE
-Also see https://github.com/IntellectualSites/FastAsyncWorldEdit/issues/3437
-
 This patch is based on the following mixins:
 * "net/caffeinemc/mods/lithium/mixin/chunk/palette/StrategyMixin.java"
 By: 2No2Name <2No2Name@web.de>
 As part of: Lithium (https://github.com/CaffeineMC/lithium)
 Licensed under: LGPL-3.0 (https://www.gnu.org/licenses/lgpl-3.0.html)
 
+diff --git a/net/minecraft/world/level/chunk/HashMapPalette.java b/net/minecraft/world/level/chunk/HashMapPalette.java
+index 5b9346b25aa01db9f3c36e243f46846b87a6eb75..2d73bddc6375584d1594acd8c48ee3502a89c2b4 100644
+--- a/net/minecraft/world/level/chunk/HashMapPalette.java
++++ b/net/minecraft/world/level/chunk/HashMapPalette.java
+@@ -14,7 +14,7 @@ public class HashMapPalette<T> implements Palette<T>, ca.spottedleaf.moonrise.pa
+ 
+     // Paper start - optimise palette reads
+     @Override
+-    public final T[] moonrise$getRawPalette(final ca.spottedleaf.moonrise.patches.fast_palette.FastPaletteData<T> container) {
++    public T[] moonrise$getRawPalette(final ca.spottedleaf.moonrise.patches.fast_palette.FastPaletteData<T> container) { // Leaf - Lithium - faster hash palette - public final -> public
+         return ((ca.spottedleaf.moonrise.patches.fast_palette.FastPalette<T>)this.values).moonrise$getRawPalette(container);
+     }
+     // Paper end - optimise palette reads
+@@ -28,6 +28,14 @@ public class HashMapPalette<T> implements Palette<T>, ca.spottedleaf.moonrise.pa
+         this(bits, CrudeIncrementalIntIdentityHashBiMap.create((1 << bits) + 1)); // Paper - Perf: Avoid unnecessary resize operation in CrudeIncrementalIntIdentityHashBiMap
+     }
+ 
++    // Leaf start - Lithium - faster hash palette
++    protected HashMapPalette(int bits, boolean dummy) {
++        this.bits = bits;
++        //noinspection DataFlowIssue
++        this.values = dummy ? null : CrudeIncrementalIntIdentityHashBiMap.create((1 << bits) + 1);
++    }
++    // Leaf end - Lithium - faster hash palette
++
+     private HashMapPalette(int bits, CrudeIncrementalIntIdentityHashBiMap<T> values) {
+         this.bits = bits;
+         this.values = values;
 diff --git a/net/minecraft/world/level/chunk/Strategy.java b/net/minecraft/world/level/chunk/Strategy.java
 index 787f5173425f617a89033e5b76256688be36b31d..a08756342f3cdb3a1188b2e6e56c59c4742db0d1 100644
 --- a/net/minecraft/world/level/chunk/Strategy.java

--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/LithiumHashPalette.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/LithiumHashPalette.java
@@ -2,6 +2,8 @@
 
 package net.caffeinemc.mods.lithium.common.world.chunk;
 
+import ca.spottedleaf.moonrise.patches.fast_palette.FastPalette;
+import ca.spottedleaf.moonrise.patches.fast_palette.FastPaletteData;
 import it.unimi.dsi.fastutil.HashCommon;
 import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 import net.minecraft.CrashReport;
@@ -10,12 +12,13 @@ import net.minecraft.ReportedException;
 import net.minecraft.core.IdMap;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.VarInt;
+import net.minecraft.world.level.chunk.HashMapPalette;
 import net.minecraft.world.level.chunk.MissingPaletteEntryException;
 import net.minecraft.world.level.chunk.Palette;
 import net.minecraft.world.level.chunk.PaletteResize;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
@@ -24,9 +27,9 @@ import static it.unimi.dsi.fastutil.Hash.FAST_LOAD_FACTOR;
 
 /**
  * Generally provides better performance over the vanilla {@link net.minecraft.world.level.chunk.HashMapPalette} when calling
- * {@link LithiumHashPalette#idFor(Object, PaletteResize<T>)} through using a faster backing map and reducing pointer chasing.
+ * {@link LithiumHashPalette#idFor(Object, PaletteResize)} through using a faster backing map and reducing pointer chasing.
  */
-public class LithiumHashPalette<T> implements Palette<T> {
+public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<T>, FastPalette<T> {
     private static final int ABSENT_VALUE = -1;
 
     private final int indexBits;
@@ -36,6 +39,7 @@ public class LithiumHashPalette<T> implements Palette<T> {
     private int size = 0;
 
     private LithiumHashPalette(int indexBits, T[] entries, Reference2IntOpenHashMap<T> table, int size) {
+        super(size, true);
         this.indexBits = indexBits;
         this.entries = entries;
         this.table = table;
@@ -52,6 +56,7 @@ public class LithiumHashPalette<T> implements Palette<T> {
 
     @SuppressWarnings("unchecked")
     public LithiumHashPalette(int bits) {
+        super(bits, true);
         this.indexBits = bits;
 
         int capacity = 1 << bits;
@@ -60,6 +65,13 @@ public class LithiumHashPalette<T> implements Palette<T> {
         this.table = new Reference2IntOpenHashMap<>(capacity, FAST_LOAD_FACTOR);
         this.table.defaultReturnValue(ABSENT_VALUE);
     }
+
+    // Leaf start - Sync moonrise changes
+    @Override
+    public final T @NonNull [] moonrise$getRawPalette(final @NonNull FastPaletteData<T> container) {
+        return this.entries;
+    }
+    // Leaf end - Sync moonrise changes
 
     @Override
     public int idFor(@NotNull T obj, @NotNull PaletteResize<T> paletteResize) {
@@ -198,7 +210,15 @@ public class LithiumHashPalette<T> implements Palette<T> {
         return Arrays.asList(copy);
     }
 
-    public static <A> Palette<A> create(int bits, List<A> list) {
-        return new LithiumHashPalette<>(bits, new ArrayList<>(list));
+    // Leaf start - override getEntries
+    @Override
+    public @NonNull List<T> getEntries() {
+        T[] copy = Arrays.copyOf(this.entries, this.size);
+        return Arrays.asList(copy);
+    }
+    // Leaf end - override getEntries
+
+    public static <A> @NonNull Palette<A> create(int bits, @NonNull List<A> list) {
+        return new LithiumHashPalette<>(bits, list);
     }
 }

--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/LithiumHashPalette.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/LithiumHashPalette.java
@@ -28,7 +28,7 @@ import static it.unimi.dsi.fastutil.Hash.FAST_LOAD_FACTOR;
  * Generally provides better performance over the vanilla {@link net.minecraft.world.level.chunk.HashMapPalette} when calling
  * {@link LithiumHashPalette#idFor(Object, PaletteResize)} through using a faster backing map and reducing pointer chasing.
  */
-public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<T>, FastPalette<T> {
+public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<T>, FastPalette<T> {
     private static final int ABSENT_VALUE = -1;
 
     private final int indexBits;
@@ -67,7 +67,7 @@ public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<
 
     // Leaf start - Sync moonrise changes
     @Override
-    public final T @NonNull [] moonrise$getRawPalette(final @NonNull FastPaletteData<T> container) {
+    public T @NonNull [] moonrise$getRawPalette(final @NonNull FastPaletteData<T> container) {
         return this.entries;
     }
     // Leaf end - Sync moonrise changes

--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/LithiumHashPalette.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/LithiumHashPalette.java
@@ -16,7 +16,6 @@ import net.minecraft.world.level.chunk.HashMapPalette;
 import net.minecraft.world.level.chunk.MissingPaletteEntryException;
 import net.minecraft.world.level.chunk.Palette;
 import net.minecraft.world.level.chunk.PaletteResize;
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Arrays;
@@ -74,7 +73,7 @@ public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<
     // Leaf end - Sync moonrise changes
 
     @Override
-    public int idFor(@NotNull T obj, @NotNull PaletteResize<T> paletteResize) {
+    public int idFor(@NonNull T obj, @NonNull PaletteResize<T> paletteResize) {
         int id = this.table.getInt(obj);
 
         if (id == ABSENT_VALUE) {
@@ -85,7 +84,7 @@ public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<
     }
 
     @Override
-    public boolean maybeHas(@NotNull Predicate<T> predicate) {
+    public boolean maybeHas(@NonNull Predicate<T> predicate) {
         for (int i = 0; i < this.size; ++i) {
             if (predicate.test(this.entries[i])) {
                 return true;
@@ -129,7 +128,7 @@ public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<
     }
 
     @Override
-    public @NotNull T valueFor(int id) {
+    public @NonNull T valueFor(int id) {
         T[] entries = this.entries;
 
         T entry = null;
@@ -158,7 +157,7 @@ public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<
     }
 
     @Override
-    public void read(FriendlyByteBuf buf, @NotNull IdMap<T> idMap) {
+    public void read(FriendlyByteBuf buf, @NonNull IdMap<T> idMap) {
         this.clear();
 
         int entryCount = buf.readVarInt();
@@ -169,7 +168,7 @@ public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<
     }
 
     @Override
-    public void write(FriendlyByteBuf buf, @NotNull IdMap<T> idMap) {
+    public void write(FriendlyByteBuf buf, @NonNull IdMap<T> idMap) {
         int size = this.size;
         buf.writeVarInt(size);
 
@@ -179,7 +178,7 @@ public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<
     }
 
     @Override
-    public int getSerializedSize(@NotNull IdMap<T> idMap) {
+    public int getSerializedSize(@NonNull IdMap<T> idMap) {
         int size = VarInt.getByteSize(this.size);
 
         for (int i = 0; i < this.size; ++i) {
@@ -195,7 +194,7 @@ public class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<
     }
 
     @Override
-    public @NotNull Palette<T> copy() {
+    public @NonNull Palette<T> copy() {
         return new LithiumHashPalette<>(this.indexBits, this.entries.clone(), this.table.clone(), this.size);
     }
 

--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/LithiumHashPalette.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/LithiumHashPalette.java
@@ -16,7 +16,7 @@ import net.minecraft.world.level.chunk.HashMapPalette;
 import net.minecraft.world.level.chunk.MissingPaletteEntryException;
 import net.minecraft.world.level.chunk.Palette;
 import net.minecraft.world.level.chunk.PaletteResize;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +28,7 @@ import static it.unimi.dsi.fastutil.Hash.FAST_LOAD_FACTOR;
  * Generally provides better performance over the vanilla {@link net.minecraft.world.level.chunk.HashMapPalette} when calling
  * {@link LithiumHashPalette#idFor(Object, PaletteResize)} through using a faster backing map and reducing pointer chasing.
  */
+@NullMarked
 public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Palette<T>, FastPalette<T> {
     private static final int ABSENT_VALUE = -1;
 
@@ -67,13 +68,13 @@ public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Pa
 
     // Leaf start - Sync moonrise changes
     @Override
-    public T @NonNull [] moonrise$getRawPalette(final @NonNull FastPaletteData<T> container) {
+    public T[] moonrise$getRawPalette(final FastPaletteData<T> container) {
         return this.entries;
     }
     // Leaf end - Sync moonrise changes
 
     @Override
-    public int idFor(@NonNull T obj, @NonNull PaletteResize<T> paletteResize) {
+    public int idFor(T obj, PaletteResize<T> paletteResize) {
         int id = this.table.getInt(obj);
 
         if (id == ABSENT_VALUE) {
@@ -84,7 +85,7 @@ public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Pa
     }
 
     @Override
-    public boolean maybeHas(@NonNull Predicate<T> predicate) {
+    public boolean maybeHas(Predicate<T> predicate) {
         for (int i = 0; i < this.size; ++i) {
             if (predicate.test(this.entries[i])) {
                 return true;
@@ -128,7 +129,7 @@ public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Pa
     }
 
     @Override
-    public @NonNull T valueFor(int id) {
+    public T valueFor(int id) {
         T[] entries = this.entries;
 
         T entry = null;
@@ -157,7 +158,7 @@ public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Pa
     }
 
     @Override
-    public void read(FriendlyByteBuf buf, @NonNull IdMap<T> idMap) {
+    public void read(FriendlyByteBuf buf, IdMap<T> idMap) {
         this.clear();
 
         int entryCount = buf.readVarInt();
@@ -168,7 +169,7 @@ public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Pa
     }
 
     @Override
-    public void write(FriendlyByteBuf buf, @NonNull IdMap<T> idMap) {
+    public void write(FriendlyByteBuf buf, IdMap<T> idMap) {
         int size = this.size;
         buf.writeVarInt(size);
 
@@ -178,7 +179,7 @@ public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Pa
     }
 
     @Override
-    public int getSerializedSize(@NonNull IdMap<T> idMap) {
+    public int getSerializedSize(IdMap<T> idMap) {
         int size = VarInt.getByteSize(this.size);
 
         for (int i = 0; i < this.size; ++i) {
@@ -194,7 +195,7 @@ public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Pa
     }
 
     @Override
-    public @NonNull Palette<T> copy() {
+    public Palette<T> copy() {
         return new LithiumHashPalette<>(this.indexBits, this.entries.clone(), this.table.clone(), this.size);
     }
 
@@ -211,13 +212,13 @@ public final class LithiumHashPalette<T> extends HashMapPalette<T> implements Pa
 
     // Leaf start - override getEntries
     @Override
-    public @NonNull List<T> getEntries() {
+    public List<T> getEntries() {
         T[] copy = Arrays.copyOf(this.entries, this.size);
         return Arrays.asList(copy);
     }
     // Leaf end - override getEntries
 
-    public static <A> @NonNull Palette<A> create(int bits, @NonNull List<A> list) {
+    public static <A> Palette<A> create(int bits, List<A> list) {
         return new LithiumHashPalette<>(bits, list);
     }
 }


### PR DESCRIPTION
FAWE detects vanilla Palettes with `instanceof LinearPalette` and `HashMapPalette`, LithiumHashPalette will be considered as GlobalPalette and fall to the else branch, causing incompatibilities.