### PR TITLE
Optimize respawn anchor explosion

### DIFF
--- a/leaf-server/minecraft-patches/features/0308-Optimize-respawn-anchor-explosion.patch
+++ b/leaf-server/minecraft-patches/features/0308-Optimize-respawn-anchor-explosion.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dreeam <61569423+Dreeam-qwq@users.noreply.github.com>
+Date: Tue, 31 Mar 2026 05:23:16 -0400
+Subject: [PATCH] Optimize respawn anchor explosion
+
+- Remove stream
+- Use faster method to get fluid state
+(Since we can assume the chunk is loaded when a respawn anchor exploded.)
+
+diff --git a/net/minecraft/world/level/block/RespawnAnchorBlock.java b/net/minecraft/world/level/block/RespawnAnchorBlock.java
+index 2b96781a2aaaef3837e617fa982c0d35862d4f39..126b36fc2b5e1404673e50235e21605c840d2f4c 100644
+--- a/net/minecraft/world/level/block/RespawnAnchorBlock.java
++++ b/net/minecraft/world/level/block/RespawnAnchorBlock.java
+@@ -135,7 +135,8 @@ public class RespawnAnchorBlock extends Block {
+     }
+ 
+     private static boolean isWaterThatWouldFlow(BlockPos pos, Level level) {
+-        FluidState fluidState = level.getFluidState(pos);
++        FluidState fluidState = level.getFluidStateIfLoadedUnchecked(pos.getX(), pos.getY(), pos.getZ()); // Leaf - Optimize respawn anchor explosion
++        if (fluidState == null) return false; // Leaf - Optimize respawn anchor explosion
+         if (!fluidState.is(FluidTags.WATER)) {
+             return false;
+         } else if (fluidState.isSource()) {
+@@ -145,8 +146,8 @@ public class RespawnAnchorBlock extends Block {
+             if (f < 2.0F) {
+                 return false;
+             } else {
+-                FluidState fluidState1 = level.getFluidState(pos.below());
+-                return !fluidState1.is(FluidTags.WATER);
++                FluidState fluidState1 = level.getFluidStateIfLoadedUnchecked(pos.getX(), pos.getY() - 1, pos.getZ()); // Leaf - Optimize respawn anchor explosion
++                return fluidState1 != null && !fluidState1.is(FluidTags.WATER); // Leaf - Optimize respawn anchor explosion
+             }
+         }
+     }
+@@ -154,12 +155,10 @@ public class RespawnAnchorBlock extends Block {
+     private void explode(BlockState state, ServerLevel level, final BlockPos pos2) {
+         org.bukkit.block.BlockState blockState = org.bukkit.craftbukkit.block.CraftBlock.at(level, pos2).getState(); // CraftBukkit - capture BlockState before remove block
+         level.removeBlock(pos2, false);
+-        boolean flag = Direction.Plane.HORIZONTAL.stream().map(pos2::relative).anyMatch(blockPos -> isWaterThatWouldFlow(blockPos, level));
+-        final boolean flag1 = flag || level.getFluidState(pos2.above()).is(FluidTags.WATER);
+         ExplosionDamageCalculator explosionDamageCalculator = new ExplosionDamageCalculator() {
+             @Override
+             public Optional<Float> getBlockExplosionResistance(Explosion explosion, BlockGetter level1, BlockPos pos, BlockState state1, FluidState fluid) {
+-                return pos.equals(pos2) && flag1
++                return pos.equals(pos2) && hasWaterFlow(level, pos2) // Leaf - Optimize respawn anchor explosion
+                     ? Optional.of(Blocks.WATER.getExplosionResistance())
+                     : super.getBlockExplosionResistance(explosion, level1, pos, state1, fluid);
+             }
+@@ -170,6 +169,21 @@ public class RespawnAnchorBlock extends Block {
+         );
+     }
+ 
++    // Leaf start - Optimize respawn anchor explosion
++    private static boolean hasWaterFlow(Level level, BlockPos secondPos) {
++        for (Direction direction : Direction.Plane.HORIZONTAL.faces) {
++            final BlockPos blockPos = secondPos.relative(direction);
++            if (isWaterThatWouldFlow(blockPos, level)) {
++                return true;
++            }
++        }
++
++        final FluidState fluidStateAbove = level.getFluidStateIfLoadedUnchecked(secondPos.getX(), secondPos.getY() + 1, secondPos.getZ());
++
++        return fluidStateAbove != null && fluidStateAbove.is(FluidTags.WATER);
++    }
++    // Leaf end - Optimize respawn anchor explosion
++
+     public static boolean canSetSpawn(ServerLevel level, BlockPos pos) {
+         return level.environmentAttributes().getValue(EnvironmentAttributes.RESPAWN_ANCHOR_WORKS, pos);
+     }


### PR DESCRIPTION
- Remove stream
- Use faster method to get fluid state
(Since we can assume the chunk is loaded when a respawn anchor exploded.)