### PR TITLE
Lazily copy itemstack

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/util/cache/CachedItemStackSupplier.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/cache/CachedItemStackSupplier.java
@@ -3,16 +3,20 @@ package org.dreeam.leaf.util.cache;
 import net.minecraft.world.item.ItemStack;
 import java.util.function.Supplier;
 
-public class CachedItemStackSupplier implements Supplier<ItemStack> {
-
+public final class CachedItemStackSupplier implements Supplier<ItemStack> {
+    private ItemStack source;
     private ItemStack cachedCopy;
 
-    public void reset(ItemStack source) {
-        this.cachedCopy = source != null ? source.copy() : null;
+    public void reset(ItemStack stack) {
+        this.source = stack;
+        this.cachedCopy = null;
     }
 
     @Override
     public ItemStack get() {
+        if (this.cachedCopy == null && this.source != null) {
+            this.cachedCopy = this.source.copy();
+        }
         return this.cachedCopy;
     }
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/cache/CachedItemStackSupplier.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/cache/CachedItemStackSupplier.java
@@ -13,7 +13,7 @@ public final class CachedItemStackSupplier implements Supplier<ItemStack> {
     }
 
     @Override
-    public ItemStack get() {
+    public ItemStack get() { // The supplier passed down may not always in active use, copy it lazily like Guava's memoize suppliers
         if (this.cachedCopy == null && this.source != null) {
             this.cachedCopy = this.source.copy();
         }


### PR DESCRIPTION
The supplier passed down may not always in active use, copy it lazily and restore vanilla behavior