### PR TITLE
allow non-ascii character in unquoted string of command argument

### DIFF
--- a/leaf-server/minecraft-patches/features/0295-allow-non-ascii-character-in-unquoted-string-of-comm.patch
+++ b/leaf-server/minecraft-patches/features/0295-allow-non-ascii-character-in-unquoted-string-of-comm.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: hayanesuru <hayanesuru@outlook.jp>
+Date: Tue, 1 Apr 2025 11:56:43 +0800
+Subject: [PATCH] allow non-ascii character in unquoted string of command
+ argument
+
+
+diff --git a/com/mojang/brigadier/StringReader.java b/com/mojang/brigadier/StringReader.java
+index c1465df63a48e08ec9ccd6889be4f2f8d13d7552..0b6f139fa02ab6fc48a5b68c9c24be3974257f50 100644
+--- a/com/mojang/brigadier/StringReader.java
++++ b/com/mojang/brigadier/StringReader.java
+@@ -171,7 +171,7 @@ public class StringReader implements ImmutableStringReader {
+             || c >= 'A' && c <= 'Z'
+             || c >= 'a' && c <= 'z'
+             || c == '_' || c == '-'
+-            || c == '.' || c == '+';
++            || c == '.' || c == '+' || Character.isLetterOrDigit(c); // Leaf - allow non-ascii character in unquoted string of command argument
+     }
+ 
+     public String readUnquotedString() {


### PR DESCRIPTION
test command:
```mcfunction
data merge storage ns:test {String:テスト}
data get storage ns:test String
```