### PR TITLE
Configurable max neighbours per item merge scan

### DIFF
--- a/leaf-server/minecraft-patches/features/0315-Configurable-max-neighbours-per-item-merge-scan.patch
+++ b/leaf-server/minecraft-patches/features/0315-Configurable-max-neighbours-per-item-merge-scan.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nostalfinals <yuu8583@proton.me>
+Date: Thu, 16 Apr 2026 16:25:56 +0800
+Subject: [PATCH] Configurable max neighbours per item merge scan
+
+
+diff --git a/net/minecraft/world/entity/item/ItemEntity.java b/net/minecraft/world/entity/item/ItemEntity.java
+index c1e7c04b048099dab7bb4cabdcb53add2201247f..1d1c0e757ece72900abde6af616f5c98d4d196db 100644
+--- a/net/minecraft/world/entity/item/ItemEntity.java
++++ b/net/minecraft/world/entity/item/ItemEntity.java
+@@ -283,8 +283,18 @@ public class ItemEntity extends Entity implements TraceableEntity {
+     private void mergeWithNeighbours() {
+         if (this.isMergable()) {
+             double radius = this.level().spigotConfig.itemMerge; // Spigot
+-            for (ItemEntity itemEntity : this.level()
+-                .getEntitiesOfClass(ItemEntity.class, this.getBoundingBox().inflate(radius, this.level().paperConfig().entities.behavior.onlyMergeItemsHorizontally ? 0 : radius - 0.5D, radius), neighbour -> neighbour != this && neighbour.isMergable())) { // Spigot // Paper - configuration to only merge items horizontally
++            // Leaf start - Configurable max neighbours per item merge scan
++            final java.util.List<ItemEntity> neighbours = new java.util.ArrayList<>();
++            this.level().getEntities(
++                net.minecraft.world.level.entity.EntityTypeTest.forClass(ItemEntity.class),
++                this.getBoundingBox().inflate(radius, this.level().paperConfig().entities.behavior.onlyMergeItemsHorizontally ? 0 : radius - 0.5D, radius),
++                neighbour -> neighbour != this && neighbour.isMergable(),
++                neighbours,
++                org.dreeam.leaf.config.modules.opt.ItemMergeMaxNeighboursPerScan.maxNeighboursPerItemMergeScan <= -1
++                    ? Integer.MAX_VALUE
++                    : org.dreeam.leaf.config.modules.opt.ItemMergeMaxNeighboursPerScan.maxNeighboursPerItemMergeScan
++            ); // Spigot // Paper - configuration to only merge items horizontally
++            for (ItemEntity itemEntity : neighbours) {
+                 if (itemEntity.isMergable()) {
+                     // Paper start - Fix items merging through walls
+                     if (this.level().paperConfig().fixes.fixItemsMergingThroughWalls) {
+@@ -300,6 +310,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+                     }
+                 }
+             }
++            // Leaf end - Configurable max neighbours per item merge scan
+         }
+     }
+ 

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/ItemMergeMaxNeighboursPerScan.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/ItemMergeMaxNeighboursPerScan.java
@@ -1,0 +1,30 @@
+package org.dreeam.leaf.config.modules.opt;
+
+import org.dreeam.leaf.config.ConfigModules;
+import org.dreeam.leaf.config.EnumConfigCategory;
+
+public class ItemMergeMaxNeighboursPerScan extends ConfigModules {
+
+    public String getBasePath() {
+        return EnumConfigCategory.PERF.getBaseKeyName();
+    }
+
+    public static int maxNeighboursPerItemMergeScan = 16;
+
+    @Override
+    public void onLoaded() {
+        maxNeighboursPerItemMergeScan = config.getInt(getBasePath() + ".max-neighbours-per-item-merge-scan", maxNeighboursPerItemMergeScan,
+            config.pickStringRegionBased(
+                """
+                    Maximum number of nearby item entities a single item merge scan may inspect.
+                    This can help prevent nearby item merge checks from consuming too much server thread time when many dropped items pile up in a small area.
+                    Set to -1 to disable this limit.
+                    """,
+                """
+                    单次物品合并时, 最多检查多少个附近的物品实体.
+                    可用于防止局部大量掉落物堆积时, 邻近合并逻辑占用过多主线程时间.
+                    设置为 -1 以禁用该限制.
+                    """
+            ));
+    }
+}


### PR DESCRIPTION
By default, `ItemEntity#mergeWithNeighbours` scans all nearby item entities within the merge range.

In some extreme cases, item entities may continue to be produced without being ticked. For example, a player may build a machine that generates large amounts of dropped items and keep the area loaded with a nether portal chunk loader. If the machine is left running while no players are nearby, items can accumulate in a very small area without being processed. As a result, `mergeWithNeighbours` is never called during that time.

When such a chunk is loaded again, the server will immediately tick every unmerged item entity in that area. In extreme cases, this can mean 1,000+ item entities being processed at once. Since each item entity runs `mergeWithNeighbours`, and each call scans nearby item entities again, this results in roughly `n * n` merge checks and can stall the main thread.

<details>
<summary>Watchdog output</summary>

```text
[13:26:07] [Paper Watchdog Thread/ERROR]: --- DO NOT REPORT THIS TO PAPER - THIS IS NOT A BUG OR A CRASH  - 1.21.11-88-8556cb4 (MC: 1.21.11) ---
[13:26:07] [Paper Watchdog Thread/ERROR]: The server has not responded for 10 seconds! Creating thread dump
[13:26:07] [Paper Watchdog Thread/ERROR]: ------------------------------
[13:26:07] [Paper Watchdog Thread/ERROR]: Server thread dump (Look for plugins here before reporting to Paper!):
[13:26:07] [Paper Watchdog Thread/ERROR]: ------------------------------
[13:26:07] [Paper Watchdog Thread/ERROR]: Current Thread: Server thread
[13:26:07] [Paper Watchdog Thread/ERROR]: 	PID: 80 | Suspended: false | Native: false | State: RUNNABLE
[13:26:07] [Paper Watchdog Thread/ERROR]: 	Stack:
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.item.ItemStack.getMaxStackSize(ItemStack.java:587)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.entity.item.ItemEntity.isMergable(ItemEntity.java:270)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.entity.item.ItemEntity.lambda$mergeWithNeighbours$0(ItemEntity.java:249)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.entity.item.ItemEntity$$Lambda/0x00000000826ea488.test(Unknown Source)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		ca.spottedleaf.moonrise.patches.chunk_system.level.entity.ChunkEntitySlices$EntityCollectionBySection.getEntities(ChunkEntitySlices.java:549)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		ca.spottedleaf.moonrise.patches.chunk_system.level.entity.ChunkEntitySlices.getEntities(ChunkEntitySlices.java:383)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		ca.spottedleaf.moonrise.patches.chunk_system.level.entity.EntityLookup.getEntities(EntityLookup.java:718)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.Level.getEntitiesOfClass(Level.java:220)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.entity.item.ItemEntity.mergeWithNeighbours(ItemEntity.java:249)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.entity.item.ItemEntity.tick(ItemEntity.java:200)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel.tickNonPassenger(ServerLevel.java:1354)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel$$Lambda/0x00000000826a1ae8.accept(Unknown Source)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.Level.guardEntityTick(Level.java:1428)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel.lambda$tick$4(ServerLevel.java:854)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel$$Lambda/0x00000000826a1650.accept(Unknown Source)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.world.level.entity.EntityTickList.forEach(EntityTickList.java:39)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:836)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1826)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1618)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.dedicated.DedicatedServer.tickServer(DedicatedServer.java:427)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer.processPacketsAndTick(MinecraftServer.java:1674)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1342)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:388)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		net.minecraft.server.MinecraftServer$$Lambda/0x00000000810e52a8.run(Unknown Source)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		java.base@21.0.2/java.lang.Thread.runWith(Thread.java:1596)
[13:26:07] [Paper Watchdog Thread/ERROR]: 		java.base@21.0.2/java.lang.Thread.run(Thread.java:1583)
[13:26:07] [Paper Watchdog Thread/ERROR]: ------------------------------
[13:26:07] [Paper Watchdog Thread/ERROR]: --- DO NOT REPORT THIS TO PAPER - THIS IS NOT A BUG OR A CRASH ---
[13:26:07] [Paper Watchdog Thread/ERROR]: ------------------------------
```

</details>

This patch adds `performance.max-neighbours-per-item-merge-scan` to mitigate the issue, with a default value of `16`.

With the default value, if 3,000 item entities are piled up in one area, vanilla behavior may perform close to `3000 * 3000` merge checks. By capping each merge scan to at most 16 candidates, this is reduced to approximately `3000 * 16`.

It is also recommended to use Paper's `chunks.entity-per-chunk-save-limit` alongside this change to further limit how many item entities can be stored in a chunk during save/load.