### PR TITLE
Use enum for unsafe read request

### DIFF
--- a/leaf-server/minecraft-patches/features/0194-SparklyPaper-Parallel-world-ticking.patch
+++ b/leaf-server/minecraft-patches/features/0194-SparklyPaper-Parallel-world-ticking.patch
@@ -392,7 +392,7 @@ index 8ebc3aaa79526cc489885bc817d0c9880ab6ca55..3849314a97b484af454aa8b9a3fe9638
                  continue;
              }
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 8f6cbc40c59800f2e1ee08c3ea0f12c9daa375c3..b7eea90601b6d546a80e3efa06014d19729183fd 100644
+index 8f6cbc40c59800f2e1ee08c3ea0f12c9daa375c3..79745c9e576ff0c861ce920fb80dc1512af02d4c 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -194,7 +194,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
@@ -467,7 +467,7 @@ index 8f6cbc40c59800f2e1ee08c3ea0f12c9daa375c3..b7eea90601b6d546a80e3efa06014d19
 +    // Leaf start - SparklyPaper - parallel world ticking
 +    private void processAsyncReadRequests() {
 +        // Clear queue if buffering gets disabled to prevent memory leaks
-+        if (!org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling.equals("BUFFERED") && !this.asyncReadRequestQueue.isEmpty()) {
++        if (org.dreeam.leaf.async.world.UnsafeReadPolicy.BUFFERED != org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling && !this.asyncReadRequestQueue.isEmpty()) {
 +            org.dreeam.leaf.async.world.WorldReadRequest req;
 +            while ((req = this.asyncReadRequestQueue.poll()) != null) {
 +                req.future().completeExceptionally(new IllegalStateException("Async read buffering disabled while request was pending."));

--- a/leaf-server/paper-patches/features/0044-SparklyPaper-Parallel-world-ticking.patch
+++ b/leaf-server/paper-patches/features/0044-SparklyPaper-Parallel-world-ticking.patch
@@ -349,10 +349,10 @@ index 01719a81cea75654a0d7eac52fd43ebf2d692b9c..e1638106d5e4ae9968599f7e908ac246
      }
      // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b47b32c1f0 100644
+index 720b4afb4438964149073f47c886ab683fd31b58..aacd08358fd118146cde0df0f71226c9cff9f2d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -74,12 +74,117 @@ public class CraftBlock implements Block {
+@@ -74,12 +74,116 @@ public class CraftBlock implements Block {
          return new CraftBlock(world, position);
      }
  
@@ -361,14 +361,14 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        return this.world instanceof ServerLevel serverLevel ? serverLevel : null;
 +    }
 +
-+    private boolean needsBuffering(ServerLevel level, org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode) {
++    private boolean needsBuffering(ServerLevel level) {
 +        // No ServerLevel means no queue, can't buffer
-+        return level != null && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && handlingMode == org.dreeam.leaf.async.world.UnsafeReadPolicy.BUFFERED && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(level);
++        return level != null && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling == org.dreeam.leaf.async.world.UnsafeReadPolicy.BUFFERED && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(level);
 +    }
 +
-+    private void checkStrictMode(ServerLevel level, org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode, String methodName) {
++    private void checkStrictMode(ServerLevel level, String methodName) {
 +        // Only check if PWT enabled, mode is STRICT, and we have a ServerLevel
-+        if (level != null && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && handlingMode == org.dreeam.leaf.async.world.UnsafeReadPolicy.STRICT) {
++        if (level != null && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling == org.dreeam.leaf.async.world.UnsafeReadPolicy.STRICT) {
 +            ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(level, this.position, "PWT: Async unsafe block read (strict mode): " + methodName);
 +        }
 +    }
@@ -430,14 +430,13 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
-+            if (needsBuffering(level, handlingMode)) {
++            if (needsBuffering(level)) {
 +                // Buffered path
 +                return executeBufferedRead(level, org.dreeam.leaf.async.world.ReadOperationType.BLOCK_GET_NMS_STATE, new Object[]{this.position}, Blocks.AIR.defaultBlockState(), "getNMS");
 +            } else {
 +                // Strict/Disabled/Non-ServerLevel path
-+                checkStrictMode(level, handlingMode, "getNMS");
++                checkStrictMode(level, "getNMS");
 +                try {
 +                    return this.world.getBlockState(this.position);
 +                } catch (Exception e) {
@@ -456,8 +455,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "getNMSFluid");
++
++            checkStrictMode(level, "getNMSFluid");
 +
 +            try {
 +                return this.world.getFluidState(this.position);
@@ -472,7 +471,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
      }
  
      public BlockPos getPosition() {
-@@ -142,10 +247,12 @@ public class CraftBlock implements Block {
+@@ -142,10 +246,12 @@ public class CraftBlock implements Block {
          return this.getWorld().getChunkAt(this);
      }
  
@@ -485,7 +484,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
      public void setData(final byte data, boolean applyPhysics) {
          if (applyPhysics) {
              this.setData(data, net.minecraft.world.level.block.Block.UPDATE_ALL);
-@@ -155,12 +262,14 @@ public class CraftBlock implements Block {
+@@ -155,12 +261,14 @@ public class CraftBlock implements Block {
      }
  
      private void setData(final byte data, @net.minecraft.world.level.block.Block.UpdateFlags int flags) {
@@ -501,7 +500,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
          return CraftMagicNumbers.toLegacyData(state);
      }
  
-@@ -177,6 +286,7 @@ public class CraftBlock implements Block {
+@@ -177,6 +285,7 @@ public class CraftBlock implements Block {
      @Override
      public void setType(Material type, boolean applyPhysics) {
          Preconditions.checkArgument(type != null, "Material cannot be null");
@@ -509,7 +508,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
          this.setBlockData(type.createBlockData(), applyPhysics);
      }
  
-@@ -196,6 +306,7 @@ public class CraftBlock implements Block {
+@@ -196,6 +305,7 @@ public class CraftBlock implements Block {
      }
  
      public static boolean setBlockState(LevelAccessor world, BlockPos pos, net.minecraft.world.level.block.state.BlockState oldState, net.minecraft.world.level.block.state.BlockState newState, boolean applyPhysics) {
@@ -517,7 +516,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
          // SPIGOT-611: need to do this to prevent glitchiness. Easier to handle this here (like /setblock) than to fix weirdness in block entity cleanup
          if (oldState.hasBlockEntity() && newState.getBlock() != oldState.getBlock()) { // SPIGOT-3725 remove old block entity if block changes
              // SPIGOT-4612: faster - just clear tile
-@@ -227,22 +338,74 @@ public class CraftBlock implements Block {
+@@ -227,22 +337,74 @@ public class CraftBlock implements Block {
  
      @Override
      public Material getType() {
@@ -531,8 +530,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "getLightLevel"); // Strict check if applicable
++
++            checkStrictMode(level, "getLightLevel"); // Strict check if applicable
 +
 +            try {
 +                // Requires Level for getMaxLocalRawBrightness
@@ -557,8 +556,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "getLightFromSky"); // Strict check if applicable
++
++            checkStrictMode(level, "getLightFromSky"); // Strict check if applicable
 +
 +            try {
 +                // LevelAccessor has getBrightness
@@ -579,8 +578,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "getLightFromBlocks"); // Strict check if applicable
++
++            checkStrictMode(level, "getLightFromBlocks"); // Strict check if applicable
 +
 +            try {
 +                // LevelAccessor has getBrightness
@@ -596,7 +595,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
      }
  
      public Block getFace(final BlockFace face) {
-@@ -344,18 +507,69 @@ public class CraftBlock implements Block {
+@@ -344,18 +506,67 @@ public class CraftBlock implements Block {
  
      @Override
      public Biome getBiome() {
@@ -604,9 +603,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
-+            if (needsBuffering(level, handlingMode)) {
++            if (needsBuffering(level)) {
 +                // Buffered path
 +                net.minecraft.core.Holder<net.minecraft.world.level.biome.Biome> nmsResult = executeBufferedRead(
 +                    level, org.dreeam.leaf.async.world.ReadOperationType.BLOCK_GET_BIOME, new Object[]{this.position}, null, "getBiome"
@@ -614,7 +612,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +                return (nmsResult != null) ? CraftBiome.minecraftHolderToBukkit(nmsResult) : Biome.PLAINS; // Default biome
 +            } else {
 +                // Strict/Disabled/Non-ServerLevel path
-+                checkStrictMode(level, handlingMode, "getBiome");
++                checkStrictMode(level, "getBiome");
 +                try {
 +                    // Use Bukkit API, which should delegate safely (or buffer itself if needed)
 +                    return this.getWorld().getBiome(this.getX(), this.getY(), this.getZ());
@@ -636,9 +634,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
-+            if (needsBuffering(level, handlingMode)) {
++            if (needsBuffering(level)) {
 +                // Buffered path
 +                net.minecraft.core.Holder<net.minecraft.world.level.biome.Biome> nmsResult = executeBufferedRead(
 +                    level, org.dreeam.leaf.async.world.ReadOperationType.BLOCK_GET_COMPUTED_BIOME, new Object[]{this.position}, null, "getComputedBiome"
@@ -646,7 +643,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +                return (nmsResult != null) ? CraftBiome.minecraftHolderToBukkit(nmsResult) : Biome.PLAINS; // Default biome
 +            } else {
 +                // Strict/Disabled/Non-ServerLevel path
-+                checkStrictMode(level, handlingMode, "getComputedBiome");
++                checkStrictMode(level, "getComputedBiome");
 +                try {
 +                    // Use Bukkit API
 +                    return this.getWorld().getComputedBiome(this.getX(), this.getY(), this.getZ());
@@ -668,7 +665,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
          this.getWorld().setBiome(this.getX(), this.getY(), this.getZ(), bio);
      }
  
-@@ -371,12 +585,58 @@ public class CraftBlock implements Block {
+@@ -371,12 +582,57 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean isBlockPowered() {
@@ -676,8 +673,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "isBlockPowered"); // Strict check if applicable
++
++            checkStrictMode(level, "isBlockPowered"); // Strict check if applicable
 +
 +            try {
 +                // Requires Level.getDirectSignalTo
@@ -702,14 +699,13 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
-+            if (needsBuffering(level, handlingMode)) {
++            if (needsBuffering(level)) {
 +                // Buffered path
 +                return executeBufferedRead(level, org.dreeam.leaf.async.world.ReadOperationType.BLOCK_IS_INDIRECTLY_POWERED, new Object[]{this.position}, false, "isBlockIndirectlyPowered");
 +            } else {
 +                // Strict/Disabled/Non-ServerLevel path
-+                checkStrictMode(level, handlingMode, "isBlockIndirectlyPowered");
++                checkStrictMode(level, "isBlockIndirectlyPowered");
 +                try {
 +                    // Requires Level.hasNeighborSignal
 +                    if (this.world instanceof net.minecraft.world.level.Level nmsLevel) {
@@ -729,17 +725,24 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
      }
  
      @Override
-@@ -398,38 +658,40 @@ public class CraftBlock implements Block {
+@@ -398,38 +654,40 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean isBlockFacePowered(BlockFace face) {
 -        return this.world.getMinecraftWorld().hasSignal(this.position, CraftBlock.blockFaceToNotch(face));
+-    }
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "isBlockFacePowered"); // Strict check if applicable
-+
+ 
+-    @Override
+-    public boolean isBlockFaceIndirectlyPowered(BlockFace face) {
+-        int power = this.world.getMinecraftWorld().getSignal(this.position, CraftBlock.blockFaceToNotch(face));
++            checkStrictMode(level, "isBlockFacePowered"); // Strict check if applicable
+ 
+-        Block relative = this.getRelative(face);
+-        if (relative.getType() == Material.REDSTONE_WIRE) {
+-            return Math.max(power, relative.getData()) > 0; // todo remove legacy usage
 +            try {
 +                if (this.world instanceof net.minecraft.world.level.Level nmsLevel) {
 +                    return nmsLevel.hasSignal(this.position, CraftBlock.blockFaceToNotch(face));
@@ -752,20 +755,13 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +            }
 +        } else {
 +            return this.world.getMinecraftWorld().hasSignal(this.position, CraftBlock.blockFaceToNotch(face));
-+        }
+         }
 +        // Leaf end - SparklyPaper - parallel world ticking
-     }
++    }
  
-     @Override
-     public boolean isBlockFaceIndirectlyPowered(BlockFace face) {
--        int power = this.world.getMinecraftWorld().getSignal(this.position, CraftBlock.blockFaceToNotch(face));
--
--        Block relative = this.getRelative(face);
--        if (relative.getType() == Material.REDSTONE_WIRE) {
--            return Math.max(power, relative.getData()) > 0; // todo remove legacy usage
--        }
--
 -        return power > 0;
++    @Override
++    public boolean isBlockFaceIndirectlyPowered(BlockFace face) {
 +        return pwt$isBlockFaceIndirectlyPowered(face); // Leaf - SparklyPaper - parallel world ticking
      }
  
@@ -794,7 +790,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
          if (!state.is(Blocks.REDSTONE_WIRE)) {
              return power;
          } else {
-@@ -478,23 +740,37 @@ public class CraftBlock implements Block {
+@@ -478,23 +736,37 @@ public class CraftBlock implements Block {
  
      @Override
      public PistonMoveReaction getPistonMoveReaction() {
@@ -835,7 +831,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
      }
  
      @Override
-@@ -505,85 +781,12 @@ public class CraftBlock implements Block {
+@@ -505,85 +777,12 @@ public class CraftBlock implements Block {
      @Override
      public boolean breakNaturally(ItemStack item, boolean triggerEffect, boolean dropExperience, boolean forceEffect) {
          // Paper end
@@ -923,7 +919,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
      }
  
      @Override
-@@ -598,20 +801,12 @@ public class CraftBlock implements Block {
+@@ -598,20 +797,12 @@ public class CraftBlock implements Block {
  
      @Override
      public Collection<ItemStack> getDrops(ItemStack item, Entity entity) {
@@ -946,7 +942,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
          net.minecraft.world.level.block.state.BlockState state = this.getNMS();
          net.minecraft.world.item.ItemStack nms = CraftItemStack.asNMSCopy(item);
          return CraftBlockData.isPreferredTool(state, nms);
-@@ -620,9 +815,27 @@ public class CraftBlock implements Block {
+@@ -620,9 +811,27 @@ public class CraftBlock implements Block {
      @Override
      public float getBreakSpeed(Player player) {
          Preconditions.checkArgument(player != null, "player cannot be null");
@@ -955,8 +951,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            // Requires LevelReader (LevelAccessor is sufficient)
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "getBreakSpeed"); // Strict check if applicable
++
++            checkStrictMode(level, "getBreakSpeed"); // Strict check if applicable
 +
 +            try {
 +                // Uses safe getNMS()
@@ -975,7 +971,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
      @Override
      public void setMetadata(String metadataKey, MetadataValue newMetadataValue) {
          this.getCraftWorld().getBlockMetadata().setMetadata(this, metadataKey, newMetadataValue);
-@@ -645,7 +858,25 @@ public class CraftBlock implements Block {
+@@ -645,7 +854,25 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean isPassable() {
@@ -984,8 +980,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            // Requires LevelReader (LevelAccessor is sufficient)
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "isPassable"); // Strict check if applicable
++
++            checkStrictMode(level, "isPassable"); // Strict check if applicable
 +
 +            try {
 +                // Uses safe getNMS()
@@ -1002,7 +998,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
      }
  
      @Override
-@@ -663,39 +894,68 @@ public class CraftBlock implements Block {
+@@ -663,39 +890,67 @@ public class CraftBlock implements Block {
              return null;
          }
  
@@ -1036,8 +1032,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            // Requires LevelReader (LevelAccessor is sufficient)
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "getCollisionShape"); // Strict check if applicable
++
++            checkStrictMode(level, "getCollisionShape"); // Strict check if applicable
 +
 +            try {
 +                // Uses safe getNMS()
@@ -1062,14 +1058,14 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+
-+            if (needsBuffering(level, handlingMode)) {
+ 
+-        return iblockdata.canSurvive(world, this.position);
++            if (needsBuffering(level)) {
 +                // Buffered path
 +                return executeBufferedRead(level, org.dreeam.leaf.async.world.ReadOperationType.BLOCK_CAN_PLACE, new Object[]{this.position, data}, false, "canPlace");
 +            } else {
 +                // Strict/Disabled/Non-ServerLevel path
-+                checkStrictMode(level, handlingMode, "canPlace");
++                checkStrictMode(level, "canPlace");
 +                try {
 +                    net.minecraft.world.level.block.state.BlockState nmsData = ((CraftBlockData) data).getState();
 +                    // LevelAccessor has canSurvive
@@ -1082,15 +1078,14 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        } else {
 +            net.minecraft.world.level.block.state.BlockState iblockdata = ((CraftBlockData) data).getState();
 +            net.minecraft.world.level.Level world = this.world.getMinecraftWorld();
- 
--        return iblockdata.canSurvive(world, this.position);
++
 +            return iblockdata.canSurvive(world, this.position);
 +        }
 +        // Leaf end - SparklyPaper - parallel world ticking
      }
  
      @Override
-@@ -711,7 +971,10 @@ public class CraftBlock implements Block {
+@@ -711,7 +966,10 @@ public class CraftBlock implements Block {
      // Paper start
      @Override
      public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
@@ -1102,7 +1097,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
      }
  
      @Override
-@@ -730,20 +993,511 @@ public class CraftBlock implements Block {
+@@ -730,20 +988,507 @@ public class CraftBlock implements Block {
  
      @Override
      public void tick() {
@@ -1173,8 +1168,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +    private boolean pwt$isBlockFaceIndirectlyPowered(BlockFace face) {
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "isBlockFaceIndirectlyPowered"); // Strict check if applicable
++
++            checkStrictMode(level, "isBlockFaceIndirectlyPowered"); // Strict check if applicable
 +
 +            try {
 +                // Requires Level.getSignal and potentially relative block access (which might need safety checks)
@@ -1209,14 +1204,13 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +    private int pwt$getBlockPower(BlockFace face) {
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
-+            if (needsBuffering(level, handlingMode)) {
++            if (needsBuffering(level)) {
 +                // Buffered path
 +                return executeBufferedRead(level, org.dreeam.leaf.async.world.ReadOperationType.BLOCK_GET_BLOCK_POWER, new Object[]{this.position, face}, 0, "getBlockPower");
 +            } else {
 +                // Strict/Disabled/Non-ServerLevel path
-+                checkStrictMode(level, handlingMode, "getBlockPower");
++                checkStrictMode(level, "getBlockPower");
 +                try {
 +                    // Requires Level for hasSignal and getBlockState
 +                    if (this.world instanceof net.minecraft.world.level.Level nmsLevel) {
@@ -1494,9 +1488,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +                return Collections.emptyList();
 +            }
 +
-+            // Strict check if applicable
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "getDrops");
++            checkStrictMode(level, "getDrops"); // Strict check if applicable
 +
 +            try {
 +                net.minecraft.world.level.block.state.BlockState state = this.getNMS(); // Use safe getNMS
@@ -1536,9 +1528,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +    private RayTraceResult pwt$rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode) {
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
-+            if (needsBuffering(level, handlingMode)) {
++            if (needsBuffering(level)) {
 +                // Buffered path
 +                HitResult nmsHitResult = executeBufferedRead(
 +                    level, org.dreeam.leaf.async.world.ReadOperationType.BLOCK_RAY_TRACE,
@@ -1549,7 +1540,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +                return CraftRayTraceResult.convertFromInternal(this.world, nmsHitResult);
 +            } else {
 +                // Strict/Disabled/Non-ServerLevel path
-+                checkStrictMode(level, handlingMode, "rayTrace");
++                checkStrictMode(level, "rayTrace");
 +                try {
 +                    // Calculate start and end points for the ray trace
 +                    Vec3 startPos = CraftLocation.toVec3(start);
@@ -1584,8 +1575,8 @@ index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b4
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            // Requires LevelReader (LevelAccessor is sufficient)
 +            ServerLevel level = getServerLevel();
-+            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
-+            checkStrictMode(level, handlingMode, "getBoundingBox"); // Strict check if applicable
++
++            checkStrictMode(level, "getBoundingBox"); // Strict check if applicable
 +
 +            try {
 +                // Uses safe getNMS()

--- a/leaf-server/paper-patches/features/0044-SparklyPaper-Parallel-world-ticking.patch
+++ b/leaf-server/paper-patches/features/0044-SparklyPaper-Parallel-world-ticking.patch
@@ -349,7 +349,7 @@ index 01719a81cea75654a0d7eac52fd43ebf2d692b9c..e1638106d5e4ae9968599f7e908ac246
      }
      // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda03680977b0aa 100644
+index 720b4afb4438964149073f47c886ab683fd31b58..d5932f1b8985766ca344451420bd91b47b32c1f0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 @@ -74,12 +74,117 @@ public class CraftBlock implements Block {
@@ -361,14 +361,14 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        return this.world instanceof ServerLevel serverLevel ? serverLevel : null;
 +    }
 +
-+    private boolean needsBuffering(ServerLevel level, String handlingMode) {
++    private boolean needsBuffering(ServerLevel level, org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode) {
 +        // No ServerLevel means no queue, can't buffer
-+        return level != null && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && handlingMode.equals("BUFFERED") && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(level);
++        return level != null && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && handlingMode == org.dreeam.leaf.async.world.UnsafeReadPolicy.BUFFERED && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(level);
 +    }
 +
-+    private void checkStrictMode(ServerLevel level, String handlingMode, String methodName) {
++    private void checkStrictMode(ServerLevel level, org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode, String methodName) {
 +        // Only check if PWT enabled, mode is STRICT, and we have a ServerLevel
-+        if (level != null && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && handlingMode.equals("STRICT")) {
++        if (level != null && org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled && handlingMode == org.dreeam.leaf.async.world.UnsafeReadPolicy.STRICT) {
 +            ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(level, this.position, "PWT: Async unsafe block read (strict mode): " + methodName);
 +        }
 +    }
@@ -430,7 +430,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
 +            if (needsBuffering(level, handlingMode)) {
 +                // Buffered path
@@ -456,7 +456,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "getNMSFluid");
 +
 +            try {
@@ -531,7 +531,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "getLightLevel"); // Strict check if applicable
 +
 +            try {
@@ -557,7 +557,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "getLightFromSky"); // Strict check if applicable
 +
 +            try {
@@ -579,7 +579,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "getLightFromBlocks"); // Strict check if applicable
 +
 +            try {
@@ -604,7 +604,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
 +            if (needsBuffering(level, handlingMode)) {
 +                // Buffered path
@@ -636,7 +636,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
 +            if (needsBuffering(level, handlingMode)) {
 +                // Buffered path
@@ -676,7 +676,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "isBlockPowered"); // Strict check if applicable
 +
 +            try {
@@ -702,7 +702,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
 +            if (needsBuffering(level, handlingMode)) {
 +                // Buffered path
@@ -737,7 +737,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "isBlockFacePowered"); // Strict check if applicable
 +
 +            try {
@@ -955,7 +955,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            // Requires LevelReader (LevelAccessor is sufficient)
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "getBreakSpeed"); // Strict check if applicable
 +
 +            try {
@@ -984,7 +984,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            // Requires LevelReader (LevelAccessor is sufficient)
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "isPassable"); // Strict check if applicable
 +
 +            try {
@@ -1036,7 +1036,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            // Requires LevelReader (LevelAccessor is sufficient)
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "getCollisionShape"); // Strict check if applicable
 +
 +            try {
@@ -1062,7 +1062,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        // Leaf start - SparklyPaper - parallel world ticking
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
 +            if (needsBuffering(level, handlingMode)) {
 +                // Buffered path
@@ -1173,7 +1173,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +    private boolean pwt$isBlockFaceIndirectlyPowered(BlockFace face) {
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "isBlockFaceIndirectlyPowered"); // Strict check if applicable
 +
 +            try {
@@ -1209,7 +1209,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +    private int pwt$getBlockPower(BlockFace face) {
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
 +            if (needsBuffering(level, handlingMode)) {
 +                // Buffered path
@@ -1495,7 +1495,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +            }
 +
 +            // Strict check if applicable
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "getDrops");
 +
 +            try {
@@ -1536,7 +1536,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +    private RayTraceResult pwt$rayTrace(Location start, Vector direction, double maxDistance, FluidCollisionMode fluidCollisionMode) {
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +
 +            if (needsBuffering(level, handlingMode)) {
 +                // Buffered path
@@ -1584,7 +1584,7 @@ index 720b4afb4438964149073f47c886ab683fd31b58..134a79e359839496de4e86b6ebda0368
 +        if (org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.enabled) {
 +            // Requires LevelReader (LevelAccessor is sufficient)
 +            ServerLevel level = getServerLevel();
-+            String handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
++            org.dreeam.leaf.async.world.UnsafeReadPolicy handlingMode = org.dreeam.leaf.config.modules.async.SparklyPaperParallelWorldTicking.asyncUnsafeReadHandling;
 +            checkStrictMode(level, handlingMode, "getBoundingBox"); // Strict check if applicable
 +
 +            try {

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/world/SparklyPaperServerLevelTickExecutorThreadFactory.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/world/SparklyPaperServerLevelTickExecutorThreadFactory.java
@@ -16,14 +16,15 @@ public class SparklyPaperServerLevelTickExecutorThreadFactory implements ThreadF
 
     @Override
     public Thread newThread(Runnable runnable) {
-        TickThread.ServerLevelTickThread tickThread = new TickThread.ServerLevelTickThread(runnable, "Leaf World Ticking Thread - " + this.worldName);
+        TickThread.ServerLevelTickThread tickThread = new TickThread.ServerLevelTickThread(runnable, "Leaf Level Ticking Thread - " + this.worldName);
 
         if (tickThread.isDaemon()) {
             tickThread.setDaemon(false);
         }
 
-        if (tickThread.getPriority() != 5) {
-            tickThread.setPriority(5);
+        tickThread.setPriority(Thread.NORM_PRIORITY + 1);
+        if (Runtime.getRuntime().availableProcessors() > 4) {
+            tickThread.setPriority(7);
         }
 
         return tickThread;

--- a/leaf-server/src/main/java/org/dreeam/leaf/async/world/UnsafeReadPolicy.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/world/UnsafeReadPolicy.java
@@ -1,0 +1,20 @@
+package org.dreeam.leaf.async.world;
+
+import org.dreeam.leaf.config.LeafConfig;
+
+import java.util.Locale;
+
+public enum UnsafeReadPolicy {
+    STRICT,
+    BUFFERED,
+    DISABLED;
+
+    public static UnsafeReadPolicy fromString(String readPolicy) {
+        try {
+            return valueOf(readPolicy.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            LeafConfig.LOGGER.warn("Invalid unsafe read policy: {}, falling back to {}.", readPolicy, DISABLED.toString());
+            return DISABLED;
+        }
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/SparklyPaperParallelWorldTicking.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/async/SparklyPaperParallelWorldTicking.java
@@ -1,5 +1,6 @@
 package org.dreeam.leaf.config.modules.async;
 
+import org.dreeam.leaf.async.world.UnsafeReadPolicy;
 import org.dreeam.leaf.config.ConfigModules;
 import org.dreeam.leaf.config.EnumConfigCategory;
 import org.dreeam.leaf.config.LeafConfig;
@@ -18,8 +19,7 @@ public class SparklyPaperParallelWorldTicking extends ConfigModules {
     public static boolean disableHardThrow = false;
     @Deprecated
     public static Boolean runAsyncTasksSync;
-    // STRICT, BUFFERED, DISABLED
-    public static String asyncUnsafeReadHandling = "BUFFERED";
+    public static UnsafeReadPolicy asyncUnsafeReadHandling = UnsafeReadPolicy.DISABLED;
 
     @Override
     public void onLoaded() {
@@ -42,15 +42,7 @@ public class SparklyPaperParallelWorldTicking extends ConfigModules {
         logContainerCreationStacktraces = enabled && logContainerCreationStacktraces;
         disableHardThrow = config.getBoolean(getBasePath() + ".disable-hard-throw", disableHardThrow);
         disableHardThrow = enabled && disableHardThrow;
-        asyncUnsafeReadHandling = config.getString(getBasePath() + ".async-unsafe-read-handling", asyncUnsafeReadHandling).toUpperCase();
-
-        if (!asyncUnsafeReadHandling.equals("STRICT") && !asyncUnsafeReadHandling.equals("BUFFERED") && !asyncUnsafeReadHandling.equals("DISABLED")) {
-            LeafConfig.LOGGER.warn("Invalid value for {}.async-unsafe-read-handling: {}, fallback to STRICT.", getBasePath(), asyncUnsafeReadHandling);
-            asyncUnsafeReadHandling = "STRICT";
-        }
-        if (!enabled) {
-            asyncUnsafeReadHandling = "DISABLED";
-        }
+        asyncUnsafeReadHandling = UnsafeReadPolicy.fromString(config.getString(getBasePath() + ".async-unsafe-read-handling", asyncUnsafeReadHandling.toString()));
 
         // Transfer old config
         runAsyncTasksSync = config.getBoolean(getBasePath() + ".run-async-tasks-sync");


### PR DESCRIPTION
1. Use enum for unsafe read request
2. Boost priority of world tickers, lower than server thread