### PR TITLE
Improve logger/terminal shutdown

### DIFF
--- a/leaf-server/build.gradle.kts.patch
+++ b/leaf-server/build.gradle.kts.patch
@@ -83,8 +83,8 @@
      implementation("ca.spottedleaf:concurrentutil:0.0.8")
 -    implementation("org.jline:jline-terminal-ffm:3.27.1") // use ffm on java 22+
 -    implementation("org.jline:jline-terminal-jni:3.27.1") // fall back to jni on java 21
-+    implementation("org.jline:jline-terminal-ffm:4.0.4") // use ffm on java 22+ // Leaf - Bump Dependencies
-+    implementation("org.jline:jline-terminal-jni:4.0.4") // fall back to jni on java 21 // Leaf - Bump Dependencies
++    implementation("org.jline:jline-terminal-ffm:4.0.12") // use ffm on java 22+ // Leaf - Bump Dependencies
++    implementation("org.jline:jline-terminal-jni:4.0.12") // fall back to jni on java 21 // Leaf - Bump Dependencies
      implementation("net.minecrell:terminalconsoleappender:1.3.0")
      implementation("net.kyori:adventure-text-serializer-ansi")
  

--- a/leaf-server/minecraft-patches/features/0314-Improve-logger-terminal-shutdown.patch
+++ b/leaf-server/minecraft-patches/features/0314-Improve-logger-terminal-shutdown.patch
@@ -8,7 +8,7 @@ which is at the end of the server exit and before the System#exit.
 
 The original way relies on the finalization.
 And the finalization is untrustworthy, see JEP 421: https://openjdk.org/jeps/421
-The System#exit also may interrupt the normal closure.
+The System#exit may also interrupt the normal closure.
 
 The race still exists, and the logging still happens after the terminal is shut down.
 This problem is entirely exposed since the latest JLine 3.x or 4.x, the strict terminal closure check was introduced.

--- a/leaf-server/minecraft-patches/features/0314-Improve-logger-terminal-shutdown.patch
+++ b/leaf-server/minecraft-patches/features/0314-Improve-logger-terminal-shutdown.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dreeam <61569423+Dreeam-qwq@users.noreply.github.com>
+Date: Wed, 15 Apr 2026 01:12:53 -0400
+Subject: [PATCH] Improve logger/terminal shutdown
+
+Move logger and terminal shutdown processes to the correct stage,
+which is at the end of the server exit and before the System#exit.
+
+The original way relies on the finalization.
+And the finalization is untrustworthy, see JEP 421: https://openjdk.org/jeps/421
+The System#exit also may interrupt the normal closure.
+
+The race still exists, and the logging still happens after the terminal is shut down.
+This problem is entirely exposed since the latest JLine 3.x or 4.x, the strict terminal closure check was introduced.
+See jline3#1576 and jline3#1577
+
+diff --git a/net/minecraft/server/dedicated/DedicatedServer.java b/net/minecraft/server/dedicated/DedicatedServer.java
+index 0e77c717d3481aae5d591a08eed1eb5f1439cdbf..a8970516cd737600ac7fca608ad2d27a083f8dab 100644
+--- a/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -606,6 +606,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         }
+ 
+         this.hasFullyShutdown = true; // Paper - Improved watchdog support
++        io.papermc.paper.log.LoggerShutdown.shutdownLogging(); // Leaf - Improve logger/terminal shutdown
+         System.exit(this.abnormalExit ? 70 : 0); // CraftBukkit // Paper - Improved watchdog support
+     }
+ 

--- a/leaf-server/paper-patches/features/0065-Improve-logger-terminal-shutdown.patch
+++ b/leaf-server/paper-patches/features/0065-Improve-logger-terminal-shutdown.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dreeam <61569423+Dreeam-qwq@users.noreply.github.com>
+Date: Wed, 15 Apr 2026 01:12:53 -0400
+Subject: [PATCH] Improve logger/terminal shutdown
+
+Move logger and terminal shutdown processes to the correct stage,
+which is at the end of the server exit and before the System#exit.
+
+The original way relies on the finalization.
+And the finalization is untrustworthy, see JEP 421: https://openjdk.org/jeps/421
+The System#exit also may interrupt the normal closure.
+
+The race still exists, and the logging still happens after the terminal is shut down.
+This problem is entirely exposed since the latest JLine 3.x or 4.x, the strict terminal closure check was introduced.
+See jline3#1576 and jline3#1577
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java b/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
+index 6050180e65d2a664e96318029cf5031d1bc1f504..61301ead5e2780d1fc1003b7bb94d84157cef7b7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
+@@ -29,8 +29,6 @@ public class ServerShutdownThread extends Thread {
+         } catch (InterruptedException e) {
+             e.printStackTrace();
+             // Paper end
+-        } finally {
+-            LoggerShutdown.shutdownLogging();
+-        }
++        } // Leaf - Improve logger/terminal shutdown - move to DedicatedServer#onServerExit
+     }
+ }

--- a/leaf-server/paper-patches/features/0065-Improve-logger-terminal-shutdown.patch
+++ b/leaf-server/paper-patches/features/0065-Improve-logger-terminal-shutdown.patch
@@ -8,7 +8,7 @@ which is at the end of the server exit and before the System#exit.
 
 The original way relies on the finalization.
 And the finalization is untrustworthy, see JEP 421: https://openjdk.org/jeps/421
-The System#exit also may interrupt the normal closure.
+The System#exit may also interrupt the normal closure.
 
 The race still exists, and the logging still happens after the terminal is shut down.
 This problem is entirely exposed since the latest JLine 3.x or 4.x, the strict terminal closure check was introduced.


### PR DESCRIPTION
Move logger and terminal shutdown processes to the correct stage,
which is at the end of the server exit and before the System#exit.

The original way relies on the finalization.
And the finalization is untrustworthy, see JEP 421: https://openjdk.org/jeps/421
The System#exit may also interrupt the normal closure.

The race still exists, and the logging still happens after the terminal is shut down.
This problem is entirely exposed since the latest JLine 3.x or 4.x, the strict terminal closure check was introduced.
See jline3#1576 and jline3#1577

Close #671 