### PR TITLE
Fix lag-compensation causing cobblestone generators to produce stone

### DIFF
--- a/leaf-server/minecraft-patches/features/0172-TT20-Lag-compensation.patch
+++ b/leaf-server/minecraft-patches/features/0172-TT20-Lag-compensation.patch
@@ -46,7 +46,7 @@ index 4533d9f76f4ea21cee3c3114bcfcded40fe7321b..6f88a991bcc96f5819ebe85e5e353bf6
      @Override
      public int getTickDelay(LevelReader level) {
 -        return 5;
-+        return org.dreeam.leaf.config.modules.misc.LagCompensation.enabled && org.dreeam.leaf.config.modules.misc.LagCompensation.enableForWater ? org.dreeam.leaf.misc.LagCompensation.tt20(5, true) : 5; // Leaf - TT20 - Lag compensation
++        return 5; // Leaf - TT20 - Lag compensation - Water delay is always 5 to prevent cobblestone generator timing issues
      }
  
      @Override

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/LagCompensation.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/LagCompensation.java
@@ -10,7 +10,6 @@ public class LagCompensation extends ConfigModules {
     }
 
     public static boolean enabled = false;
-    public static boolean enableForWater = false;
     public static boolean enableForLava = false;
 
     @Override
@@ -23,7 +22,6 @@ public class LagCompensation extends ConfigModules {
                 可以在卡顿情况下保障基本游戏体验.""");
 
         enabled = config.getBoolean(getBasePath() + ".enabled", enabled);
-        enableForWater = config.getBoolean(getBasePath() + ".enable-for-water", enableForWater);
         enableForLava = config.getBoolean(getBasePath() + ".enable-for-lava", enableForLava);
     }
 }


### PR DESCRIPTION
Fix lag-compensation water tick delay breaking cobblestone generators at low TPS; remove unused enable-for-water config.