### PR TITLE
Reduce AbstractContainerMenu allocations

### DIFF
--- a/leaf-server/minecraft-patches/features/0295-Reduce-AbstractContainerMenu-allocations.patch
+++ b/leaf-server/minecraft-patches/features/0295-Reduce-AbstractContainerMenu-allocations.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Reduce AbstractContainerMenu allocations
+
+Must be checked every MC update to make sure the supplier reference lifecycle won't get leaked to the next loop.
+
+diff --git a/net/minecraft/world/inventory/AbstractContainerMenu.java b/net/minecraft/world/inventory/AbstractContainerMenu.java
+index 3a0c8dca827f567a00e611461aeb74699155bffb..d3ff6d078485e12eaa68e6d4f1bc21ae30de20f1 100644
+--- a/net/minecraft/world/inventory/AbstractContainerMenu.java
++++ b/net/minecraft/world/inventory/AbstractContainerMenu.java
+@@ -262,12 +262,15 @@ public abstract class AbstractContainerMenu {
+         return list;
+     }
+ 
++    private final org.dreeam.leaf.util.cache.CachedItemStackSupplier broadcastCarried = new org.dreeam.leaf.util.cache.CachedItemStackSupplier(); // Leaf - Reduce AbstractContainerMenu allocations
+     public void broadcastChanges() {
+         for (int i = 0; i < this.slots.size(); i++) {
+             ItemStack item = this.slots.get(i).getItem();
+-            Supplier<ItemStack> supplier = Suppliers.memoize(item::copy);
+-            this.triggerSlotListeners(i, item, supplier);
+-            this.synchronizeSlotToRemote(i, item, supplier);
++            // Leaf start - Reduce AbstractContainerMenu allocations
++            this.broadcastCarried.reset(item);
++            this.triggerSlotListeners(i, item, this.broadcastCarried);
++            this.synchronizeSlotToRemote(i, item, this.broadcastCarried);
++            // Leaf end - Reduce AbstractContainerMenu allocations
+         }
+ 
+         this.synchronizeCarriedToRemote();

--- a/leaf-server/minecraft-patches/features/0295-Reduce-AbstractContainerMenu-allocations.patch
+++ b/leaf-server/minecraft-patches/features/0295-Reduce-AbstractContainerMenu-allocations.patch
@@ -3,7 +3,8 @@ From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 Date: Tue, 9 Nov 2077 00:00:00 +0800
 Subject: [PATCH] Reduce AbstractContainerMenu allocations
 
-Must be checked every MC update to make sure the supplier reference lifecycle won't get leaked to the next loop.
+Use simplified and more efficient supplier.
+Must be checked every MC update to make sure the supplier reference lifecycle won't get leaked and be reused in the next loop.
 
 diff --git a/net/minecraft/world/inventory/AbstractContainerMenu.java b/net/minecraft/world/inventory/AbstractContainerMenu.java
 index 3a0c8dca827f567a00e611461aeb74699155bffb..d3ff6d078485e12eaa68e6d4f1bc21ae30de20f1 100644

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/cache/CachedItemStackSupplier.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/cache/CachedItemStackSupplier.java
@@ -1,0 +1,22 @@
+package org.dreeam.leaf.util.cache;
+
+import net.minecraft.world.item.ItemStack;
+import java.util.function.Supplier;
+
+public class CachedItemStackSupplier implements Supplier<ItemStack> {
+    private ItemStack source;
+    private ItemStack cachedCopy;
+
+    public void reset(ItemStack stack) {
+        this.source = stack;
+        this.cachedCopy = null;
+    }
+
+    @Override
+    public ItemStack get() {
+        if (this.cachedCopy == null && this.source != null) {
+            this.cachedCopy = this.source.copy();
+        }
+        return this.cachedCopy;
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/cache/CachedItemStackSupplier.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/cache/CachedItemStackSupplier.java
@@ -4,19 +4,15 @@ import net.minecraft.world.item.ItemStack;
 import java.util.function.Supplier;
 
 public class CachedItemStackSupplier implements Supplier<ItemStack> {
-    private ItemStack source;
+
     private ItemStack cachedCopy;
 
-    public void reset(ItemStack stack) {
-        this.source = stack;
-        this.cachedCopy = null;
+    public void reset(ItemStack source) {
+        this.cachedCopy = source != null ? source.copy() : null;
     }
 
     @Override
     public ItemStack get() {
-        if (this.cachedCopy == null && this.source != null) {
-            this.cachedCopy = this.source.copy();
-        }
         return this.cachedCopy;
     }
 }


### PR DESCRIPTION
Allocating Supplier in `broadcastChanges` every loop causes high GC pressure and also hurts performance with a high player count:

<img width="1231" height="312" alt="image" src="https://github.com/user-attachments/assets/ffb32c5b-f599-48ee-b2ce-d00b0617e3d6" />
