### PR TITLE
Use 26.1 like section fluid counting to fix compatibility issue with CraftEngine

### DIFF
--- a/leaf-server/minecraft-patches/features/0277-counting-chunk-section-fluid.patch
+++ b/leaf-server/minecraft-patches/features/0277-counting-chunk-section-fluid.patch
@@ -3,6 +3,10 @@ From: hayanesuru <hayanesuru@outlook.jp>
 Date: Sat, 9 Aug 2025 15:12:14 +0900
 Subject: [PATCH] counting chunk section fluid
 
+Port `fluidCount` optimization from vanilla 26.1. Uses `fluidCount` name instead of other custom fields,
+since plugins like CraftEngine may inject LevelChunkSection.
+And it's safe to use `fluidCount` if we assume plugins support multiple versions, and they can easily
+support Leaf by just adding a condition.
 
 diff --git a/net/minecraft/world/level/Level.java b/net/minecraft/world/level/Level.java
 index 80f699cece888aa7001867d0d431f9d26de8b9c6..be09251aea3a217e40ae990649efa18b1b2abaa3 100644
@@ -24,7 +28,7 @@ index 80f699cece888aa7001867d0d431f9d26de8b9c6..be09251aea3a217e40ae990649efa18b
          return !this.dimensionType().hasFixedTime() && this.skyDarken < 4;
      }
 diff --git a/net/minecraft/world/level/chunk/LevelChunk.java b/net/minecraft/world/level/chunk/LevelChunk.java
-index 672656e9a5079c3050dee9efffd9db0b8a303ec9..e96a9872152fc3276fedda14f6bc61eafbafca0f 100644
+index 672656e9a5079c3050dee9efffd9db0b8a303ec9..96d4b20e2a264921d690cb193687df6e94d1ce1b 100644
 --- a/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -338,6 +338,21 @@ public class LevelChunk extends ChunkAccess implements DebugValueSource, ca.spot
@@ -38,7 +42,7 @@ index 672656e9a5079c3050dee9efffd9db0b8a303ec9..e96a9872152fc3276fedda14f6bc61ea
 +            return AIR_FLUIDSTATE;
 +        } else {
 +            LevelChunkSection section = this.sections[sectionIndex];
-+            if (section.waterFluidCount == 0 && section.lavaFluidCount == 0) {
++            if (section.fluidCount <= 0) {
 +                return AIR_FLUIDSTATE;
 +            }
 +            return section.states.get((y & 15) << 8 | (z & 15) << 4 | x & 15).getFluidState();
@@ -50,81 +54,62 @@ index 672656e9a5079c3050dee9efffd9db0b8a303ec9..e96a9872152fc3276fedda14f6bc61ea
      public BlockState getBlockState(BlockPos pos) {
          if (true) {
 diff --git a/net/minecraft/world/level/chunk/LevelChunkSection.java b/net/minecraft/world/level/chunk/LevelChunkSection.java
-index 201ba8b6ea45f526fbd5292164bb4cb6c066d9a8..7442f168e4c0dc0f19e4a7efaaca474358a501b1 100644
+index 201ba8b6ea45f526fbd5292164bb4cb6c066d9a8..d94228bb0df6a4fee2290d47fd2afe81a81d373d 100644
 --- a/net/minecraft/world/level/chunk/LevelChunkSection.java
 +++ b/net/minecraft/world/level/chunk/LevelChunkSection.java
-@@ -17,6 +17,8 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
+@@ -17,6 +17,7 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
      short nonEmptyBlockCount; // Paper - package private
      private short tickingBlockCount;
      private short tickingFluidCount;
-+    public short waterFluidCount; // Leaf - counting chunk section fluid
-+    public short lavaFluidCount; // Leaf - counting chunk section fluid
++    public short fluidCount; // Leaf - counting chunk section fluid
      public final PalettedContainer<BlockState> states;
      private PalettedContainer<Holder<Biome>> biomes; // CraftBukkit - read/write
  
-@@ -48,6 +50,8 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
+@@ -48,6 +49,7 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
          this.nonEmptyBlockCount = section.nonEmptyBlockCount;
          this.tickingBlockCount = section.tickingBlockCount;
          this.tickingFluidCount = section.tickingFluidCount;
-+        this.waterFluidCount = section.waterFluidCount; // Leaf - counting chunk section fluid
-+        this.lavaFluidCount = section.lavaFluidCount; // Leaf - counting chunk section fluid
++        this.fluidCount = section.fluidCount; // Leaf - counting chunk section fluid
          this.states = section.states.copy();
          this.biomes = section.biomes.copy();
      }
-@@ -143,6 +147,15 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
+@@ -143,6 +145,11 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
              if (blockState.isRandomlyTicking()) {
                  this.tickingBlockCount--;
              }
 +            // Leaf start - counting chunk section fluid
-+            final int flags = blockState.tagFlag;
-+            if ((flags & org.dreeam.leaf.util.BlockMasks.WATER) != 0) {
-+                this.waterFluidCount--;
-+            }
-+            if ((flags & org.dreeam.leaf.util.BlockMasks.LAVA) != 0) {
-+                this.lavaFluidCount--;
++            if (!fluidState.isEmpty()) {
++                this.fluidCount--;
 +            }
 +            // Leaf end - counting chunk section fluid
          }
  
          if (!!fluidState.isRandomlyTicking()) { // Paper - block counting
-@@ -154,6 +167,15 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
+@@ -154,6 +161,11 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
              if (state.isRandomlyTicking()) {
                  this.tickingBlockCount++;
              }
 +            // Leaf start - counting chunk section fluid
-+            final int flags = state.tagFlag;
-+            if ((flags & org.dreeam.leaf.util.BlockMasks.WATER) != 0) {
-+                this.waterFluidCount++;
-+            }
-+            if ((flags & org.dreeam.leaf.util.BlockMasks.LAVA) != 0) {
-+                this.lavaFluidCount++;
++            if (!fluidState1.isEmpty()) {
++                this.fluidCount++;
 +            }
 +            // Leaf end - counting chunk section fluid
          }
  
          if (!!fluidState1.isRandomlyTicking()) { // Paper - block counting
-@@ -187,6 +209,8 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
+@@ -187,6 +199,7 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
          this.nonEmptyBlockCount = (short)0;
          this.tickingBlockCount = (short)0;
          this.tickingFluidCount = (short)0;
-+        this.waterFluidCount = (short)0; // Leaf - counting chunk section fluid
-+        this.lavaFluidCount = (short)0; // Leaf - counting chunk section fluid
++        this.fluidCount = (short)0; // Leaf - counting chunk section fluid
          this.specialCollidingBlocks = (short)0;
          this.tickingBlocks.clear();
  
-@@ -234,6 +258,15 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
-                         tickingBlocks.add(raw[i]);
+@@ -239,6 +252,7 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
+ 
+                 if (!fluid.isEmpty()) {
+                     //this.nonEmptyBlockCount += count; // fix vanilla bug: make non-empty block count correct
++                    this.fluidCount += (short)paletteCount; // Leaf - counting chunk section fluid
+                     if (fluid.isRandomlyTicking()) {
+                         this.tickingFluidCount += (short)paletteCount;
                      }
-                 }
-+                // Leaf start - counting chunk section fluid
-+                final int flags = state.tagFlag;
-+                if ((flags & org.dreeam.leaf.util.BlockMasks.WATER) != 0) {
-+                    this.waterFluidCount += (short)paletteCount;
-+                }
-+                if ((flags & org.dreeam.leaf.util.BlockMasks.LAVA) != 0) {
-+                    this.lavaFluidCount += (short)paletteCount;
-+                }
-+                // Leaf end - counting chunk section fluid
- 
-                 final FluidState fluid = state.getFluidState();
- 

--- a/leaf-server/minecraft-patches/features/0277-counting-chunk-section-fluid.patch
+++ b/leaf-server/minecraft-patches/features/0277-counting-chunk-section-fluid.patch
@@ -54,7 +54,7 @@ index 672656e9a5079c3050dee9efffd9db0b8a303ec9..96d4b20e2a264921d690cb193687df6e
      public BlockState getBlockState(BlockPos pos) {
          if (true) {
 diff --git a/net/minecraft/world/level/chunk/LevelChunkSection.java b/net/minecraft/world/level/chunk/LevelChunkSection.java
-index 201ba8b6ea45f526fbd5292164bb4cb6c066d9a8..d94228bb0df6a4fee2290d47fd2afe81a81d373d 100644
+index 201ba8b6ea45f526fbd5292164bb4cb6c066d9a8..b2157681449f1fc5461ac3f7ccb91c61043416ab 100644
 --- a/net/minecraft/world/level/chunk/LevelChunkSection.java
 +++ b/net/minecraft/world/level/chunk/LevelChunkSection.java
 @@ -17,6 +17,7 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
@@ -97,7 +97,16 @@ index 201ba8b6ea45f526fbd5292164bb4cb6c066d9a8..d94228bb0df6a4fee2290d47fd2afe81
          }
  
          if (!!fluidState1.isRandomlyTicking()) { // Paper - block counting
-@@ -187,6 +199,7 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
+@@ -169,6 +181,8 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
+         return this.nonEmptyBlockCount == 0;
+     }
+ 
++    public boolean hasFluid() { return this.fluidCount > 0; } // Leaf - counting chunk section fluid
++
+     public boolean isRandomlyTicking() {
+         return this.isRandomlyTickingBlocks() || this.isRandomlyTickingFluids();
+     }
+@@ -187,6 +201,7 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
          this.nonEmptyBlockCount = (short)0;
          this.tickingBlockCount = (short)0;
          this.tickingFluidCount = (short)0;
@@ -105,7 +114,7 @@ index 201ba8b6ea45f526fbd5292164bb4cb6c066d9a8..d94228bb0df6a4fee2290d47fd2afe81
          this.specialCollidingBlocks = (short)0;
          this.tickingBlocks.clear();
  
-@@ -239,6 +252,7 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
+@@ -239,6 +254,7 @@ public class LevelChunkSection implements ca.spottedleaf.moonrise.patches.block_
  
                  if (!fluid.isEmpty()) {
                      //this.nonEmptyBlockCount += count; // fix vanilla bug: make non-empty block count correct

--- a/leaf-server/minecraft-patches/features/0283-optimize-entity-in-fluid.patch
+++ b/leaf-server/minecraft-patches/features/0283-optimize-entity-in-fluid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] optimize entity in fluid
 
 
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
-index 06745483f0e30b17edce80913c39368a84b4b94b..62de3439850298ba01c862fe9b4eecdda7be64c7 100644
+index 06745483f0e30b17edce80913c39368a84b4b94b..f0bfd55be864e767c2460e1aa7e7a6b15736dd59 100644
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
 @@ -4947,7 +4947,7 @@ public abstract class Entity implements SyncedDataHolder, DebugValueSource, Name
@@ -33,7 +33,7 @@ index 06745483f0e30b17edce80913c39368a84b4b94b..62de3439850298ba01c862fe9b4eecdd
 -                        .states.get((currX & 15) | ((currZ & 15) << 4) | ((currY & 15) << 8)).getFluidState();
 +                    // Leaf start - optimize entity in fluid
 +                    final net.minecraft.world.level.chunk.LevelChunkSection section = sections[(currX >> 4) + chunkLenX*(currZ >> 4) + chunkOffset][(currY >> 4) - minSection];
-+                    if ((fluid == FluidTags.WATER && section.waterFluidCount == 0) || (fluid == FluidTags.LAVA && section.lavaFluidCount == 0)) {
++                    if (section.fluidCount <= 0) {
 +                        continue;
 +                    }
 +                    final FluidState fluidState = section.states.get((currX & 15) | ((currZ & 15) << 4) | ((currY & 15) << 8)).getFluidState();


### PR DESCRIPTION
CraftEngine injects `LevelChunkSection` for its own purposes, copying original fields in `LevelChunkSection` and injecting them into its custom one.

We added our own water and lava counting and used it in entity fluid updating & pushing (for early return).
So that it may conflict with CraftEngine, and the entity's fluid updating will be skipped wrongly.

However, we can port `fluidCount` optimization from vanilla 26.1, since CraftEngine has made support for 26.1, and it will be easy for them to add a condition to support Leaf if we have a similar approach. See [CraftEngine: 添加leaf fluid count支持与canvas 26.1支持](https://github.com/Xiao-MoMi/craft-engine/commit/a532ff60bb6cafdc9524d1ecf1c8260aee1fa6ed).
It's the same for other plugins that do a similar thing and also support multiple versions (If they support many versions, including 26.1, and inject into `LevelChunkSection` too, they can also add support for Leaf easily.)

### Alternatives
The safest way is to drop this patch maybe? since 26.1 already has it.