### PR TITLE
Fix MC-17876 on 1.21.11

### DIFF
--- a/leaf-server/minecraft-patches/features/0294-Fix-MC-17876.patch
+++ b/leaf-server/minecraft-patches/features/0294-Fix-MC-17876.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Fix MC-17876
+
+Related MC issue: https://bugs.mojang.com/browse/MC/issues/MC-17876
+
+Temporarily bypass the max health check during entity creation, as equipment attributes are not applied yet at this stage.
+
+Co-authored-by: Bjarne Koll <git@lynxplay.dev>
+
+diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
+index 3b3a801e632bf65b9bef5833755b2de3be1b059a..ec39f3cd20bec29cc0aeaf58e0d72bfe1cabe774 100644
+--- a/net/minecraft/world/entity/LivingEntity.java
++++ b/net/minecraft/world/entity/LivingEntity.java
+@@ -901,7 +901,7 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+             this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(maxHealth);
+         });
+         // CraftBukkit end
+-        this.setHealth(input.getFloatOr("Health", this.getMaxHealth()));
++        this.setHealth(input.getFloatOr("Health", this.getMaxHealth()), true); // Leaf - Fix MC-17876
+         this.hurtTime = input.getShortOr("HurtTime", (short)0);
+         this.deathTime = input.getShortOr("DeathTime", (short)0);
+         this.lastHurtByMobTimestamp = input.getIntOr("HurtByTimestamp", 0);
+@@ -1442,7 +1442,7 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+         return this.entityData.get(DATA_HEALTH_ID);
+     }
+ 
+-    public void setHealth(float health) {
++    public void setHealth(float health, boolean bypassCap) { // Leaf - Fix MC-17876
+         // Paper start - Check for NaN
+         if (Float.isNaN(health)) { health = getMaxHealth(); if (this.valid) {
+             System.err.println("[NAN-HEALTH] " + getScoreboardName() + " had NaN health set");
+@@ -1453,7 +1453,7 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+             // Squeeze
+             if (health < 0.0F) {
+                 player.setRealHealth(0.0D);
+-            } else if (health > player.getMaxHealth()) {
++            } else if (!bypassCap && health > player.getMaxHealth()) { // Leaf - Fix MC-17876
+                 player.setRealHealth(player.getMaxHealth());
+             } else {
+                 player.setRealHealth(health);
+@@ -1464,8 +1464,21 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+             return;
+         }
+         // CraftBukkit end
+-        this.entityData.set(DATA_HEALTH_ID, Mth.clamp(health, 0.0F, this.getMaxHealth()));
++        this.entityData.set(DATA_HEALTH_ID, bypassCap ? this.leaf$sanitizeHealth(health) : Mth.clamp(health, 0.0F, this.getMaxHealth())); // Leaf - Fix MC-17876
++    }
++
++    // Leaf start - Fix MC-17876
++    private float leaf$sanitizeHealth(float health) {
++        if (health < 0.0F || !Float.isFinite(health)) {
++            health = 0.0F;
++        }
++        return health;
++    }
++
++    public void setHealth(float health) {
++        this.setHealth(health, false);
+     }
++    // Leaf end - Fix MC-17876
+ 
+     public boolean isDeadOrDying() {
+         return this.getHealth() <= 0.0F;


### PR DESCRIPTION
Previous PR #576.

Fixed by temporarily bypassing the max health check during entity creation, less invasive than previous one.

### To reproduce

Type command `/item replace entity @s armor.head with iron_helmet[minecraft:attribute_modifiers=[ {id:"test",type:"max_health",amount:6,operation:"add_value"}]], quit the server after health regen, the extra health will lost upon rejoin without this fix`.