### PR TITLE
Fix SPIGOT-625

### DIFF
--- a/leaf-server/minecraft-patches/features/0294-Fix-SPIGOT-625-server-shutdown-not-cleanly-disconnec.patch
+++ b/leaf-server/minecraft-patches/features/0294-Fix-SPIGOT-625-server-shutdown-not-cleanly-disconnec.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Fix SPIGOT-625 server shutdown not cleanly disconnecting
+ everyone
+
+
+diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
+index aca1f4eb6cba11ea27863375c825a74eb11916e1..242c66ce9075469cd37ab657f6879ffc6d49d243 100644
+--- a/net/minecraft/server/MinecraftServer.java
++++ b/net/minecraft/server/MinecraftServer.java
+@@ -1091,15 +1091,37 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         }
+         // CraftBukkit end
+         if (io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper != null) io.papermc.paper.plugin.PluginInitializerManager.instance().pluginRemapper.shutdown(); // Paper - Plugin remapping
+-        this.getConnection().stop();
++        //this.getConnection().stop(); // Leaf - Fix SPIGOT-625 - move down
+         this.isSaving = true;
+         if (this.playerList != null) {
+             LOGGER.info("Saving players");
+             this.playerList.saveAll();
+             this.playerList.removeAll(this.isRestarting); // Paper
+-            try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
++            // Leaf start - Fix SPIGOT-625
++            List<net.minecraft.network.Connection> connections = this.getConnection().getConnections();
++            if (!connections.isEmpty()) {
++                List<CompletableFuture<Void>> futures = new java.util.ArrayList<>();
++                synchronized (connections) {
++                    for (net.minecraft.network.Connection connection : connections) {
++                        if (connection.channel != null && connection.channel.isOpen()) {
++                            CompletableFuture<Void> future = new CompletableFuture<>();
++                            connection.channel.closeFuture().addListener(f -> future.complete(null));
++                            futures.add(future);
++                        }
++                    }
++                }
++                if (!futures.isEmpty()) {
++                    try {
++                        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
++                            .get(15, java.util.concurrent.TimeUnit.SECONDS);
++                    } catch (Exception ignored) {}
++                }
++            }
++            //try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
++            // Leaf end - Fix SPIGOT-625
+         }
+ 
++        this.getConnection().stop(); // Leaf - Fix SPIGOT-625 - moved from above
+         LOGGER.info("Saving worlds");
+ 
+         for (ServerLevel serverLevel : this.getAllLevels()) {


### PR DESCRIPTION
Fixes https://hub.spigotmc.org/jira/browse/SPIGOT-625, server channel is closed too early before the disconnect packet is sent. Waiting for 100ms is not a clean solution.

Execute `/stop`

Before:
<img width="1133" height="370" alt="image" src="https://github.com/user-attachments/assets/3bd1d359-eadd-4557-8a77-f6fd13ae8dd1" />

After:
<img width="967" height="333" alt="image" src="https://github.com/user-attachments/assets/202343b6-aba9-4bd1-b18d-8beaea07fe5d" />

