### PR TITLE
Limit dont-save entity config to chunk serialization only

### DIFF
--- a/leaf-server/minecraft-patches/features/0195-Limit-dont-save-entity-config-to-chunk-serializa.patch
+++ b/leaf-server/minecraft-patches/features/0195-Limit-dont-save-entity-config-to-chunk-serializa.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: XUANHLGG <lhxuan6@gmail.com>
+Date: Wed, 23 Apr 2026 00:32:00 +0800
+Subject: [PATCH] Limit dont-save entity config to chunk serialization
+
+
+diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
+--- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
++++ b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
+@@ -101,6 +101,16 @@ public final class ChunkEntitySlices {
+         into.put("Entities", entitiesInto); // this is in case into doesn't have any entities
+         entitiesInto.addAll(0, entitiesFrom);
+     }
++
++    private static boolean shouldSerializeEntityForChunk(final Entity entity) {
++        if (entity instanceof net.minecraft.world.entity.item.FallingBlockEntity) {
++            return !org.dreeam.leaf.config.modules.opt.DontSaveEntity.dontSaveFallingBlock;
++        }
++        if (entity instanceof net.minecraft.world.entity.item.PrimedTnt) {
++            return !org.dreeam.leaf.config.modules.opt.DontSaveEntity.dontSavePrimedTNT;
++        }
++        return true;
++    }
+ 
+     public static CompoundTag saveEntityChunk(final List<Entity> entities, final ChunkPos chunkPos, final ServerLevel world) {
+         return saveEntityChunk0(entities, chunkPos, world, false);
+@@ -114,6 +124,9 @@ public final class ChunkEntitySlices {
+         final ListTag entitiesTag = new ListTag();
+         final java.util.Map<net.minecraft.world.entity.EntityType<?>, Integer> savedEntityCounts = new java.util.HashMap<>(); // Paper - Entity load/save limit per chunk
+         for (final Entity entity : PlatformHooks.get().modifySavedEntities(world, chunkPos.x, chunkPos.z, entities)) {
++            if (!shouldSerializeEntityForChunk(entity)) {
++                continue;
++            }
+             // Paper start - Entity load/save limit per chunk
+             final EntityType<?> entityType = entity.getType();
+             final int saveLimit = world.paperConfig().chunks.entityPerChunkSaveLimit.getOrDefault(entityType, -1);
+diff --git a/net/minecraft/world/entity/item/FallingBlockEntity.java b/net/minecraft/world/entity/item/FallingBlockEntity.java
+--- a/net/minecraft/world/entity/item/FallingBlockEntity.java
++++ b/net/minecraft/world/entity/item/FallingBlockEntity.java
+@@ -405,10 +405,4 @@ public class FallingBlockEntity extends Entity {
+         this.forceTickAfterTeleportToDuplicate = entity != null && flag && io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.allowUnsafeEndPortalTeleportation; // Paper
+         return entity;
+     }
+-
+-    // Leaf start - PMC - Don't save falling block entity
+-    @Override
+-    public boolean shouldBeSaved() {
+-        return !org.dreeam.leaf.config.modules.opt.DontSaveEntity.dontSaveFallingBlock && super.shouldBeSaved();
+-    }
+-    // Leaf end - PMC - Don't save falling block entity
+ }
+diff --git a/net/minecraft/world/entity/item/PrimedTnt.java b/net/minecraft/world/entity/item/PrimedTnt.java
+--- a/net/minecraft/world/entity/item/PrimedTnt.java
++++ b/net/minecraft/world/entity/item/PrimedTnt.java
+@@ -282,10 +282,4 @@ public class PrimedTnt extends Entity implements TraceableEntity {
+         return super.interact(player, hand);
+     }
+     // Purpur end - Shears can defuse TNT
+-
+-    // Leaf start - PMC - Don't save primed tnt entity
+-    @Override
+-    public boolean shouldBeSaved() {
+-        return !org.dreeam.leaf.config.modules.opt.DontSaveEntity.dontSavePrimedTNT && super.shouldBeSaved();
+-    }
+-    // Leaf - PMC - Don't save primed tnt entity
+ }


### PR DESCRIPTION
This option were meant to prevent falling blocks and primed TNT from being written to chunk entity data, but the old implementation applied them through shouldBeSaved(), which is also used during chunk unload. As a result, those entities could bypass the normal unload/remove path and remain in memory. This change limits the handling to saveEntityChunk0(), so falling blocks and primed TNT are still unloaded normally while remaining excluded from chunk saves.
#606 