### PR TITLE
Optimize PatchedDataComponentMap equals

### DIFF
--- a/leaf-server/minecraft-patches/features/0294-Optimize-PatchedDataComponentMap-equals.patch
+++ b/leaf-server/minecraft-patches/features/0294-Optimize-PatchedDataComponentMap-equals.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Optimize PatchedDataComponentMap equals
+
+The server frequently compares item states via broadcastChanges() during player ticks,
+the original equals() implementation directly calls the underlying map's equality check,
+which often leads to expensive linear scans when dealing with Reference2ObjectArrayMap.
+
+Optimizations:
+1. fail fast by early comparing patch size.
+2. Check for reference equality of the patch maps first.
+This is highly effective due to the COW mechanism where many unmodified ItemStacks share the same map instance.
+
+diff --git a/net/minecraft/core/component/PatchedDataComponentMap.java b/net/minecraft/core/component/PatchedDataComponentMap.java
+index 95dca918687547574ae926b9819b4f02109fa633..285aabb234463e34ed426be04eb7cc582d3e9ba1 100644
+--- a/net/minecraft/core/component/PatchedDataComponentMap.java
++++ b/net/minecraft/core/component/PatchedDataComponentMap.java
+@@ -246,10 +246,18 @@ public final class PatchedDataComponentMap implements DataComponentMap, net.caff
+ 
+     @Override
+     public boolean equals(Object other) {
+-        return this == other
+-            || other instanceof PatchedDataComponentMap patchedDataComponentMap
+-                && this.prototype.equals(patchedDataComponentMap.prototype)
+-                && this.patch.equals(patchedDataComponentMap.patch);
++        // Leaf start - Optimize PatchedDataComponentMap equals
++        if (this == other) return true;
++        if (!(other instanceof PatchedDataComponentMap that)) return false;
++        if (this.patch.size() != that.patch.size()) {
++            return false;
++        }
++        if (!this.prototype.equals(that.prototype)) {
++            return false;
++        }
++        if (this.patch == that.patch) return true;
++        return this.patch.equals(that.patch);
++        // Leaf end - Optimize PatchedDataComponentMap equals
+     }
+ 
+     @Override


### PR DESCRIPTION
The server frequently compares item states via broadcastChanges() during player ticks,
the original equals() implementation directly calls the underlying map's equality check,
which often leads to expensive linear scans when dealing with Reference2ObjectArrayMap.

Optimizations:
1. fail fast by early comparing patch size.
2. Check for reference equality of the patch maps first. This is highly effective due to the COW mechanism where many unmodified ItemStacks share the same map instance. (Map#equals contains this, manually inlining)