### PR TITLE
Fix plugin compatibility related to snakeyaml's Base64Coder usage

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
@@ -8,7 +8,7 @@ public final class LeafConstants {
     public static final boolean DISABLE_VANILLA_PROFILER = Boolean.getBoolean("Leaf.disable-vanilla-profiler");
     public static final boolean ENABLE_FMA = Boolean.getBoolean("Leaf.enableFMA");
     public static final boolean ENABLE_IO_URING = Boolean.getBoolean("Leaf.enable-io-uring");
-    public static final boolean ENABLE_BASE64CODER_DEBUG_WARNING = Boolean.getBoolean("Leaf.enable-base64coder-debug-warning");
+    public static final boolean ENABLE_BASE64CODER_WARNING = Boolean.getBoolean("Leaf.enable-base64coder-warning");
 
     public static final String DISABLE_VANILLA_PROFILER_DOCS_URL = "https://www.leafmc.one/docs/config/system-properties#dleaf-disable-vanilla-profiler";
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
@@ -8,6 +8,7 @@ public final class LeafConstants {
     public static final boolean DISABLE_VANILLA_PROFILER = Boolean.getBoolean("Leaf.disable-vanilla-profiler");
     public static final boolean ENABLE_FMA = Boolean.getBoolean("Leaf.enableFMA");
     public static final boolean ENABLE_IO_URING = Boolean.getBoolean("Leaf.enable-io-uring");
+    public static final boolean ENABLE_BASE64CODER_DEBUG_WARNING = Boolean.getBoolean("Leaf.enable-base64coder-debug-warning");
 
     public static final String DISABLE_VANILLA_PROFILER_DOCS_URL = "https://www.leafmc.one/docs/config/system-properties#dleaf-disable-vanilla-profiler";
 }

--- a/leaf-server/src/main/java/org/yaml/snakeyaml/external/biz/base64Coder/Base64Coder.java
+++ b/leaf-server/src/main/java/org/yaml/snakeyaml/external/biz/base64Coder/Base64Coder.java
@@ -1,0 +1,373 @@
+// Copyright 2003-2010 Christian d'Heureuse, Inventec Informatik AG, Zurich, Switzerland
+// www.source-code.biz, www.inventec.ch/chdh
+//
+// This module is multi-licensed and may be used under the terms
+// of any of the following licenses:
+//
+// EPL, Eclipse Public License, V1.0 or later, http://www.eclipse.org/legal
+// LGPL, GNU Lesser General Public License, V2.1 or later, http://www.gnu.org/licenses/lgpl.html
+// GPL, GNU General Public License, V2 or later, http://www.gnu.org/licenses/gpl.html
+// AL, Apache License, V2.0 or later, http://www.apache.org/licenses
+// BSD, BSD License, http://www.opensource.org/licenses/bsd-license.php
+//
+// Please contact the author if you need another license.
+// This module is provided "as is", without warranties of any kind.
+
+// Leaf - Print warning for using deprecated snakeyaml's Base64Coder library
+// This class is for compatibility of some plugins.
+// It's better to use Java's standard Base64 utility methods for better performance and more standard,
+// since the Base64Coder is removed since snakeyaml 2.3-SNAPSHOT, it's not recommended to reply on it anymore.
+// For more information, please see https://github.com/Winds-Studio/Leaf/issues/571
+package org.yaml.snakeyaml.external.biz.base64Coder;
+
+/**
+ * A Base64 encoder/decoder.
+ *
+ * <p>
+ * This class is used to encode and decode data in Base64 format as described in RFC 1521.
+ *
+ * <p>
+ * Project home page: <a href="http://www.source-code.biz/base64coder/java/">www.
+ * source-code.biz/base64coder/java</a><br>
+ * Author: Christian d'Heureuse, Inventec Informatik AG, Zurich, Switzerland<br>
+ * Multi-licensed: EPL / LGPL / GPL / AL / BSD.
+ */
+public class Base64Coder {
+
+    // The line separator string of the operating system.
+    private static final String systemLineSeparator = System.getProperty("line.separator");
+
+    // Mapping table from 6-bit nibbles to Base64 characters.
+    private static final char[] map1 = new char[64];
+
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger("Leaf"); // Leaf - Print warning for using deprecated snakeyaml's Base64Coder library
+
+    static {
+        int i = 0;
+        for (char c = 'A'; c <= 'Z'; c++) {
+            map1[i++] = c;
+        }
+        for (char c = 'a'; c <= 'z'; c++) {
+            map1[i++] = c;
+        }
+        for (char c = '0'; c <= '9'; c++) {
+            map1[i++] = c;
+        }
+        map1[i++] = '+';
+        map1[i++] = '/';
+        warnOnInit(); // Leaf - Print warning for using deprecated snakeyaml's Base64Coder library
+    }
+
+    // Mapping table from Base64 characters to 6-bit nibbles.
+    private static final byte[] map2 = new byte[128];
+
+    static {
+        for (int i = 0; i < map2.length; i++) {
+            map2[i] = -1;
+        }
+        for (int i = 0; i < 64; i++) {
+            map2[map1[i]] = (byte) i;
+        }
+    }
+
+    /**
+     * Encodes a string into Base64 format. No blanks or line breaks are inserted.
+     *
+     * @param s A String to be encoded.
+     * @return A String containing the Base64 encoded data.
+     */
+    public static String encodeString(String s) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return encodeString(s, false);
+    }
+    private static String encodeString(String s, boolean dummy) {
+        return new String(encode(s.getBytes(), dummy));
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+    }
+
+    /**
+     * Encodes a byte array into Base 64 format and breaks the output into lines of 76 characters.
+     * This method is compatible with <code>sun.misc.BASE64Encoder.encodeBuffer(byte[])</code>.
+     *
+     * @param in An array containing the data bytes to be encoded.
+     * @return A String containing the Base64 encoded data, broken into lines.
+     */
+    public static String encodeLines(byte[] in) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return encodeLines(in, false);
+    }
+    private static String encodeLines(byte[] in, boolean dummy) {
+        return encodeLines(in, 0, in.length, 76, systemLineSeparator, dummy);
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+    }
+
+    /**
+     * Encodes a byte array into Base 64 format and breaks the output into lines.
+     *
+     * @param in An array containing the data bytes to be encoded.
+     * @param iOff Offset of the first byte in <code>in</code> to be processed.
+     * @param iLen Number of bytes to be processed in <code>in</code>, starting at <code>iOff</code>.
+     * @param lineLen Line length for the output data. Should be a multiple of 4.
+     * @param lineSeparator The line separator to be used to separate the output lines.
+     * @return A String containing the Base64 encoded data, broken into lines.
+     */
+    public static String encodeLines(byte[] in, int iOff, int iLen, int lineLen,
+                                     String lineSeparator) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return encodeLines(in, iOff, iLen, lineLen, lineSeparator, false);
+    }
+    private static String encodeLines(byte[] in, int iOff, int iLen, int lineLen,
+                                     String lineSeparator, boolean dummy) {
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+        int blockLen = (lineLen * 3) / 4;
+        if (blockLen <= 0) {
+            throw new IllegalArgumentException();
+        }
+        int lines = (iLen + blockLen - 1) / blockLen;
+        int bufLen = ((iLen + 2) / 3) * 4 + lines * lineSeparator.length();
+        StringBuilder buf = new StringBuilder(bufLen);
+        int ip = 0;
+        while (ip < iLen) {
+            int l = Math.min(iLen - ip, blockLen);
+            buf.append(encode(in, iOff + ip, l, dummy)); // Leaf - Print warning for using deprecated snakeyaml's Base64Coder library
+            buf.append(lineSeparator);
+            ip += l;
+        }
+        return buf.toString();
+    }
+
+    /**
+     * Encodes a byte array into Base64 format. No blanks or line breaks are inserted in the output.
+     *
+     * @param in An array containing the data bytes to be encoded.
+     * @return A character array containing the Base64 encoded data.
+     */
+    public static char[] encode(byte[] in) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return encode(in, false);
+    }
+    private static char[] encode(byte[] in, boolean dummy) {
+        return encode(in, 0, in.length, dummy);
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+    }
+
+    /**
+     * Encodes a byte array into Base64 format. No blanks or line breaks are inserted in the output.
+     *
+     * @param in An array containing the data bytes to be encoded.
+     * @param iLen Number of bytes to process in <code>in</code>.
+     * @return A character array containing the Base64 encoded data.
+     */
+    public static char[] encode(byte[] in, int iLen) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return encode(in, iLen, false);
+    }
+    private static char[] encode(byte[] in, int iLen, boolean dummy) {
+        return encode(in, 0, iLen, dummy);
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+    }
+
+    /**
+     * Encodes a byte array into Base64 format. No blanks or line breaks are inserted in the output.
+     *
+     * @param in An array containing the data bytes to be encoded.
+     * @param iOff Offset of the first byte in <code>in</code> to be processed.
+     * @param iLen Number of bytes to process in <code>in</code>, starting at <code>iOff</code>.
+     * @return A character array containing the Base64 encoded data.
+     */
+    public static char[] encode(byte[] in, int iOff, int iLen) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return encode(in, iOff, iLen, false);
+    }
+    private static char[] encode(byte[] in, int iOff, int iLen, boolean dummy) {
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+        int oDataLen = (iLen * 4 + 2) / 3; // output length without padding
+        int oLen = ((iLen + 2) / 3) * 4; // output length including padding
+        char[] out = new char[oLen];
+        int ip = iOff;
+        int iEnd = iOff + iLen;
+        int op = 0;
+        while (ip < iEnd) {
+            int i0 = in[ip++] & 0xff;
+            int i1 = ip < iEnd ? in[ip++] & 0xff : 0;
+            int i2 = ip < iEnd ? in[ip++] & 0xff : 0;
+            int o0 = i0 >>> 2;
+            int o1 = ((i0 & 3) << 4) | (i1 >>> 4);
+            int o2 = ((i1 & 0xf) << 2) | (i2 >>> 6);
+            int o3 = i2 & 0x3F;
+            out[op++] = map1[o0];
+            out[op++] = map1[o1];
+            out[op] = op < oDataLen ? map1[o2] : '=';
+            op++;
+            out[op] = op < oDataLen ? map1[o3] : '=';
+            op++;
+        }
+        return out;
+    }
+
+    /**
+     * Decodes a string from Base64 format. No blanks or line breaks are allowed within the Base64
+     * encoded input data.
+     *
+     * @param s A Base64 String to be decoded.
+     * @return A String containing the decoded data.
+     * @throws IllegalArgumentException If the input is not valid Base64 encoded data.
+     */
+    public static String decodeString(String s) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return decodeString(s, false);
+    }
+    private static String decodeString(String s, boolean dummy) {
+        return new String(decode(s, dummy));
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+    }
+
+    /**
+     * Decodes a byte array from Base64 format and ignores line separators, tabs and blanks. CR, LF,
+     * Tab and Space characters are ignored in the input data. This method is compatible with
+     * <code>sun.misc.BASE64Decoder.decodeBuffer(String)</code>.
+     *
+     * @param s A Base64 String to be decoded.
+     * @return An array containing the decoded data bytes.
+     * @throws IllegalArgumentException If the input is not valid Base64 encoded data.
+     */
+    public static byte[] decodeLines(String s) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return decodeLines(s, false);
+    }
+    private static byte[] decodeLines(String s, boolean dummy) {
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+        char[] buf = new char[s.length()];
+        int p = 0;
+        for (int ip = 0; ip < s.length(); ip++) {
+            char c = s.charAt(ip);
+            if (c != ' ' && c != '\r' && c != '\n' && c != '\t') {
+                buf[p++] = c;
+            }
+        }
+        return decode(buf, 0, p, dummy); // Leaf - Print warning for using deprecated snakeyaml's Base64Coder library
+    }
+
+    /**
+     * Decodes a byte array from Base64 format. No blanks or line breaks are allowed within the Base64
+     * encoded input data.
+     *
+     * @param s A Base64 String to be decoded.
+     * @return An array containing the decoded data bytes.
+     * @throws IllegalArgumentException If the input is not valid Base64 encoded data.
+     */
+    public static byte[] decode(String s) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return decode(s, false);
+    }
+    private static byte[] decode(String s, boolean dummy) {
+        return decode(s.toCharArray(), dummy);
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+    }
+
+    /**
+     * Decodes a byte array from Base64 format. No blanks or line breaks are allowed within the Base64
+     * encoded input data.
+     *
+     * @param in A character array containing the Base64 encoded data.
+     * @return An array containing the decoded data bytes.
+     * @throws IllegalArgumentException If the input is not valid Base64 encoded data.
+     */
+    public static byte[] decode(char[] in) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return decode(in, false);
+    }
+    private static byte[] decode(char[] in, boolean dummy) {
+        return decode(in, 0, in.length, dummy);
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+    }
+
+    /**
+     * Decodes a byte array from Base64 format. No blanks or line breaks are allowed within the Base64
+     * encoded input data.
+     *
+     * @param in A character array containing the Base64 encoded data.
+     * @param iOff Offset of the first character in <code>in</code> to be processed.
+     * @param iLen Number of characters to process in <code>in</code>, starting at <code>iOff</code>.
+     * @return An array containing the decoded data bytes.
+     * @throws IllegalArgumentException If the input is not valid Base64 encoded data.
+     */
+    public static byte[] decode(char[] in, int iOff, int iLen) {
+        // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (true) warn();
+        return decode(in, iOff, iLen, false);
+    }
+    private static byte[] decode(char[] in, int iOff, int iLen, boolean dummy) {
+        // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+        if (iLen % 4 != 0) {
+            throw new IllegalArgumentException(
+                "Length of Base64 encoded input string is not a multiple of 4.");
+        }
+        while (iLen > 0 && in[iOff + iLen - 1] == '=') {
+            iLen--;
+        }
+        int oLen = (iLen * 3) / 4;
+        byte[] out = new byte[oLen];
+        int ip = iOff;
+        int iEnd = iOff + iLen;
+        int op = 0;
+        while (ip < iEnd) {
+            int i0 = in[ip++];
+            int i1 = in[ip++];
+            int i2 = ip < iEnd ? in[ip++] : 'A';
+            int i3 = ip < iEnd ? in[ip++] : 'A';
+            if (i0 > 127 || i1 > 127 || i2 > 127 || i3 > 127) {
+                throw new IllegalArgumentException("Illegal character in Base64 encoded data.");
+            }
+            int b0 = map2[i0];
+            int b1 = map2[i1];
+            int b2 = map2[i2];
+            int b3 = map2[i3];
+            if (b0 < 0 || b1 < 0 || b2 < 0 || b3 < 0) {
+                throw new IllegalArgumentException("Illegal character in Base64 encoded data.");
+            }
+            int o0 = (b0 << 2) | (b1 >>> 4);
+            int o1 = ((b1 & 0xf) << 4) | (b2 >>> 2);
+            int o2 = ((b2 & 3) << 6) | b3;
+            out[op++] = (byte) o0;
+            if (op < oLen) {
+                out[op++] = (byte) o1;
+            }
+            if (op < oLen) {
+                out[op++] = (byte) o2;
+            }
+        }
+        return out;
+    }
+
+    // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
+    private static void warnOnInit() {
+        final String message = """
+            Detected one or more than one plugins are using deprecated util method from snakeyaml library.
+            It's not the best practice, please see:
+            https://github.com/Winds-Studio/Leaf/issues/571
+            for more detail.""";
+        LOGGER.warn(message);
+    }
+
+    private static void warn() {
+        if (org.dreeam.leaf.util.LeafConstants.ENABLE_BASE64CODER_DEBUG_WARNING) {
+            LOGGER.warn("Plugin is using deprecated method from Base64Coder.", new Throwable());
+        }
+    }
+    // Leaf end - Print warning for using deprecated snakeyaml's Base64Coder library
+
+    // Dummy constructor.
+    private Base64Coder() {}
+
+} // end class Base64Coder

--- a/leaf-server/src/main/java/org/yaml/snakeyaml/external/biz/base64Coder/Base64Coder.java
+++ b/leaf-server/src/main/java/org/yaml/snakeyaml/external/biz/base64Coder/Base64Coder.java
@@ -78,7 +78,7 @@ public class Base64Coder {
      */
     public static String encodeString(String s) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return encodeString(s, false);
     }
     private static String encodeString(String s, boolean dummy) {
@@ -95,7 +95,7 @@ public class Base64Coder {
      */
     public static String encodeLines(byte[] in) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return encodeLines(in, false);
     }
     private static String encodeLines(byte[] in, boolean dummy) {
@@ -116,7 +116,7 @@ public class Base64Coder {
     public static String encodeLines(byte[] in, int iOff, int iLen, int lineLen,
                                      String lineSeparator) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return encodeLines(in, iOff, iLen, lineLen, lineSeparator, false);
     }
     private static String encodeLines(byte[] in, int iOff, int iLen, int lineLen,
@@ -147,7 +147,7 @@ public class Base64Coder {
      */
     public static char[] encode(byte[] in) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return encode(in, false);
     }
     private static char[] encode(byte[] in, boolean dummy) {
@@ -164,7 +164,7 @@ public class Base64Coder {
      */
     public static char[] encode(byte[] in, int iLen) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return encode(in, iLen, false);
     }
     private static char[] encode(byte[] in, int iLen, boolean dummy) {
@@ -182,7 +182,7 @@ public class Base64Coder {
      */
     public static char[] encode(byte[] in, int iOff, int iLen) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return encode(in, iOff, iLen, false);
     }
     private static char[] encode(byte[] in, int iOff, int iLen, boolean dummy) {
@@ -221,7 +221,7 @@ public class Base64Coder {
      */
     public static String decodeString(String s) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return decodeString(s, false);
     }
     private static String decodeString(String s, boolean dummy) {
@@ -240,7 +240,7 @@ public class Base64Coder {
      */
     public static byte[] decodeLines(String s) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return decodeLines(s, false);
     }
     private static byte[] decodeLines(String s, boolean dummy) {
@@ -266,7 +266,7 @@ public class Base64Coder {
      */
     public static byte[] decode(String s) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return decode(s, false);
     }
     private static byte[] decode(String s, boolean dummy) {
@@ -284,7 +284,7 @@ public class Base64Coder {
      */
     public static byte[] decode(char[] in) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return decode(in, false);
     }
     private static byte[] decode(char[] in, boolean dummy) {
@@ -304,7 +304,7 @@ public class Base64Coder {
      */
     public static byte[] decode(char[] in, int iOff, int iLen) {
         // Leaf start - Print warning for using deprecated snakeyaml's Base64Coder library
-        if (true) warn();
+        warn();
         return decode(in, iOff, iLen, false);
     }
     private static byte[] decode(char[] in, int iOff, int iLen, boolean dummy) {

--- a/leaf-server/src/main/java/org/yaml/snakeyaml/external/biz/base64Coder/Base64Coder.java
+++ b/leaf-server/src/main/java/org/yaml/snakeyaml/external/biz/base64Coder/Base64Coder.java
@@ -361,7 +361,7 @@ public class Base64Coder {
     }
 
     private static void warn() {
-        if (org.dreeam.leaf.util.LeafConstants.ENABLE_BASE64CODER_DEBUG_WARNING) {
+        if (org.dreeam.leaf.util.LeafConstants.ENABLE_BASE64CODER_WARNING) {
             LOGGER.warn("Plugin is using deprecated method from Base64Coder.", new Throwable());
         }
     }


### PR DESCRIPTION
Add back the `Base64Coder` class for plugin compatibility, print a warning message on class init, and print the warning when a method is called (if the debug flag is set).

I'll edit my response in the original issue and Leaf docs to instruct people to find which plugins use these methods during runtime (Server running), by adding the debug JVM flag in their start script.

Concern: Why not use `StackWalker` to match, collect, and print simpler information of those plugins? 
It looks like just made this thing complex, so I think just use "spamming error" to help find plugins is enough (It happens on the debug phase, so I think it's not a big deal?)

Feel free to provide any suggestions (
