### PR TITLE
Replace entity equipment items to array

### DIFF
--- a/leaf-server/minecraft-patches/features/0316-Replace-entity-equipment-items-to-array.patch
+++ b/leaf-server/minecraft-patches/features/0316-Replace-entity-equipment-items-to-array.patch
@@ -1,0 +1,140 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dreeam <61569423+Dreeam-qwq@users.noreply.github.com>
+Date: Fri, 24 Apr 2026 02:41:08 -0400
+Subject: [PATCH] Replace entity equipment items to array
+
+
+diff --git a/net/minecraft/world/entity/EntityEquipment.java b/net/minecraft/world/entity/EntityEquipment.java
+index 2e7c404e3808c39c0835e1e39fd238af4cf41022..79c000616beb1cec8724049a520518e103c27508 100644
+--- a/net/minecraft/world/entity/EntityEquipment.java
++++ b/net/minecraft/world/entity/EntityEquipment.java
+@@ -13,11 +13,19 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+         map1.putAll((Map<? extends EquipmentSlot, ? extends ItemStack>)map);
+         return new EntityEquipment(map1);
+     }, entityEquipment -> {
+-        Map<EquipmentSlot, ItemStack> map = new EnumMap<>(entityEquipment.items);
+-        map.values().removeIf(ItemStack::isEmpty);
++        // Leaf start - Replace entity equipment items to array
++        Map<EquipmentSlot, ItemStack> map = new EnumMap<>(EquipmentSlot.class);
++        final ItemStack[] stacks = entityEquipment.items;
++        for (int i = 0; i < stacks.length; i++) {
++            ItemStack stack = stacks[i];
++            if (!stack.isEmpty()) {
++                map.put(EquipmentSlot.VALUES_ARRAY[i], stack);
++            }
++        }
++        // Leaf end - Replace entity equipment items to array
+         return map;
+     });
+-    private final EnumMap<EquipmentSlot, ItemStack> items;
++    private final ItemStack[] items; // Leaf - Replace entity equipment items to array
+     // Leaf start - Lithium - equipment tracking
+     boolean shouldTickEnchantments = false;
+     ItemStack recheckEnchantmentForStack = null;
+@@ -26,7 +34,7 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+     // Leaf end - Lithium - equipment tracking
+ 
+     private EntityEquipment(EnumMap<EquipmentSlot, ItemStack> items) {
+-        this.items = items;
++        this.items = items.values().toArray(new ItemStack[0]); // Leaf - Replace entity equipment items to array
+     }
+ 
+     public EntityEquipment() {
+@@ -35,21 +43,25 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+ 
+     public ItemStack set(EquipmentSlot slot, ItemStack stack) {
+         // Leaf start - Lithium - equipment tracking
+-        ItemStack oldStack = Objects.requireNonNullElse(this.items.put(slot, stack), ItemStack.EMPTY);
++        // Leaf start - Replace entity equipment items to array
++        final ItemStack[] items = this.items;
++        final int slotIndex = slot.ordinal();
++        ItemStack oldStack = items[slotIndex];
++        items[slotIndex] = stack == null ? ItemStack.EMPTY : stack;
++        // Leaf end - Replace entity equipment items to array
+         if (inLevel) this.onEquipmentReplaced(oldStack, stack);
+         return oldStack;
+         // Leaf end - Lithium - equipment tracking
+     }
+ 
+     public ItemStack get(EquipmentSlot slot) {
+-        return this.items.getOrDefault(slot, ItemStack.EMPTY);
++        return this.items[slot.ordinal()]; // Leaf - Replace entity equipment items to array
+     }
+ 
+     public boolean isEmpty() {
+         // Leaf start - Multithreaded tracker
+-        for (int i = 0; i < EquipmentSlot.VALUES_ARRAY.length; i++) {
+-            ItemStack itemStack = this.items.get(EquipmentSlot.VALUES_ARRAY[i]);
+-            if (itemStack != null && !itemStack.isEmpty()) {
++        for (ItemStack itemStack : this.items) { // Leaf - Replace entity equipment items to array
++            if (!itemStack.isEmpty()) { // Leaf - Replace entity equipment items to array
+                 return false;
+             }
+         }
+@@ -59,23 +71,25 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+     }
+ 
+     public void tick(Entity entity) {
+-        for (Entry<EquipmentSlot, ItemStack> entry : this.items.entrySet()) {
+-            ItemStack itemStack = entry.getValue();
++        // Leaf start - Replace entity equipment items to array
++        final ItemStack[] items = this.items;
++        for (int i = 0; i < items.length; i++) {
++            ItemStack itemStack = items[i];
+             if (!itemStack.isEmpty()) {
+-                itemStack.inventoryTick(entity.level(), entity, entry.getKey());
++                itemStack.inventoryTick(entity.level(), entity, EquipmentSlot.VALUES_ARRAY[i]);
+             }
+         }
++        // Leaf end - Replace entity equipment items to array
+     }
+ 
+     public void setAll(EntityEquipment equipment) {
+         if (this.inLevel) this.invalidateData(); // Leaf - Lithium - equipment tracking
+-        this.items.clear();
+-        this.items.putAll(equipment.items);
++        System.arraycopy(equipment.items, 0, this.items, 0, this.items.length); // Leaf - Replace entity equipment items to array
+         if (this.inLevel) this.initializeData(); // Leaf - Lithium - equipment tracking
+     }
+ 
+     public void dropAll(LivingEntity entity) {
+-        for (ItemStack itemStack : this.items.values()) {
++        for (ItemStack itemStack : this.items) { // Leaf - Replace entity equipment items to array
+             entity.drop(itemStack, true, false);
+         }
+ 
+@@ -83,14 +97,14 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+     }
+ 
+     public void clear() {
+-        this.items.replaceAll((equipmentSlot, itemStack) -> ItemStack.EMPTY);
++        java.util.Arrays.fill(this.items, ItemStack.EMPTY); // Leaf - Replace entity equipment items to array
+         if (inLevel) this.invalidateData(); // Leaf - Lithium - equipment tracking
+     }
+ 
+     // Paper start - EntityDeathEvent
+     // Needed to not set ItemStack.EMPTY to not existent slot.
+     public boolean has(final EquipmentSlot slot) {
+-        return this.items.containsKey(slot);
++        return this.items[slot.ordinal()] != ItemStack.EMPTY; // Leaf - Replace entity equipment items to array
+     }
+     // Paper end - EntityDeathEvent
+ 
+@@ -213,7 +227,7 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+         this.recheckEnchantmentForStack = null;
+         this.hasUnsentEquipmentChanges = true;
+ 
+-        for (ItemStack oldStack : this.items.values()) {
++        for (ItemStack oldStack : this.items) { // Leaf - Replace entity equipment items to array
+             if (!oldStack.isEmpty()) {
+                 //noinspection unchecked
+                 oldStack.lithium$unsubscribeWithData(this, 0);
+@@ -226,7 +240,7 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+         this.recheckEnchantmentForStack = null;
+         this.hasUnsentEquipmentChanges = true;
+ 
+-        for (ItemStack newStack : this.items.values()) {
++        for (ItemStack newStack : this.items) { // Leaf - Replace entity equipment items to array
+             if (!newStack.isEmpty()) {
+                 if (!this.shouldTickEnchantments) {
+                     this.shouldTickEnchantments = stackHasTickableEnchantment(newStack);

--- a/leaf-server/minecraft-patches/features/0327-Replace-entity-equipment-items-to-array.patch
+++ b/leaf-server/minecraft-patches/features/0327-Replace-entity-equipment-items-to-array.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Replace entity equipment items to array
 
 
 diff --git a/net/minecraft/world/entity/EntityEquipment.java b/net/minecraft/world/entity/EntityEquipment.java
-index 2e7c404e3808c39c0835e1e39fd238af4cf41022..79c000616beb1cec8724049a520518e103c27508 100644
+index 2e7c404e3808c39c0835e1e39fd238af4cf41022..2a45165a23c62d7df097a3358f7e8c4b1500945c 100644
 --- a/net/minecraft/world/entity/EntityEquipment.java
 +++ b/net/minecraft/world/entity/EntityEquipment.java
 @@ -13,11 +13,19 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
@@ -31,16 +31,24 @@ index 2e7c404e3808c39c0835e1e39fd238af4cf41022..79c000616beb1cec8724049a520518e1
      // Leaf start - Lithium - equipment tracking
      boolean shouldTickEnchantments = false;
      ItemStack recheckEnchantmentForStack = null;
-@@ -26,7 +34,7 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+@@ -26,7 +34,15 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
      // Leaf end - Lithium - equipment tracking
  
      private EntityEquipment(EnumMap<EquipmentSlot, ItemStack> items) {
 -        this.items = items;
-+        this.items = items.values().toArray(new ItemStack[0]); // Leaf - Replace entity equipment items to array
++        // Leaf start - Replace entity equipment items to array
++        ItemStack[] self = new ItemStack[EquipmentSlot.VALUES_ARRAY.length];
++        if (!items.isEmpty()) {
++            for (Entry<EquipmentSlot, ItemStack> e : items.entrySet()) {
++                self[e.getKey().ordinal()] = e.getValue();
++            }
++        }
++        this.items = self;
++        // Leaf end - Replace entity equipment items to array
      }
  
      public EntityEquipment() {
-@@ -35,21 +43,25 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+@@ -35,21 +51,25 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
  
      public ItemStack set(EquipmentSlot slot, ItemStack stack) {
          // Leaf start - Lithium - equipment tracking
@@ -71,7 +79,7 @@ index 2e7c404e3808c39c0835e1e39fd238af4cf41022..79c000616beb1cec8724049a520518e1
                  return false;
              }
          }
-@@ -59,23 +71,25 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+@@ -59,23 +79,25 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
      }
  
      public void tick(Entity entity) {
@@ -103,7 +111,7 @@ index 2e7c404e3808c39c0835e1e39fd238af4cf41022..79c000616beb1cec8724049a520518e1
              entity.drop(itemStack, true, false);
          }
  
-@@ -83,14 +97,14 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+@@ -83,14 +105,14 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
      }
  
      public void clear() {
@@ -120,7 +128,7 @@ index 2e7c404e3808c39c0835e1e39fd238af4cf41022..79c000616beb1cec8724049a520518e1
      }
      // Paper end - EntityDeathEvent
  
-@@ -213,7 +227,7 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+@@ -213,7 +235,7 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
          this.recheckEnchantmentForStack = null;
          this.hasUnsentEquipmentChanges = true;
  
@@ -129,7 +137,7 @@ index 2e7c404e3808c39c0835e1e39fd238af4cf41022..79c000616beb1cec8724049a520518e1
              if (!oldStack.isEmpty()) {
                  //noinspection unchecked
                  oldStack.lithium$unsubscribeWithData(this, 0);
-@@ -226,7 +240,7 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
+@@ -226,7 +248,7 @@ public class EntityEquipment implements net.caffeinemc.mods.lithium.common.entit
          this.recheckEnchantmentForStack = null;
          this.hasUnsentEquipmentChanges = true;
  


### PR DESCRIPTION
Directly using the array to avoid unnecessary safe checks and casting in the enum map.

https://spark.lucko.me/VwjjVcMgwv?hl=95640
From discord post: https://discord.com/channels/1145991395388162119/1495041949885927515

<img width="885" height="376" alt="PixPin_2026-04-24_03-44-24" src="https://github.com/user-attachments/assets/b5c6f505-ffce-449f-a4fa-c0e43b1fd086" />
