### PR TITLE
Override consumeCount

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/util/math/random/FasterRandomSource.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/math/random/FasterRandomSource.java
@@ -37,6 +37,13 @@ public final class FasterRandomSource implements BitRandomSource {
     }
 
     @Override
+    public void consumeCount(int count) {
+        for (int i = 0; i < count; i++) {
+            this.delegate.nextLong();
+        }
+    }
+
+    @Override
     public int next(int bits) {
         return (int) (nextLong() >>> (64 - bits));
     }


### PR DESCRIPTION
Xoroshiro128++ is native 128-bit (2x 64-bit long for internal state), use nextLong avoids bit operations that move longs down to integers