### PR TITLE
Fix TT20 lag compensation breaking stone/cobblestone generators

### DIFF
--- a/leaf-server/minecraft-patches/features/0174-TT20-Lag-compensation.patch
+++ b/leaf-server/minecraft-patches/features/0174-TT20-Lag-compensation.patch
@@ -6,6 +6,8 @@ Subject: [PATCH] TT20: Lag compensation
 Original license: AGPL-3.0-only
 Original project: https://github.com/snackbag/TT20
 
+Co-authored-by: MrlingXD <90316914+wling-art@users.noreply.github.com>
+
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
 index 1155ec2dc0954bc31fb04abdc17bed05af51dc45..055d0d330aba403cd57b94536d8da0455f4b5886 100644
 --- a/net/minecraft/server/MinecraftServer.java
@@ -18,30 +20,88 @@ index 1155ec2dc0954bc31fb04abdc17bed05af51dc45..055d0d330aba403cd57b94536d8da045
          this.tickCount++;
          this.tickRateManager.tick();
          this.tickChildren(hasTimeLeft);
+diff --git a/net/minecraft/world/level/block/LiquidBlock.java b/net/minecraft/world/level/block/LiquidBlock.java
+index 77d1ecfd0f866f3fa5cd8fdf88eb4c147ba07d81..095feaa4e9f7738ef7f6cc61e320e0ead7c5c43d 100644
+--- a/net/minecraft/world/level/block/LiquidBlock.java
++++ b/net/minecraft/world/level/block/LiquidBlock.java
+@@ -155,7 +155,7 @@ public class LiquidBlock extends Block implements BucketPickup {
+                 return level.paperConfig().environment.waterOverLavaFlowSpeed;
+             }
+         }
+-        return this.fluid.getTickDelay(level);
++        return this.fluid.getCompensatedTickDelay(level, pos); // Leaf - TT20 - Lag compensation
+     }
+ 
+     private static boolean isLava(Level level, BlockPos pos) {
+@@ -176,7 +176,10 @@ public class LiquidBlock extends Block implements BucketPickup {
+         RandomSource random
+     ) {
+         if ((level.getWorldBorder().world == null || level.getWorldBorder().world.purpurConfig.tickFluids) && state.getFluidState().isSource() || neighborState.getFluidState().isSource()) { // Purpur - Tick fluids config
+-            scheduledTickAccess.scheduleTick(pos, state.getFluidState().getType(), this.fluid.getTickDelay(level));
++            // Leaf start - TT20 - Lag compensation
++            int delay = level instanceof Level realLevel ? this.fluid.getCompensatedTickDelay(realLevel, pos) : this.fluid.getTickDelay(level);
++            scheduledTickAccess.scheduleTick(pos, state.getFluidState().getType(), delay);
++            // Leaf end - TT20 - Lag compensation
+         }
+ 
+         return super.updateShape(state, level, scheduledTickAccess, pos, direction, neighborPos, neighborState, random);
+diff --git a/net/minecraft/world/level/material/FlowingFluid.java b/net/minecraft/world/level/material/FlowingFluid.java
+index af3d41aa18fc864970961ce788ecb23f03d1bbf2..4f4eb5a8b24d6966c0c8a2406f9a2afa5cfe1708 100644
+--- a/net/minecraft/world/level/material/FlowingFluid.java
++++ b/net/minecraft/world/level/material/FlowingFluid.java
+@@ -481,6 +481,12 @@ public abstract class FlowingFluid extends Fluid {
+         return this.getTickDelay(level);
+     }
+ 
++    // Leaf start - TT20 - Lag compensation - pos-aware delay, overridden to keep vanilla timing at fluid interfaces
++    public int getCompensatedTickDelay(Level level, BlockPos pos) {
++        return this.getTickDelay(level);
++    }
++    // Leaf end - TT20 - Lag compensation
++
+     @Override
+     public void tick(ServerLevel level, BlockPos pos, BlockState state, FluidState fluidState) {
+         if (!fluidState.isSource()) {
 diff --git a/net/minecraft/world/level/material/LavaFluid.java b/net/minecraft/world/level/material/LavaFluid.java
-index 3e81c98e2e6b0f1424429ab52aa43d229c867cc7..be35248556e21b227adde0f02f7f958d7c860fa2 100644
+index 3e81c98e2e6b0f1424429ab52aa43d229c867cc7..55d2586391604972a188c25c921ba1ec9cada08b 100644
 --- a/net/minecraft/world/level/material/LavaFluid.java
 +++ b/net/minecraft/world/level/material/LavaFluid.java
-@@ -190,7 +190,13 @@ public abstract class LavaFluid extends FlowingFluid {
+@@ -190,12 +190,29 @@ public abstract class LavaFluid extends FlowingFluid {
  
      @Override
      public int getTickDelay(LevelReader level) {
--        return level.getWorldBorder().world != null ? (isFastLava(level) ? level.getWorldBorder().world.purpurConfig.lavaSpeedNether : level.getWorldBorder().world.purpurConfig.lavaSpeedNotNether) : (isFastLava(level) ? 10 : 30); // Purpur - Make lava flow speed configurable
 +        // Leaf start - TT20 - Lag compensation
-+        int delay = level.getWorldBorder().world != null ? (isFastLava(level) ? level.getWorldBorder().world.purpurConfig.lavaSpeedNether : level.getWorldBorder().world.purpurConfig.lavaSpeedNotNether) : (isFastLava(level) ? 10 : 30); // Purpur - Make lava flow speed configurable
++        int delay = this.getRawTickDelay(level);
 +        if (org.dreeam.leaf.config.modules.misc.LagCompensation.enabled && org.dreeam.leaf.config.modules.misc.LagCompensation.enableForLava) {
 +            delay = org.dreeam.leaf.misc.LagCompensation.tt20(delay, true);
 +        }
 +        return delay;
 +        // Leaf end - TT20 - Lag compensation
++    }
++
++    // Leaf start - TT20 - Lag compensation
++    private int getRawTickDelay(LevelReader level) {
+         return level.getWorldBorder().world != null ? (isFastLava(level) ? level.getWorldBorder().world.purpurConfig.lavaSpeedNether : level.getWorldBorder().world.purpurConfig.lavaSpeedNotNether) : (isFastLava(level) ? 10 : 30); // Purpur - Make lava flow speed configurable
      }
  
++    @Override
++    public int getCompensatedTickDelay(Level level, BlockPos pos) {
++        return org.dreeam.leaf.misc.LagCompensation.fluidDelay(level, pos, this.getRawTickDelay(level), org.dreeam.leaf.config.modules.misc.LagCompensation.enableForLava, FluidTags.WATER);
++    }
++    // Leaf end - TT20 - Lag compensation
++
      @Override
+     public int getSpreadDelay(Level level, BlockPos pos, FluidState currentState, FluidState newState) {
+-        int tickDelay = this.getTickDelay(level);
++        int tickDelay = this.getCompensatedTickDelay(level, pos); // Leaf - TT20 - Lag compensation
+         if (!currentState.isEmpty()
+             && !newState.isEmpty()
+             && !currentState.getValue(FALLING)
 diff --git a/net/minecraft/world/level/material/WaterFluid.java b/net/minecraft/world/level/material/WaterFluid.java
-index 4533d9f76f4ea21cee3c3114bcfcded40fe7321b..6f88a991bcc96f5819ebe85e5e353bf695539399 100644
+index 4533d9f76f4ea21cee3c3114bcfcded40fe7321b..d1df2186bf77b3ee7105cad6d6f27664c2ff10f9 100644
 --- a/net/minecraft/world/level/material/WaterFluid.java
 +++ b/net/minecraft/world/level/material/WaterFluid.java
-@@ -125,7 +125,7 @@ public abstract class WaterFluid extends FlowingFluid {
+@@ -125,9 +125,21 @@ public abstract class WaterFluid extends FlowingFluid {
  
      @Override
      public int getTickDelay(LevelReader level) {
@@ -49,4 +109,18 @@ index 4533d9f76f4ea21cee3c3114bcfcded40fe7321b..6f88a991bcc96f5819ebe85e5e353bf6
 +        return org.dreeam.leaf.config.modules.misc.LagCompensation.enabled && org.dreeam.leaf.config.modules.misc.LagCompensation.enableForWater ? org.dreeam.leaf.misc.LagCompensation.tt20(5, true) : 5; // Leaf - TT20 - Lag compensation
      }
  
++    // Leaf start - TT20 - Lag compensation
++    @Override
++    public int getCompensatedTickDelay(Level level, BlockPos pos) {
++        return org.dreeam.leaf.misc.LagCompensation.fluidDelay(level, pos, 5, org.dreeam.leaf.config.modules.misc.LagCompensation.enableForWater, FluidTags.LAVA); // 5 = vanilla water delay
++    }
++
++    @Override
++    protected int getSpreadDelay(Level level, BlockPos pos, FluidState currentState, FluidState newState) {
++        return this.getCompensatedTickDelay(level, pos);
++    }
++    // Leaf end - TT20 - Lag compensation
++
      @Override
+     public boolean canBeReplacedWith(FluidState fluidState, BlockGetter level, BlockPos pos, Fluid fluid, Direction direction) {
+         return direction == Direction.DOWN && !fluid.is(FluidTags.WATER);

--- a/leaf-server/src/main/java/org/dreeam/leaf/misc/LagCompensation.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/misc/LagCompensation.java
@@ -1,11 +1,34 @@
 package org.dreeam.leaf.misc;
 
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.FluidState;
 
 import java.util.Collections;
 import java.util.List;
 
 public class LagCompensation {
+
+    public static boolean isTouchingFluid(Level level, BlockPos pos, TagKey<Fluid> fluidTag) {
+        final BlockPos.MutableBlockPos neighbor = new BlockPos.MutableBlockPos();
+        for (final Direction direction : Direction.VALUES) {
+            final FluidState fluidState = level.getFluidIfLoaded(neighbor.setWithOffset(pos, direction));
+            if (fluidState != null && fluidState.is(fluidTag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static int fluidDelay(Level level, BlockPos pos, int vanillaDelay, boolean enabledForThisFluid, TagKey<Fluid> oppositeTag) {
+        return org.dreeam.leaf.config.modules.misc.LagCompensation.enabled && enabledForThisFluid && !isTouchingFluid(level, pos, oppositeTag)
+            ? tt20(vanillaDelay, true)
+            : vanillaDelay;
+    }
 
     public static float tt20(float ticks, boolean limitZero) {
         float newTicks = (float) rawTT20(ticks);

--- a/leaf-server/src/main/java/org/dreeam/leaf/misc/LagCompensation.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/misc/LagCompensation.java
@@ -24,10 +24,10 @@ public class LagCompensation {
         return false;
     }
 
-    public static int fluidDelay(Level level, BlockPos pos, int vanillaDelay, boolean enabledForThisFluid, TagKey<Fluid> oppositeTag) {
+    public static int fluidDelay(Level level, BlockPos pos, int rawDelay, boolean enabledForThisFluid, TagKey<Fluid> oppositeTag) {
         return org.dreeam.leaf.config.modules.misc.LagCompensation.enabled && enabledForThisFluid && !isTouchingFluid(level, pos, oppositeTag)
-            ? tt20(vanillaDelay, true)
-            : vanillaDelay;
+            ? tt20(rawDelay, true)
+            : rawDelay;
     }
 
     public static float tt20(float ticks, boolean limitZero) {


### PR DESCRIPTION
由于 TT20 流体卡顿补偿功能中，两个流体是独立的计算和补偿。
岩浆与水相遇有互相竞争的反应路径：
- 石头：LavaFluid.spreadTo 岩浆在流体 tick 中向下灌进含水格
- 圆石 / 黑曜石：LiquidBlock.shouldSpreadLiquid 岩浆水平邻格有水时会同步转换

那到底生成哪种取决于两种事谁先发生，而它们的时机由各自 tick 的调度决定。原版是水（5 tick）与熔岩（10/30 tick），所以节奏稳定，生成器没有工作问题。

但 TT20 对水、岩浆做了非线性的补偿，导致打乱节奏，导致互相竞争，结果出现问题（具体例子：导致 刷石机 / 刷圆石机 产物错乱）

## 解决方法

在一个流体格只要紧邻对方流体（生成器接口），它的每次调度都 fallback 到原始的 vanilla 时序，保证水、岩浆节奏相对。其它情况原样补偿。

具体修复在 LagCompensation 引入两个方法：
- `isTouchingFluid` 六向检测是否紧邻指定的流体（已用 getFluidIfLoaded 防止强制加载区块）
- `fluidDelay` 单纯作为决策，决策是否补偿。

在基类 FlowingFluid 引入 getCompensatedTickDelay。实现与 getTickDelay 相同，每个流体单独覆盖，用于接入 LagCompensation.fluidDelay 决策层。

如果只修改 getSpreadDelay，会导致只能覆盖到**持续扩散**的那一 tick，其它如 onPlace、neighborChanged、updateShape 无法覆盖到。所以必须引入 getCompensatedTickDelay 把 LiquidBlock 那几条也接入进去。

---

相关问题：
- https://github.com/snackbag/TT20/issues/74
- https://github.com/Winds-Studio/Leaf/issues/761

fix: https://github.com/Winds-Studio/Leaf/issues/761