### PR TITLE
Refactor hashCompare to use try-with-resources

### DIFF
--- a/leaf-server/src/main/java/org/leavesmc/leaves/protocol/syncmatica/FileStorage.java
+++ b/leaf-server/src/main/java/org/leavesmc/leaves/protocol/syncmatica/FileStorage.java
@@ -58,7 +58,9 @@ public class FileStorage {
     private boolean hashCompare(final File localFile, final ServerPlacement placement) {
         UUID hash = null;
         try {
-            hash = SyncmaticaProtocol.createChecksum(new FileInputStream(localFile));
+            try (FileInputStream in = new FileInputStream(localFile)) {
+                hash = SyncmaticaProtocol.createChecksum(in);
+            }
         } catch (final Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Wrapped "FileInputStream" in a try-with-resources block to ensure the stream 
is always closed after use, even if an exception occurs.
Prevents file descriptor leaks under heavy load and fixes potential file lock issues on Windows.