### PR TITLE
Skip item merge checks for full stacks

### DIFF
--- a/leaf-server/minecraft-patches/features/0322-Skip-item-merge-checks-for-full-stacks.patch
+++ b/leaf-server/minecraft-patches/features/0322-Skip-item-merge-checks-for-full-stacks.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nostalfinals <yuu8583@proton.me>
+Date: Thu, 16 Apr 2026 16:46:39 +0800
+Subject: [PATCH] Skip item merge checks for full stacks
+
+
+diff --git a/net/minecraft/world/entity/item/ItemEntity.java b/net/minecraft/world/entity/item/ItemEntity.java
+index c1e7c04b048099dab7bb4cabdcb53add2201247f..abcb9fb10887aea6356fe39ab45f0ebc483988f0 100644
+--- a/net/minecraft/world/entity/item/ItemEntity.java
++++ b/net/minecraft/world/entity/item/ItemEntity.java
+@@ -295,7 +295,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+                     }
+                     // Paper end - Fix items merging through walls
+                     this.tryToMerge(itemEntity);
+-                    if (this.isRemoved()) {
++                    if (this.isRemoved() || this.getItem().getCount() >= this.getItem().getMaxStackSize()) { // Leaf - Skip item merge checks for full stacks
+                         break;
+                     }
+                 }

--- a/leaf-server/minecraft-patches/features/0322-Skip-item-merge-checks-for-full-stacks.patch
+++ b/leaf-server/minecraft-patches/features/0322-Skip-item-merge-checks-for-full-stacks.patch
@@ -5,15 +5,32 @@ Subject: [PATCH] Skip item merge checks for full stacks
 
 
 diff --git a/net/minecraft/world/entity/item/ItemEntity.java b/net/minecraft/world/entity/item/ItemEntity.java
-index c1e7c04b048099dab7bb4cabdcb53add2201247f..abcb9fb10887aea6356fe39ab45f0ebc483988f0 100644
+index c1e7c04b048099dab7bb4cabdcb53add2201247f..da5fa3a73257b064819c82563e4424f01009fc37 100644
 --- a/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/net/minecraft/world/entity/item/ItemEntity.java
-@@ -295,7 +295,7 @@ public class ItemEntity extends Entity implements TraceableEntity {
+@@ -294,8 +294,11 @@ public class ItemEntity extends Entity implements TraceableEntity {
+                         }
                      }
                      // Paper end - Fix items merging through walls
-                     this.tryToMerge(itemEntity);
+-                    this.tryToMerge(itemEntity);
 -                    if (this.isRemoved()) {
-+                    if (this.isRemoved() || this.getItem().getCount() >= this.getItem().getMaxStackSize()) { // Leaf - Skip item merge checks for full stacks
++                    // Leaf start - Skip item merge checks for full stacks
++                    final ItemStack item = this.getItem();
++                    this.tryToMerge(itemEntity, item, itemEntity.getItem());
++                    if (this.isRemoved() || item.getCount() >= item.getMaxStackSize()) {
++                        // Leaf end - Skip item merge checks for full stacks
                          break;
                      }
                  }
+@@ -311,6 +314,11 @@ public class ItemEntity extends Entity implements TraceableEntity {
+     private void tryToMerge(ItemEntity itemEntity) {
+         ItemStack item = this.getItem();
+         ItemStack item1 = itemEntity.getItem();
++        // Leaf start - Skip item merge checks for full stacks
++        tryToMerge(itemEntity, item, item1);
++    }
++    private void tryToMerge(ItemEntity itemEntity, ItemStack item, ItemStack item1) {
++        // Leaf end - Skip item merge checks for full stacks
+         if (Objects.equals(this.target, itemEntity.target) && areMergable(item, item1)) {
+             if (org.dreeam.leaf.config.modules.gameplay.UseSpigotItemMergingMech.enabled || item1.getCount() < item.getCount()) { // Leaf - KeYi - Configurable spigot item merging mechanism
+                 merge(this, item, itemEntity, item1);


### PR DESCRIPTION
By default, when `ItemEntity#mergeWithNeighbours` is called, it will continue calling `tryToMerge` even after the current item entity is already full.

Although `tryToMerge` uses `areMergable` to check whether the merge would exceed the maximum stack size before actually calling `merge`, those checks are guaranteed to fail once the current item entity itself is already full.

This patch avoids those guaranteed-to-fail merge checks by exiting the neighbour scan early once the current item entity has already reached its maximum stack size.

This does not break `ItemMergeEvent`, because that event is only fired after `areMergable` has already passed, which would never happen for these guaranteed-to-fail cases.