### PR TITLE
Fix NPE in `CropBlock.getGrowthSpeed`

### DIFF
--- a/leaf-server/minecraft-patches/features/0295-Fix-blockPos-is-null.patch
+++ b/leaf-server/minecraft-patches/features/0295-Fix-blockPos-is-null.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: VeVeVeVel <147647046+VeVeVeVel@users.noreply.github.com>
+Date: Thu, 5 Feb 2026 23:16:37 +0900
+Subject: [PATCH] Fix blockPos is null
+
+
+diff --git a/net/minecraft/world/level/block/CropBlock.java b/net/minecraft/world/level/block/CropBlock.java
+index 372559399ce8a4ce551f4403975879e365e1ad75..84b3ebcf214d003d50f510e18defa1713b4a2109 100644
+--- a/net/minecraft/world/level/block/CropBlock.java
++++ b/net/minecraft/world/level/block/CropBlock.java
+@@ -116,6 +116,7 @@ public class CropBlock extends VegetationBlock implements BonemealableBlock {
+     protected static float getGrowthSpeed(Block block, BlockGetter level, BlockPos pos) {
+         float f = 1.0F;
+         BlockPos blockPos = pos.below();
++        if (blockPos == null) return 0.0F; // Leaf - Fix "blockPos" is null
+ 
+         for (int i = -1; i <= 1; i++) {
+             for (int i1 = -1; i1 <= 1; i1++) {


### PR DESCRIPTION
`blockPos` (derived from `pos.below()`) is expected to be non-null, but it occasionally returns null, causing a NullPointerException. This PR implements a defensive check to mitigate the crash until the root cause is identified.

https://mclo.gs/Y49xh6O
https://mclo.gs/HigpqzP