### PR TITLE
optimize-movement-vector-normalization

### DIFF
--- a/leaf-server/minecraft-patches/features/0294-optimize-movement-vector-normalization.patch
+++ b/leaf-server/minecraft-patches/features/0294-optimize-movement-vector-normalization.patch
@@ -5,21 +5,20 @@ Subject: [PATCH] optimize movement vector normalization
 
 
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 8d092716cdcc48b829a1c0ee2e5416d648143a37..310fcb589f515b223d2b263ee99f734cd876f926 100644
+index 8d092716cdcc48b829a1c0ee2e5416d648143a37..11b9dd30605926e6cc1c1a750be945c0f3063edc 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
-@@ -1262,8 +1262,16 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+@@ -1262,8 +1262,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
              double d = vec3.lengthSqr();
              if (d > 1.0E-7 || movement.lengthSqr() - d < 1.0E-7) {
                  if (this.fallDistance != 0.0 && d >= 1.0) {
 -                    double min = Math.min(vec3.length(), 8.0);
 -                    Vec3 vec31 = this.position().add(vec3.normalize().scale(min));
 +                    // Leaf start - optimize movement vector normalization
-+                    //double min = Math.min(vec3.length(), 8.0);
-+                    //Vec3 vec31 = this.position().add(vec3.normalize().scale(min));
 +                    Vec3 vec31;
 +                    if (d > 64.0) {
-+                        vec31 = this.position().add(vec3.normalize().scale(8.0));
++                        double scale = 8.0 / Math.sqrt(d);
++                        vec31 = this.position().add(vec3.x * scale, vec3.y * scale, vec3.z * scale);
 +                    } else {
 +                        vec31 = this.position().add(vec3);
 +                    }

--- a/leaf-server/minecraft-patches/features/0294-optimize-movement-vector-normalization.patch
+++ b/leaf-server/minecraft-patches/features/0294-optimize-movement-vector-normalization.patch
@@ -3,6 +3,15 @@ From: VeVeVeVel <147647046+VeVeVeVel@users.noreply.github.com>
 Date: Mon, 26 Jan 2026 22:24:02 +0900
 Subject: [PATCH] optimize movement vector normalization
 
+The previous implementation always calculated the scalar length and normalized the vector, even if the vector's length
+was already less than or equal to the maximum threshold `8.0`. Since `vec3.length()` involves a square root operation
+(`\sqrt{x}`), performing it unnecessarily can impact performance in high-frequency movement logic.
+
+I have replaced the unconditional normalization with a conditional check based on the squared length ():
+
+- If  (`d > 64.0 (8^2)`): The vector exceeds the maximum distance. We normalize and scale it to .
+- If `d <= 64.0`: The vector is already within the  limit. We can use the original `vec3` directly, skipping the
+`length()`, `normalize()`, and `scale()` calls entirely.
 
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
 index 8d092716cdcc48b829a1c0ee2e5416d648143a37..10406c921f85ddc983264d4a17a048397db9bd8f 100644

--- a/leaf-server/minecraft-patches/features/0294-optimize-movement-vector-normalization.patch
+++ b/leaf-server/minecraft-patches/features/0294-optimize-movement-vector-normalization.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] optimize movement vector normalization
 
 
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 8d092716cdcc48b829a1c0ee2e5416d648143a37..11b9dd30605926e6cc1c1a750be945c0f3063edc 100644
+index 8d092716cdcc48b829a1c0ee2e5416d648143a37..10406c921f85ddc983264d4a17a048397db9bd8f 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -1262,8 +1262,15 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
@@ -20,7 +20,7 @@ index 8d092716cdcc48b829a1c0ee2e5416d648143a37..11b9dd30605926e6cc1c1a750be945c0
 +                        double scale = 8.0 / Math.sqrt(d);
 +                        vec31 = this.position().add(vec3.x * scale, vec3.y * scale, vec3.z * scale);
 +                    } else {
-+                        vec31 = this.position().add(vec3);
++                        vec31 = this.position().add(vec3.x, vec3.y, vec3.z);
 +                    }
 +                    // Leaf end - optimize movement vector normalization
                      BlockHitResult blockHitResult = this.level()

--- a/leaf-server/minecraft-patches/features/0294-optimize-movement-vector-normalization.patch
+++ b/leaf-server/minecraft-patches/features/0294-optimize-movement-vector-normalization.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: VeVeVeVel <147647046+VeVeVeVel@users.noreply.github.com>
+Date: Mon, 26 Jan 2026 22:24:02 +0900
+Subject: [PATCH] optimize movement vector normalization
+
+
+diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
+index 8d092716cdcc48b829a1c0ee2e5416d648143a37..310fcb589f515b223d2b263ee99f734cd876f926 100644
+--- a/net/minecraft/world/entity/Entity.java
++++ b/net/minecraft/world/entity/Entity.java
+@@ -1262,8 +1262,16 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
+             double d = vec3.lengthSqr();
+             if (d > 1.0E-7 || movement.lengthSqr() - d < 1.0E-7) {
+                 if (this.fallDistance != 0.0 && d >= 1.0) {
+-                    double min = Math.min(vec3.length(), 8.0);
+-                    Vec3 vec31 = this.position().add(vec3.normalize().scale(min));
++                    // Leaf start - optimize movement vector normalization
++                    //double min = Math.min(vec3.length(), 8.0);
++                    //Vec3 vec31 = this.position().add(vec3.normalize().scale(min));
++                    Vec3 vec31;
++                    if (d > 64.0) {
++                        vec31 = this.position().add(vec3.normalize().scale(8.0));
++                    } else {
++                        vec31 = this.position().add(vec3);
++                    }
++                    // Leaf end - optimize movement vector normalization
+                     BlockHitResult blockHitResult = this.level()
+                         .clip(new ClipContext(this.position(), vec31, ClipContext.Block.FALLDAMAGE_RESETTING, ClipContext.Fluid.WATER, this));
+                     if (blockHitResult.getType() != HitResult.Type.MISS) {


### PR DESCRIPTION
## PR Description: Optimize movement vector normalization

### **Summary**

This PR optimizes the movement vector calculation by avoiding redundant `Math.min()` and `normalize()` operations when the squared length of the vector is already within known bounds.

### **Problem**

The previous implementation always calculated the scalar length and normalized the vector, even if the vector's length was already less than or equal to the maximum threshold ($8.0$). Since `vec3.length()` involves a square root operation ($\sqrt{x}$), performing it unnecessarily can impact performance in high-frequency movement logic.

### **Changes**

I have replaced the unconditional normalization with a conditional check based on the squared length ():

* **If  ($d > 64.0$ ($8^2$)):** The vector exceeds the maximum distance. We normalize and scale it to .
* **If $d \leq 64.0$:** The vector is already within the  limit. We can use the original `vec3` directly, skipping the `length()`, `normalize()`, and `scale()` calls entirely.

### **Impact**

* **Performance:** Reduces CPU cycles by skipping square root and division operations for movement vectors with a magnitude .
* **Logic:** Maintains identical behavior to the original code but with better execution efficiency.