### PR TITLE
optimize CompoundTag map compares

### DIFF
--- a/leaf-server/minecraft-patches/features/0171-Further-reduce-memory-footprint-of-CompoundTag.patch
+++ b/leaf-server/minecraft-patches/features/0171-Further-reduce-memory-footprint-of-CompoundTag.patch
@@ -7,7 +7,7 @@ Original license: GPL-3.0-only
 Original project: https://github.com/embeddedt/ModernFix
 
 diff --git a/net/minecraft/nbt/CompoundTag.java b/net/minecraft/nbt/CompoundTag.java
-index c9c050966924ddd315e7829e7f3aee2afacc106b..6e859b1add79ce4e636e2994f59963da2cb440a9 100644
+index c9c050966924ddd315e7829e7f3aee2afacc106b..1971fcfbc1c79ab3ebba612f1999e5a206600ebe 100644
 --- a/net/minecraft/nbt/CompoundTag.java
 +++ b/net/minecraft/nbt/CompoundTag.java
 @@ -54,7 +54,7 @@ public final class CompoundTag implements Tag {
@@ -28,13 +28,19 @@ index c9c050966924ddd315e7829e7f3aee2afacc106b..6e859b1add79ce4e636e2994f59963da
      }
  
      @Override
-@@ -400,6 +400,11 @@ public final class CompoundTag implements Tag {
+@@ -400,6 +400,17 @@ public final class CompoundTag implements Tag {
  
      @Override
      public CompoundTag copy() {
 +        // Leaf start - Further reduce memory footprint of CompoundTag
 +        if (this.tags instanceof org.dreeam.leaf.util.map.StringCanonizingOpenHashMap<Tag> stringCanonizingTags) {
-+            return new CompoundTag(org.dreeam.leaf.util.map.StringCanonizingOpenHashMap.deepCopy(stringCanonizingTags, Tag::copy));
++            org.dreeam.leaf.util.map.StringCanonizingOpenHashMap<Tag> ret = new org.dreeam.leaf.util.map.StringCanonizingOpenHashMap<>(stringCanonizingTags.size(), 0.8f);
++            it.unimi.dsi.fastutil.objects.ObjectIterator<it.unimi.dsi.fastutil.objects.Object2ObjectMap.Entry<String, Tag>> iterator = stringCanonizingTags.object2ObjectEntrySet().fastIterator();
++            while (iterator.hasNext()) {
++                Map.Entry<String, Tag> entry = iterator.next();
++                ret.putWithoutInterning(entry.getKey(), entry.getValue().copy());
++            }
++            return new CompoundTag(ret);
 +        }
 +        // Leaf end - Further reduce memory footprint of CompoundTag
          // Paper start - Reduce memory footprint of CompoundTag

--- a/leaf-server/minecraft-patches/features/0171-Further-reduce-memory-footprint-of-CompoundTag.patch
+++ b/leaf-server/minecraft-patches/features/0171-Further-reduce-memory-footprint-of-CompoundTag.patch
@@ -7,10 +7,10 @@ Original license: GPL-3.0-only
 Original project: https://github.com/embeddedt/ModernFix
 
 diff --git a/net/minecraft/nbt/CompoundTag.java b/net/minecraft/nbt/CompoundTag.java
-index c9c050966924ddd315e7829e7f3aee2afacc106b..1971fcfbc1c79ab3ebba612f1999e5a206600ebe 100644
+index c9c050966924ddd315e7829e7f3aee2afacc106b..35b9e48de8c1d49f1603f493b6a83ffd1e302036 100644
 --- a/net/minecraft/nbt/CompoundTag.java
 +++ b/net/minecraft/nbt/CompoundTag.java
-@@ -54,7 +54,7 @@ public final class CompoundTag implements Tag {
+@@ -54,13 +54,13 @@ public final class CompoundTag implements Tag {
  
          private static CompoundTag loadCompound(DataInput input, NbtAccounter nbtAccounter) throws IOException {
              nbtAccounter.accountBytes(48L);
@@ -19,6 +19,22 @@ index c9c050966924ddd315e7829e7f3aee2afacc106b..1971fcfbc1c79ab3ebba612f1999e5a2
  
              byte b;
              while ((b = input.readByte()) != 0) {
+                 String string = readString(input, nbtAccounter);
+                 Tag namedTagData = CompoundTag.readNamedTagData(TagTypes.getType(b), string, input, nbtAccounter);
+-                if (map.put(string, namedTagData) == null) {
++                if (map.put(org.dreeam.leaf.util.map.StringCanonizingOpenHashMap.intern(string), namedTagData) == null) { // Leaf - Further reduce memory footprint of CompoundTag
+                     nbtAccounter.accountBytes(36L);
+                 }
+             }
+@@ -101,7 +101,7 @@ public final class CompoundTag implements Tag {
+                         type.skip(input, nbtAccounter);
+                         break;
+                     default:
+-                        String string = readString(input, nbtAccounter);
++                        String string = org.dreeam.leaf.util.map.StringCanonizingOpenHashMap.intern(readString(input, nbtAccounter)); // Leaf - Further reduce memory footprint of CompoundTag
+                         switch (visitor.visitEntry(type, string)) {
+                             case HALT:
+                                 return StreamTagVisitor.ValueResult.HALT;
 @@ -171,7 +171,7 @@ public final class CompoundTag implements Tag {
      }
  
@@ -38,7 +54,7 @@ index c9c050966924ddd315e7829e7f3aee2afacc106b..1971fcfbc1c79ab3ebba612f1999e5a2
 +            it.unimi.dsi.fastutil.objects.ObjectIterator<it.unimi.dsi.fastutil.objects.Object2ObjectMap.Entry<String, Tag>> iterator = stringCanonizingTags.object2ObjectEntrySet().fastIterator();
 +            while (iterator.hasNext()) {
 +                Map.Entry<String, Tag> entry = iterator.next();
-+                ret.putWithoutInterning(entry.getKey(), entry.getValue().copy());
++                ret.put(entry.getKey(), entry.getValue().copy());
 +            }
 +            return new CompoundTag(ret);
 +        }

--- a/leaf-server/minecraft-patches/features/0171-Further-reduce-memory-footprint-of-CompoundTag.patch
+++ b/leaf-server/minecraft-patches/features/0171-Further-reduce-memory-footprint-of-CompoundTag.patch
@@ -7,10 +7,10 @@ Original license: GPL-3.0-only
 Original project: https://github.com/embeddedt/ModernFix
 
 diff --git a/net/minecraft/nbt/CompoundTag.java b/net/minecraft/nbt/CompoundTag.java
-index c9c050966924ddd315e7829e7f3aee2afacc106b..1971fcfbc1c79ab3ebba612f1999e5a206600ebe 100644
+index c9c050966924ddd315e7829e7f3aee2afacc106b..51cf19e3492d4c4f3cd4e1eff1679fb51ac7af01 100644
 --- a/net/minecraft/nbt/CompoundTag.java
 +++ b/net/minecraft/nbt/CompoundTag.java
-@@ -54,7 +54,7 @@ public final class CompoundTag implements Tag {
+@@ -54,13 +54,13 @@ public final class CompoundTag implements Tag {
  
          private static CompoundTag loadCompound(DataInput input, NbtAccounter nbtAccounter) throws IOException {
              nbtAccounter.accountBytes(48L);
@@ -19,6 +19,22 @@ index c9c050966924ddd315e7829e7f3aee2afacc106b..1971fcfbc1c79ab3ebba612f1999e5a2
  
              byte b;
              while ((b = input.readByte()) != 0) {
+                 String string = readString(input, nbtAccounter);
+                 Tag namedTagData = CompoundTag.readNamedTagData(TagTypes.getType(b), string, input, nbtAccounter);
+-                if (map.put(string, namedTagData) == null) {
++                if (map.put(org.dreeam.leaf.util.map.StringCanonizingOpenHashMap.intern(string), namedTagData) == null) { // Leaf - Further reduce memory footprint of CompoundTag
+                     nbtAccounter.accountBytes(36L);
+                 }
+             }
+@@ -101,7 +101,7 @@ public final class CompoundTag implements Tag {
+                         type.skip(input, nbtAccounter);
+                         break;
+                     default:
+-                        String string = readString(input, nbtAccounter);
++                        String string = org.dreeam.leaf.util.map.StringCanonizingOpenHashMap.intern(readString(input, nbtAccounter)); // Leaf - Further reduce memory footprint of CompoundTag
+                         switch (visitor.visitEntry(type, string)) {
+                             case HALT:
+                                 return StreamTagVisitor.ValueResult.HALT;
 @@ -171,7 +171,7 @@ public final class CompoundTag implements Tag {
      }
  

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/map/StringCanonizingOpenHashMap.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/map/StringCanonizingOpenHashMap.java
@@ -3,10 +3,8 @@ package org.dreeam.leaf.util.map;
 import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.objects.ObjectIterator;
 
 import java.util.Map;
-import java.util.function.Function;
 
 public class StringCanonizingOpenHashMap<T> extends Object2ObjectOpenHashMap<String, T> {
 
@@ -42,19 +40,29 @@ public class StringCanonizingOpenHashMap<T> extends Object2ObjectOpenHashMap<Str
         }
     }
 
-    private void putWithoutInterning(String key, T value) {
+    public void putWithoutInterning(String key, T value) {
         super.put(key, value);
     }
 
-    public static <T> StringCanonizingOpenHashMap<T> deepCopy(StringCanonizingOpenHashMap<T> incomingMap, Function<T, T> deepCopier) {
-        StringCanonizingOpenHashMap<T> newMap = new StringCanonizingOpenHashMap<>(incomingMap.size(), incomingMap.f);
-        ObjectIterator<Entry<String, T>> iterator = incomingMap.object2ObjectEntrySet().fastIterator();
-
-        while (iterator.hasNext()) {
-            Map.Entry<String, T> entry = iterator.next();
-            newMap.putWithoutInterning(entry.getKey(), deepCopier.apply(entry.getValue()));
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (!(o instanceof Map)) return false;
+        final Map<?, ?> m = (Map<?, ?>)o;
+        if (m.size() != size()) return false;
+        if (containsNullKey) {
+            if (!value[n].equals(m.get(key[n]))) {
+                return false;
+            }
         }
-
-        return newMap;
+        final Object[] key = this.key;
+        for (int pos = n; pos-- != 0;) {
+            if (!((key[pos]) == null)) {
+                if (!value[pos].equals(m.get(key[pos]))) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/map/StringCanonizingOpenHashMap.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/map/StringCanonizingOpenHashMap.java
@@ -8,9 +8,9 @@ import java.util.Map;
 
 public class StringCanonizingOpenHashMap<T> extends Object2ObjectOpenHashMap<String, T> {
 
-    private static final Interner<String> KEY_INTERNER = Interners.newBuilder().weak().concurrencyLevel(16).<String>build();
+    private static final Interner<String> KEY_INTERNER = Interners.newBuilder().weak().concurrencyLevel(16).build();
 
-    private static String intern(String key) {
+    public static String intern(String key) {
         return key != null ? KEY_INTERNER.intern(key) : null;
     }
 
@@ -27,28 +27,9 @@ public class StringCanonizingOpenHashMap<T> extends Object2ObjectOpenHashMap<Str
     }
 
     @Override
-    public T put(String key, T value) {
-        return super.put(intern(key), value);
-    }
-
-    @Override
-    public void putAll(Map<? extends String, ? extends T> m) {
-        if (m.isEmpty()) return;
-        ensureCapacity(size() + m.size());
-        for (Map.Entry<? extends String, ? extends T> entry : m.entrySet()) {
-            super.put(intern(entry.getKey()), entry.getValue());
-        }
-    }
-
-    public void putWithoutInterning(String key, T value) {
-        super.put(key, value);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (o == this) return true;
-        if (!(o instanceof Map)) return false;
-        final Map<?, ?> m = (Map<?, ?>)o;
+        if (!(o instanceof Map<?, ?> m)) return false;
         if (m.size() != size()) return false;
         if (containsNullKey) {
             if (!value[n].equals(m.get(key[n]))) {
@@ -57,6 +38,7 @@ public class StringCanonizingOpenHashMap<T> extends Object2ObjectOpenHashMap<Str
         }
         final Object[] key = this.key;
         for (int pos = n; pos-- != 0;) {
+            //noinspection ConstantValue
             if (!((key[pos]) == null)) {
                 if (!value[pos].equals(m.get(key[pos]))) {
                     return false;


### PR DESCRIPTION
#646

avoid map entry and iterator overhead

inline `StringCanonizingOpenHashMap#deepCopy`