### PR TITLE
Further optimize getBiome

### DIFF
--- a/leaf-server/minecraft-patches/features/0097-Carpet-Fixes-Optimized-getBiome-method.patch
+++ b/leaf-server/minecraft-patches/features/0097-Carpet-Fixes-Optimized-getBiome-method.patch
@@ -9,8 +9,10 @@ Original project: https://github.com/fxmorin/carpet-fixes
 Optimized the getBiome call to be 25% - 75% faster
 This is a fully vanilla optimization.
 
+Co-authored-by: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+
 diff --git a/net/minecraft/world/level/biome/BiomeManager.java b/net/minecraft/world/level/biome/BiomeManager.java
-index 73962e79a0f3d892e3155443a1b84508b0f4042e..a48175a7ebb1788ace46395621ed78d910178a53 100644
+index 73962e79a0f3d892e3155443a1b84508b0f4042e..93cbe1d76efd97899ea520a92e88b94639824174 100644
 --- a/net/minecraft/world/level/biome/BiomeManager.java
 +++ b/net/minecraft/world/level/biome/BiomeManager.java
 @@ -14,6 +14,7 @@ public class BiomeManager {
@@ -21,9 +23,11 @@ index 73962e79a0f3d892e3155443a1b84508b0f4042e..a48175a7ebb1788ace46395621ed78d9
  
      public BiomeManager(BiomeManager.NoiseBiomeSource noiseBiomeSource, long biomeZoomSeed) {
          this.noiseBiomeSource = noiseBiomeSource;
-@@ -29,39 +30,67 @@ public class BiomeManager {
+@@ -28,40 +29,73 @@ public class BiomeManager {
+         return new BiomeManager(newSource, this.biomeZoomSeed);
      }
  
++    private static final double[] QUART_OFFSETS = new double[]{0.0, 0.25, 0.5, 0.75}; // Leaf - Optimized getBiome method - eliminate divisions
      public Holder<Biome> getBiome(BlockPos pos) {
 -        int i = pos.getX() - 2;
 -        int i1 = pos.getY() - 2;
@@ -43,9 +47,13 @@ index 73962e79a0f3d892e3155443a1b84508b0f4042e..a48175a7ebb1788ace46395621ed78d9
 +        int x = xMinus2 >> 2; // BlockPos to BiomePos
 +        int y = yMinus2 >> 2;
 +        int z = zMinus2 >> 2;
-+        double quartX = (double) (xMinus2 & 3) / 4.0; // quartLocal divided by 4
-+        double quartY = (double) (yMinus2 & 3) / 4.0; // 0/4, 1/4, 2/4, 3/4
-+        double quartZ = (double) (zMinus2 & 3) / 4.0; // [0, 0.25, 0.5, 0.75]
++        // Leaf start - Optimized getBiome method - eliminate divisions
++        // any integer & 3 falls in [0,1,2,3]
++        // then the division by 4 result is deterministic [0, 0.25, 0.5, 0.75]
++        double quartX = QUART_OFFSETS[xMinus2 & 3];
++        double quartY = QUART_OFFSETS[yMinus2 & 3];
++        double quartZ = QUART_OFFSETS[zMinus2 & 3];
++        // Leaf end - Optimized getBiome method - eliminate divisions
 +        int smallestX = 0;
 +        double smallestDist = Double.POSITIVE_INFINITY;
 +        for (int biomeX = 0; biomeX < 8; ++biomeX) {

--- a/leaf-server/minecraft-patches/features/0230-cache-biome-for-mob-spawning-and-advancements.patch
+++ b/leaf-server/minecraft-patches/features/0230-cache-biome-for-mob-spawning-and-advancements.patch
@@ -57,7 +57,7 @@ index c0ed4a8c23eaaf802985cd3f9c286e2fab1d9f59..0cb3e9f4e51f30fc21c50eeb96ff1bb8
  
      public static boolean isInNetherFortressBounds(BlockPos pos, ServerLevel level, MobCategory category, StructureManager structureManager) {
 diff --git a/net/minecraft/world/level/biome/BiomeManager.java b/net/minecraft/world/level/biome/BiomeManager.java
-index a48175a7ebb1788ace46395621ed78d910178a53..787f06557ca894cbcffe747fa2c793ce91316826 100644
+index 93cbe1d76efd97899ea520a92e88b94639824174..7b03cdec6dccaf6991e32ccbbe2fa8dfbe8dd385 100644
 --- a/net/minecraft/world/level/biome/BiomeManager.java
 +++ b/net/minecraft/world/level/biome/BiomeManager.java
 @@ -15,10 +15,23 @@ public class BiomeManager {
@@ -84,9 +84,9 @@ index a48175a7ebb1788ace46395621ed78d910178a53..787f06557ca894cbcffe747fa2c793ce
      }
  
      public static long obfuscateSeed(long seed) {
-@@ -30,10 +43,36 @@ public class BiomeManager {
-     }
+@@ -31,10 +44,36 @@ public class BiomeManager {
  
+     private static final double[] QUART_OFFSETS = new double[]{0.0, 0.25, 0.5, 0.75}; // Leaf - Optimized getBiome method - eliminate divisions
      public Holder<Biome> getBiome(BlockPos pos) {
 -        // Leaf start - Carpet-Fixes - Optimized getBiome method
 +        return getBiome(null, pos.getX() - 2, pos.getY() - 2, pos.getZ() - 2); // Leaf - cache getBiome
@@ -122,7 +122,7 @@ index a48175a7ebb1788ace46395621ed78d910178a53..787f06557ca894cbcffe747fa2c793ce
          int x = xMinus2 >> 2; // BlockPos to BiomePos
          int y = yMinus2 >> 2;
          int z = zMinus2 >> 2;
-@@ -85,13 +124,16 @@ public class BiomeManager {
+@@ -90,13 +129,16 @@ public class BiomeManager {
                  smallestDist = biomeDist;
              }
          }
@@ -144,7 +144,7 @@ index a48175a7ebb1788ace46395621ed78d910178a53..787f06557ca894cbcffe747fa2c793ce
  
      public Holder<Biome> getNoiseBiomeAtPosition(double x, double y, double z) {
          int quartPosCoord = QuartPos.fromBlock(Mth.floor(x));
-@@ -126,9 +168,18 @@ public class BiomeManager {
+@@ -131,9 +173,18 @@ public class BiomeManager {
          return Mth.square(zNoise + fiddle2) + Mth.square(yNoise + fiddle1) + Mth.square(xNoise + fiddle);
      }
  


### PR DESCRIPTION
Eliminating fp divisions brings about 45% improvement in retrieving QuartPos.

Benchmark results (batching 4096 operations per invocation):

```
Benchmark                              Mode  Cnt     Score    Error  Units
BiomeLookupBenchmark.testFpDivision  avgt    5  2746.521 ± 23.079  ns/op
BiomeLookupBenchmark.testTableLookup    avgt    5  1549.182 ± 28.602  ns/op
```