### PR TITLE
Add option for lazy hopper item loading

### DIFF
--- a/leaf-server/minecraft-patches/features/0327-Optimize-container-loading.patch
+++ b/leaf-server/minecraft-patches/features/0327-Optimize-container-loading.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: DarkCat <realcat@duck.com>
+Date: Tue, 12 May 2026 11:40:43 +0300
+Subject: [PATCH] Optimize container loading
+
+
+diff --git a/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
+index 456de500c3a7043a7f05e8691e8a0839005a2747..9e17d02ae84d8e756ace14bbf3ab53211f427c81 100644
+--- a/net/minecraft/world/level/block/entity/HopperBlockEntity.java
++++ b/net/minecraft/world/level/block/entity/HopperBlockEntity.java
+@@ -38,6 +38,10 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+     public int cooldownTime = -1;
+     private long tickedGameTime;
+     private Direction facing;
++    // Leaf start - Optimize container loading - defer hopper item NBT parsing
++    private net.minecraft.world.level.storage.@Nullable ValueInput leafDeferredItemsInput;
++    private boolean leafItemsLoaded = true;
++    // Leaf end - Optimize container loading
+ 
+     // CraftBukkit start - add fields and methods
+     public List<org.bukkit.entity.HumanEntity> transaction = new java.util.ArrayList<>();
+@@ -45,6 +49,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+ 
+     @Override
+     public List<ItemStack> getContents() {
++        this.leafEnsureItemsLoaded(); // Leaf - Optimize container loading
+         return this.items;
+     }
+ 
+@@ -83,7 +88,14 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+         super.loadAdditional(input);
+         this.items = NonNullList.withSize(this.getContainerSize(), ItemStack.EMPTY);
+         if (!this.tryLoadLootTable(input)) {
+-            ContainerHelper.loadAllItems(input, this.items);
++            // Leaf start - Optimize container loading - defer item NBT parsing until first access
++            if (org.dreeam.leaf.config.modules.opt.OptimizeContainerLoading.lazyLoadHopperItems) {
++                this.leafDeferredItemsInput = input;
++                this.leafItemsLoaded = false;
++            } else {
++                ContainerHelper.loadAllItems(input, this.items);
++            }
++            // Leaf end - Optimize container loading
+         }
+ 
+         this.cooldownTime = input.getIntOr("TransferCooldown", -1);
+@@ -93,6 +105,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+     protected void saveAdditional(ValueOutput output) {
+         super.saveAdditional(output);
+         if (!this.trySaveLootTable(output)) {
++            this.leafEnsureItemsLoaded(); // Leaf - Optimize container loading - force load before serialization
+             ContainerHelper.saveAllItems(output, this.items);
+         }
+ 
+@@ -208,6 +221,7 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+     }
+ 
+     private boolean inventoryFull() {
++        this.leafEnsureItemsLoaded(); // Leaf - Optimize container loading
+         for (ItemStack itemStack : this.items) {
+             if (itemStack.isEmpty() || itemStack.getCount() != itemStack.getMaxStackSize()) {
+                 return false;
+@@ -883,14 +897,32 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+ 
+     @Override
+     protected NonNullList<ItemStack> getItems() {
++        this.leafEnsureItemsLoaded(); // Leaf - Optimize container loading
+         return this.items;
+     }
+ 
+     @Override
+     protected void setItems(NonNullList<ItemStack> items) {
++        // Leaf start - Optimize container loading - wholesale replacement invalidates lazy state
++        this.leafDeferredItemsInput = null;
++        this.leafItemsLoaded = true;
++        // Leaf end - Optimize container loading
+         this.items = items;
+     }
+ 
++    // Leaf start - Optimize container loading - lazy load helper
++    private void leafEnsureItemsLoaded() {
++        if (!this.leafItemsLoaded && this.leafDeferredItemsInput != null) {
++            final net.minecraft.world.level.storage.ValueInput input = this.leafDeferredItemsInput;
++            // Clear state before delegating so reentrant calls don't loop and the
++            // CompoundTag underlying the ValueInput becomes eligible for GC.
++            this.leafDeferredItemsInput = null;
++            this.leafItemsLoaded = true;
++            ContainerHelper.loadAllItems(input, this.items);
++        }
++    }
++    // Leaf end - Optimize container loading
++
+     public static void entityInside(Level level, BlockPos pos, BlockState state, Entity entity, HopperBlockEntity blockEntity) {
+         if (entity instanceof ItemEntity itemEntity
+             && !itemEntity.getItem().isEmpty()

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/OptimizeContainerLoading.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/OptimizeContainerLoading.java
@@ -1,0 +1,38 @@
+package org.dreeam.leaf.config.modules.opt;
+
+import org.dreeam.leaf.config.ConfigModules;
+import org.dreeam.leaf.config.EnumConfigCategory;
+
+public class OptimizeContainerLoading extends ConfigModules {
+
+    public String getBasePath() {
+        return EnumConfigCategory.PERF.getBaseKeyName() + ".optimize-container-loading";
+    }
+
+    public static boolean lazyLoadHopperItems = false;
+
+    @Override
+    public void onLoaded() {
+        lazyLoadHopperItems = config.getBoolean(getBasePath() + ".lazy-load-hopper-items", lazyLoadHopperItems,
+            config.pickStringRegionBased("""
+                    Defers parsing of hopper item NBT until the items are actually accessed.
+                    When a chunk loads, hopper block entities normally deserialize all 5 item
+                    slots from NBT immediately. With this enabled, the items list stays empty
+                    until the first read (container open, hopper transfer, plugin access, etc).
+                    Significantly speeds up chunk loading on worlds with many hoppers (tech farms,
+                    storage systems). Hoppers that are never accessed during their chunk lifetime
+                    skip the deserialize cost entirely.
+                    Note: plugins that read the 'items' NonNullList directly via reflection will
+                    observe an empty list until first access goes through the Container interface
+                    (Bukkit Inventory API access works correctly).""",
+                """
+                    将漏斗物品 NBT 的解析推迟到实际访问物品时。
+                    区块加载时，漏斗方块实体通常会立即从 NBT 反序列化全部 5 个物品槽。
+                    启用此选项后，物品列表会保持为空，直到首次读取
+                    （容器打开、漏斗传输、插件访问等）。
+                    对于拥有大量漏斗的世界（科技服务器、存储系统）能显著加速区块加载。
+                    在区块生命周期内从未被访问的漏斗将完全跳过反序列化开销。
+                    注意：通过反射直接读取 items NonNullList 字段的插件，在首次通过
+                    Container 接口访问之前会看到空列表（Bukkit Inventory API 可正常工作）。"""));
+    }
+}


### PR DESCRIPTION
Adds performance.optimize-container-loading.lazy-load-hopper-items config option (default: false).

When enabled, defers parsing of hopper item NBT until items are actually accessed. Hoppers that load and unload without being touched skip the deserialize cost entirely.