### PR TITLE
Reduce debug subscribers overhead

### DIFF
--- a/leaf-server/minecraft-patches/features/0329-Reduce-debug-subscribers-overhead.patch
+++ b/leaf-server/minecraft-patches/features/0329-Reduce-debug-subscribers-overhead.patch
@@ -1,0 +1,74 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Reduce debug subscribers overhead
+
+
+diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
+index 2316934906cc9dfaf7b5518beaa72a5839273fce..002e226666373aa9e63b7030a1812c6753e89a0f 100644
+--- a/net/minecraft/server/MinecraftServer.java
++++ b/net/minecraft/server/MinecraftServer.java
+@@ -1987,7 +1987,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         profilerFiller.popPush("players");
+         this.playerList.tick();
+         profilerFiller.popPush("debugSubscribers");
+-        this.debugSubscribers.tick();
++        if (!org.dreeam.leaf.util.LeafConstants.DISABLE_VANILLA_DEBUG_FEATURE) this.debugSubscribers.tick(); // Leaf - Reduce debug subscribers overhead
+         if (this.tickRateManager.runsNormally()) {
+             profilerFiller.popPush("gameTests");
+             GameTestTicker.SINGLETON.tick();
+diff --git a/net/minecraft/util/debug/ServerDebugSubscribers.java b/net/minecraft/util/debug/ServerDebugSubscribers.java
+index a700521a74b7e8b0c3000df18dce85592f01e568..5bdd43ef13d85005d969602cdfd4861e441e7b22 100644
+--- a/net/minecraft/util/debug/ServerDebugSubscribers.java
++++ b/net/minecraft/util/debug/ServerDebugSubscribers.java
+@@ -13,17 +13,24 @@ import net.minecraft.server.players.NameAndId;
+ 
+ public class ServerDebugSubscribers {
+     private final MinecraftServer server;
+-    private final Map<DebugSubscription<?>, List<ServerPlayer>> enabledSubscriptions = new HashMap<>();
++    // Leaf start - Reduce debug subscribers overhead
++    private final Map<DebugSubscription<?>, List<ServerPlayer>> enabledSubscriptions = new it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap<>();
++    private int tickCount;
++    private static final Set<DebugSubscription<?>> EMPTY_SUBSCRIPTIONS = Set.of();
++    private static final List<ServerPlayer> EMPTY_PLAYERS = List.of();
++    // Leaf end - Reduce debug subscribers overhead
+ 
+     public ServerDebugSubscribers(MinecraftServer server) {
+         this.server = server;
+     }
+ 
+     private List<ServerPlayer> getSubscribersFor(DebugSubscription<?> subscription) {
++        if (org.dreeam.leaf.util.LeafConstants.DISABLE_VANILLA_DEBUG_FEATURE) return EMPTY_PLAYERS; // Leaf - Reduce debug subscribers overhead
+         return this.enabledSubscriptions.getOrDefault(subscription, List.of());
+     }
+ 
+     public void tick() {
++        if (org.dreeam.leaf.util.LeafConstants.DISABLE_VANILLA_DEBUG_FEATURE || tickCount++ % 20 != 0) return; // Leaf - Reduce debug subscribers overhead
+         this.enabledSubscriptions.values().forEach(List::clear);
+ 
+         for (ServerPlayer serverPlayer : this.server.getPlayerList().getPlayers()) {
+@@ -36,20 +43,24 @@ public class ServerDebugSubscribers {
+     }
+ 
+     public void broadcastToAll(DebugSubscription<?> subscription, Packet<?> packet) {
++        if (org.dreeam.leaf.util.LeafConstants.DISABLE_VANILLA_DEBUG_FEATURE) return; // Leaf - Reduce debug subscribers overhead
+         for (ServerPlayer serverPlayer : this.getSubscribersFor(subscription)) {
+             serverPlayer.connection.send(packet);
+         }
+     }
+ 
+     public Set<DebugSubscription<?>> enabledSubscriptions() {
++        if (org.dreeam.leaf.util.LeafConstants.DISABLE_VANILLA_DEBUG_FEATURE) return EMPTY_SUBSCRIPTIONS; // Leaf - Reduce debug subscribers overhead
+         return Set.copyOf(this.enabledSubscriptions.keySet());
+     }
+ 
+     public boolean hasAnySubscriberFor(DebugSubscription<?> subscription) {
++        if (org.dreeam.leaf.util.LeafConstants.DISABLE_VANILLA_DEBUG_FEATURE) return false; // Leaf - Reduce debug subscribers overhead
+         return !this.getSubscribersFor(subscription).isEmpty();
+     }
+ 
+     public boolean hasRequiredPermissions(ServerPlayer player) {
++        if (org.dreeam.leaf.util.LeafConstants.DISABLE_VANILLA_DEBUG_FEATURE) return false; // Leaf - Reduce debug subscribers overhead
+         NameAndId nameAndId = player.nameAndId();
+         return SharedConstants.IS_RUNNING_IN_IDE && this.server.isSingleplayerOwner(nameAndId) || this.server.getPlayerList().isOp(nameAndId);
+     }

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
@@ -9,6 +9,7 @@ public final class LeafConstants {
     public static final boolean ENABLE_FMA = Boolean.getBoolean("Leaf.enableFMA");
     public static final boolean ENABLE_IO_URING = Boolean.getBoolean("Leaf.enable-io-uring");
     public static final boolean ENABLE_BASE64CODER_WARNING = Boolean.getBoolean("Leaf.enable-base64coder-warning");
+    public static final boolean DISABLE_VANILLA_DEBUG_FEATURE = Boolean.getBoolean("Leaf.disable-vanilla-debug-feature");
 
     public static final String DISABLE_VANILLA_PROFILER_DOCS_URL = "https://www.leafmc.one/docs/config/system-properties#dleaf-disable-vanilla-profiler";
 }


### PR DESCRIPTION
Vanilla ServerDebugSubscribers is causing massive object allocations even when it's not in use.

1. Throttle ticking of subscribers, update every single second is enough.
2. Add system property `Leaf.disable-vanilla-debug-feature` to completely disable debug flags.