### PR TITLE
Optimize BlockEntityTickersList

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/util/list/BlockEntityTickersList.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/list/BlockEntityTickersList.java
@@ -44,15 +44,15 @@ public final class BlockEntityTickersList extends ReferenceArrayList<TickingBloc
      * @param index the index of the item on the list to be marked as removed
      */
     public void markAsRemoved(final int index) {
-        if (index < minRemovalIndex) {
-            minRemovalIndex = index;
+        if (index < this.minRemovalIndex) {
+            this.minRemovalIndex = index;
         }
 
-        if (index < lastAddedRemoveIndex) {
-            isSorted = false; // in theory, this should never happen as the TE iteration order is incremental
+        if (index < this.lastAddedRemoveIndex) {
+            this.isSorted = false; // in theory, this should never happen as the TE iteration order is incremental
         }
 
-        lastAddedRemoveIndex = index;
+        this.lastAddedRemoveIndex = index;
         this.toRemove.add(index);
     }
 
@@ -60,34 +60,34 @@ public final class BlockEntityTickersList extends ReferenceArrayList<TickingBloc
      * Removes elements that have been marked as removed.
      */
     public void removeMarkedEntries() {
-        if (toRemove.isEmpty()) {
+        if (this.toRemove.isEmpty()) {
             return;
         }
 
-        if (!isSorted) {
-            IntArrays.quickSort(toRemove.elements(), 0, toRemove.size());
-            minRemovalIndex = toRemove.getInt(0);
+        if (!this.isSorted) {
+            IntArrays.quickSort(this.toRemove.elements(), 0, this.toRemove.size());
+            minRemovalIndex = this.toRemove.getInt(0);
         }
 
         removeBySortedIndices();
 
-        toRemove.clear();
-        minRemovalIndex = Integer.MAX_VALUE;
-        lastAddedRemoveIndex = -1;
-        isSorted = true;
+        this.toRemove.clear();
+        this.minRemovalIndex = Integer.MAX_VALUE;
+        this.lastAddedRemoveIndex = -1;
+        this.isSorted = true;
     }
 
     private void removeBySortedIndices() {
-        if (minRemovalIndex >= size) {
+        if (this.minRemovalIndex >= this.size) {
             return;
         }
 
-        final int[] removeIndices = toRemove.elements();
-        final int removeCount = toRemove.size();
+        final int[] removeIndices = this.toRemove.elements();
+        final int removeCount = this.toRemove.size();
         final Object[] backingArray = this.a;
 
-        int writeIndex = minRemovalIndex;
-        int prevRemoveIndex = minRemovalIndex;
+        int writeIndex = this.minRemovalIndex;
+        int prevRemoveIndex = this.minRemovalIndex;
 
         for (int i = 1; i < removeCount; i++) {
             int currRemoveIndex = removeIndices[i];
@@ -105,14 +105,14 @@ public final class BlockEntityTickersList extends ReferenceArrayList<TickingBloc
             prevRemoveIndex = currRemoveIndex;
         }
 
-        int tailLength = size - (prevRemoveIndex + 1);
+        int tailLength = this.size - (prevRemoveIndex + 1);
         if (tailLength > 0) {
             System.arraycopy(backingArray, prevRemoveIndex + 1, backingArray, writeIndex, tailLength);
             writeIndex += tailLength;
         }
 
-        Arrays.fill(backingArray, writeIndex, size, null);
-        size = writeIndex;
+        Arrays.fill(backingArray, writeIndex, this.size, null);
+        this.size = writeIndex;
     }
 
     @Override

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/list/BlockEntityTickersList.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/list/BlockEntityTickersList.java
@@ -1,7 +1,8 @@
 package org.dreeam.leaf.util.list;
 
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
 import net.minecraft.world.level.block.entity.TickingBlockEntity;
 
 import java.util.Arrays;
@@ -10,20 +11,20 @@ import java.util.Collection;
 /**
  * A list for ServerLevel's blockEntityTickers
  * <p>
- * This list behaves identically to ObjectArrayList, but it has an additional method, `removeAllByIndex`, that allows a list of integers to be passed indicating what
+ * This list behaves identically to ReferenceArrayList, but it has an additional method, `removeMarkedEntities`, that allows a list of integers to be passed indicating what
  * indexes should be deleted from the list
  * <p>
  * This is faster than using removeAll, since we don't need to compare the identity of each block entity, and faster than looping thru each index manually and deleting with remove,
- * since we don't need to resize the array every single remove.
+ * since we don't need to resize the array every single removal.
  */
-public final class BlockEntityTickersList extends ObjectArrayList<TickingBlockEntity> {
+public final class BlockEntityTickersList extends ReferenceArrayList<TickingBlockEntity> {
 
-    private final IntOpenHashSet toRemove = new IntOpenHashSet();
-    private int startSearchFromIndex = -1;
+    private final IntArrayList toRemove = new IntArrayList();
 
-    /**
-     * Creates a new array list with {@link #DEFAULT_INITIAL_CAPACITY} capacity.
-     */
+    private int minRemovalIndex = Integer.MAX_VALUE;
+    private int lastAddedRemoveIndex = -1;
+    private boolean isSorted = true;
+
     public BlockEntityTickersList() {
         super();
     }
@@ -43,10 +44,15 @@ public final class BlockEntityTickersList extends ObjectArrayList<TickingBlockEn
      * @param index the index of the item on the list to be marked as removed
      */
     public void markAsRemoved(final int index) {
-        // The block entities list always loop starting from 0, so we only need to check if the startSearchFromIndex is -1 and that's it
-        if (this.startSearchFromIndex == -1)
-            this.startSearchFromIndex = index;
+        if (index < minRemovalIndex) {
+            minRemovalIndex = index;
+        }
 
+        if (index < lastAddedRemoveIndex) {
+            isSorted = false; // in theory, this should never happen as the TE iteration order is incremental
+        }
+
+        lastAddedRemoveIndex = index;
         this.toRemove.add(index);
     }
 
@@ -54,52 +60,67 @@ public final class BlockEntityTickersList extends ObjectArrayList<TickingBlockEn
      * Removes elements that have been marked as removed.
      */
     public void removeMarkedEntries() {
-        if (this.startSearchFromIndex == -1) // No entries in the list, skip
+        if (toRemove.isEmpty()) {
             return;
+        }
 
-        removeAllByIndex(startSearchFromIndex, toRemove);
+        if (!isSorted) {
+            IntArrays.quickSort(toRemove.elements(), 0, toRemove.size());
+            minRemovalIndex = toRemove.getInt(0);
+        }
+
+        removeBySortedIndices();
+
         toRemove.clear();
-        this.startSearchFromIndex = -1; // Reset the start search index
+        minRemovalIndex = Integer.MAX_VALUE;
+        lastAddedRemoveIndex = -1;
+        isSorted = true;
     }
 
-    /**
-     * Removes elements by their index.
-     */
-    private void removeAllByIndex(final int startSearchFromIndex, final IntOpenHashSet c) { // can't use Set<Integer> because we want to avoid autoboxing when using contains
-        final int requiredMatches = c.size();
-        if (requiredMatches == 0)
-            return; // exit early, we don't need to do anything
+    private void removeBySortedIndices() {
+        if (minRemovalIndex >= size) {
+            return;
+        }
 
-        final Object[] a = this.a;
-        int writeIndex = startSearchFromIndex;
-        int lastCopyIndex = startSearchFromIndex;
-        int matches = 0;
+        final int[] removeIndices = toRemove.elements();
+        final int removeCount = toRemove.size();
+        final Object[] backingArray = this.a;
 
-        for (int readIndex = startSearchFromIndex; readIndex < size; readIndex++) {
-            if (c.contains(readIndex)) {
-                matches++;
-                final int blockLength = readIndex - lastCopyIndex;
-                if (blockLength > 0) {
-                    System.arraycopy(a, lastCopyIndex, a, writeIndex, blockLength);
-                    writeIndex += blockLength;
-                }
-                lastCopyIndex = readIndex + 1;
+        int writeIndex = minRemovalIndex;
+        int prevRemoveIndex = minRemovalIndex;
 
-                if (matches == requiredMatches) {
-                    break;
-                }
+        for (int i = 1; i < removeCount; i++) {
+            int currRemoveIndex = removeIndices[i];
+
+            if (currRemoveIndex == prevRemoveIndex) {
+                continue;
             }
+
+            int length = currRemoveIndex - (prevRemoveIndex + 1);
+
+            if (length > 0) {
+                System.arraycopy(backingArray, prevRemoveIndex + 1, backingArray, writeIndex, length);
+                writeIndex += length;
+            }
+            prevRemoveIndex = currRemoveIndex;
         }
 
-        final int finalBlockLength = size - lastCopyIndex;
-        if (finalBlockLength > 0) {
-            System.arraycopy(a, lastCopyIndex, a, writeIndex, finalBlockLength);
-            writeIndex += finalBlockLength;
+        int tailLength = size - (prevRemoveIndex + 1);
+        if (tailLength > 0) {
+            System.arraycopy(backingArray, prevRemoveIndex + 1, backingArray, writeIndex, tailLength);
+            writeIndex += tailLength;
         }
 
-        if (writeIndex < size) {
-            Arrays.fill(a, writeIndex, size, null);
-        }
+        Arrays.fill(backingArray, writeIndex, size, null);
         size = writeIndex;
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+        this.toRemove.clear();
+        this.minRemovalIndex = Integer.MAX_VALUE;
+        this.lastAddedRemoveIndex = -1;
+        this.isSorted = true;
     }
 }


### PR DESCRIPTION
1. Avoid cache miss by using IntArrayList.
2. Since the TE iteration order is incremental, most marked indices are already sorted (maintain the `isSorted` flag just for defensive programming). This allows us to skip O(N) iteration and directly perform bulk removal.
3. Use ReferenceArrayList as all implementations of TickBlockEntity are not overriding equals() and hashCode()

Tested with BlockEntityTickersListTest, passed integrity tests