### PR TITLE
Fix some ABA races of Linear region format

### DIFF
--- a/leaf-server/minecraft-patches/features/0332-Add-read-only-mode-for-Linear-v2.patch
+++ b/leaf-server/minecraft-patches/features/0332-Add-read-only-mode-for-Linear-v2.patch
@@ -1,0 +1,101 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Add read-only mode for Linear v2
+
+
+diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java b/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java
+index f950472f371af3581af82c5bcdd7a800191cf051..0ca348d43143d11ba6dd0e6df33b5ee90ad8c381 100644
+--- a/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java
++++ b/ca/spottedleaf/moonrise/patches/chunk_system/scheduling/NewChunkHolder.java
+@@ -1705,7 +1705,7 @@ public final class NewChunkHolder {
+ 
+     private boolean saveChunk(final ChunkAccess chunk, final boolean unloading, final Completable<CompoundTag>[] chunkSave) {
+         // Leaf start - disable world data saving
+-        if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this.world)) {
++        if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this.world) || org.dreeam.leaf.config.modules.misc.RegionFormatConfig.isReadOnlyMode()) { // Leaf - Add read-only mode for Linear v2
+             if (chunk.isUnsaved()) {
+                 chunk.tryMarkSaved();
+             }
+@@ -1763,6 +1763,7 @@ public final class NewChunkHolder {
+     private boolean lastEntitySaveNull;
+     private boolean saveEntities(final ChunkEntitySlices entities, final boolean unloading, final Completable<CompoundTag>[] entitySave) {
+         if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this.world)) return false; // Leaf - disable world data saving
++        if (org.dreeam.leaf.config.modules.misc.RegionFormatConfig.isReadOnlyMode()) return false; // Leaf - Add read-only mode for Linear v2
+         try {
+             if (entities.isTransient()) {
+                 if (!unloading) {
+@@ -1820,7 +1821,7 @@ public final class NewChunkHolder {
+     private boolean lastPoiSaveNull;
+     private boolean savePOI(final PoiChunk poi, final boolean unloading, final Completable<CompoundTag>[] poiSave) {
+         // Leaf start - disable world data saving
+-        if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this.world)) {
++        if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this.world) || org.dreeam.leaf.config.modules.misc.RegionFormatConfig.isReadOnlyMode()) { // Leaf - Add read-only mode for Linear v2
+             if (poi.isDirty()) {
+                 poi.setDirty(false);
+             }
+diff --git a/net/minecraft/server/PlayerAdvancements.java b/net/minecraft/server/PlayerAdvancements.java
+index 1d6644566947a7222dbb06470fecfd2927ba71f5..9f8dc80f279e2fa6e4c7a292c6239dc5fe9ee15f 100644
+--- a/net/minecraft/server/PlayerAdvancements.java
++++ b/net/minecraft/server/PlayerAdvancements.java
+@@ -130,6 +130,7 @@ public class PlayerAdvancements {
+ 
+     public void save() {
+         if (org.spigotmc.SpigotConfig.disableAdvancementSaving) return; // Spigot
++        if (org.dreeam.leaf.config.modules.misc.RegionFormatConfig.isReadOnlyMode()) return; // Leaf - Add read-only mode for Linear v2
+         JsonElement jsonElement = this.codec.encodeStart(JsonOps.INSTANCE, this.asData()).getOrThrow();
+ 
+         try {
+diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
+index 3fb0c67855de020b219790f542d25975803d7720..0e382269d5c0ae85ccf424104e9fb404d9cc8ce0 100644
+--- a/net/minecraft/server/level/ServerLevel.java
++++ b/net/minecraft/server/level/ServerLevel.java
+@@ -1715,6 +1715,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+     // Paper start - Incremental chunk and player saving
+     public void saveIncrementally(boolean doFull) {
+         if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this)) return; // Leaf - disable world data saving
++        if (org.dreeam.leaf.config.modules.misc.RegionFormatConfig.isReadOnlyMode()) return; // Leaf - Add read-only mode for Linear v2
+         if (doFull) {
+             org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(this.getWorld()));
+         }
+@@ -1741,7 +1742,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+         // Paper end - add close param
+         ServerChunkCache chunkSource = this.getChunkSource();
+         // Leaf start - disable world data saving
+-        if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this)) {
++        if (org.dreeam.leaf.config.modules.misc.DisableWorldDataSaving.shouldSkipSave(this) || org.dreeam.leaf.config.modules.misc.RegionFormatConfig.isReadOnlyMode()) { // Leaf - Add read-only mode for Linear v2
+             if (close) {
+                 try {
+                     chunkSource.close(false);
+diff --git a/net/minecraft/stats/ServerStatsCounter.java b/net/minecraft/stats/ServerStatsCounter.java
+index e8af6a4877d01cc56ef0347013978ba9d583aa7e..a697c066efd6b63ec5e14144ed050430197ae889 100644
+--- a/net/minecraft/stats/ServerStatsCounter.java
++++ b/net/minecraft/stats/ServerStatsCounter.java
+@@ -90,6 +90,7 @@ public class ServerStatsCounter extends StatsCounter {
+ 
+     public void save() {
+         if (org.spigotmc.SpigotConfig.disableStatSaving) return; // Spigot
++        if (org.dreeam.leaf.config.modules.misc.RegionFormatConfig.isReadOnlyMode()) return; // Leaf - Add read-only mode for Linear v2
+         try {
+             FileUtil.createDirectoriesSafe(this.file.getParent());
+ 
+@@ -104,6 +105,7 @@ public class ServerStatsCounter extends StatsCounter {
+     @Override
+     public void setValue(Player player, Stat<?> stat, int value) {
+         if (org.spigotmc.SpigotConfig.disableStatSaving) return; // Spigot
++        if (org.dreeam.leaf.config.modules.misc.RegionFormatConfig.isReadOnlyMode()) return; // Leaf - Add read-only mode for Linear v2
+         if (stat.getType() == Stats.CUSTOM && stat.getValue() instanceof final net.minecraft.resources.Identifier key && org.spigotmc.SpigotConfig.forcedStats.get(key) != null) return; // Paper - disable saving forced stats
+         super.setValue(player, stat, value);
+         this.dirty.add(stat);
+diff --git a/net/minecraft/world/level/storage/PlayerDataStorage.java b/net/minecraft/world/level/storage/PlayerDataStorage.java
+index 4099f4ebf76c6bf74384aa5b9f5e889d53ebcfa9..1d5666b7b5167b607b13874830fa7b33f22c945a 100644
+--- a/net/minecraft/world/level/storage/PlayerDataStorage.java
++++ b/net/minecraft/world/level/storage/PlayerDataStorage.java
+@@ -33,6 +33,7 @@ public class PlayerDataStorage {
+ 
+     public void save(Player player) {
+         if (org.spigotmc.SpigotConfig.disablePlayerDataSaving) return; // Spigot
++        if (org.dreeam.leaf.config.modules.misc.RegionFormatConfig.isReadOnlyMode()) return; // Leaf - Add read-only mode for Linear v2
+         // Leaf start - Async playerdata saving
+         CompoundTag compoundTag;
+         try (ProblemReporter.ScopedCollector scopedCollector = new ProblemReporter.ScopedCollector(player.problemPath(), LOGGER)) {

--- a/leaf-server/src/main/java/me/earthme/luminol/data/BufferedLinearRegionFile.java
+++ b/leaf-server/src/main/java/me/earthme/luminol/data/BufferedLinearRegionFile.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -64,7 +65,8 @@ public class BufferedLinearRegionFile implements IRegionFile {
     private static final class Bucket {
         private final Object lock = new Object();
 
-        private volatile boolean dirty = false;
+        private final AtomicLong writeEpoch = new AtomicLong();
+        private final AtomicLong syncedEpoch = new AtomicLong();
         private volatile boolean loaded = false;
     }
 
@@ -152,23 +154,38 @@ public class BufferedLinearRegionFile implements IRegionFile {
         }
     }
 
-    private void makeBucketDirty(int chunkIndex) {
-        final int bucketIndex = chunkIndex >> BUCKET_SHIFT;
-        final Bucket bucket = this.buckets[bucketIndex];
-
-        bucket.dirty = true;
+    private long markBucketDirty(int chunkIndex) {
+        return this.markBucketDirtyByIndex(chunkIndex >> BUCKET_SHIFT);
     }
 
-    private void cleanBucketDirty(int bucketIndex) {
+    private long markBucketDirtyByIndex(int bucketIndex) {
         final Bucket bucket = this.buckets[bucketIndex];
 
-        bucket.dirty = false;
+        return bucket.writeEpoch.incrementAndGet();
+    }
+
+    private long getBucketWriteEpoch(int bucketIndex) {
+        final Bucket bucket = this.buckets[bucketIndex];
+
+        return bucket.writeEpoch.get();
+    }
+
+    private long getBucketSyncedEpoch(int bucketIndex) {
+        final Bucket bucket = this.buckets[bucketIndex];
+
+        return bucket.syncedEpoch.get();
+    }
+
+    private void markBucketSynced(int bucketIndex, long syncedEpoch) {
+        final Bucket bucket = this.buckets[bucketIndex];
+
+        bucket.syncedEpoch.accumulateAndGet(syncedEpoch, Math::max);
     }
 
     private boolean isBucketDirty(int bucketIndex) {
         final Bucket bucket = this.buckets[bucketIndex];
 
-        return bucket.dirty;
+        return bucket.writeEpoch.get() != bucket.syncedEpoch.get();
     }
 
     public boolean markAsBeingSynced() {
@@ -514,6 +531,9 @@ public class BufferedLinearRegionFile implements IRegionFile {
             final Sector sector = this.sectors[index];
 
             sector.store(committed, this.swapFileChannel);
+            if (!skipSync) {
+                this.markBucketDirty(index);
+            }
         } finally {
             this.regionObjectLock.writeLock().unlock();
         }
@@ -556,11 +576,11 @@ public class BufferedLinearRegionFile implements IRegionFile {
             final Sector sector = this.sectors[index];
 
             sector.clear();
+            this.markBucketDirty(index);
         } finally {
             this.regionObjectLock.writeLock().unlock();
         }
 
-        this.makeBucketDirty(index);
         this.markAsToSync();
     }
 
@@ -690,8 +710,6 @@ public class BufferedLinearRegionFile implements IRegionFile {
         this.ensureBucketLoaded(chunkIndex);
 
         this.writeChunk(pos.x, pos.z, buf);
-
-        this.makeBucketDirty(chunkIndex);
     }
 
     // MCC 的玩意,这东西也用不上给Linear了()
@@ -892,7 +910,6 @@ public class BufferedLinearRegionFile implements IRegionFile {
             final int chunkIndex = getChunkIndex(this.pos.x, this.pos.z);
 
             BufferedLinearRegionFile.this.ensureBucketLoaded(chunkIndex);
-            BufferedLinearRegionFile.this.makeBucketDirty(chunkIndex);
             BufferedLinearRegionFile.this.writeChunk(this.pos.x, this.pos.z, bytebuffer);
 
             BufferedLinearRegionFile.this.flushInternal();
@@ -912,7 +929,7 @@ public class BufferedLinearRegionFile implements IRegionFile {
 
         public void writeMainFileBucketed(@NotNull Path mainFile) throws IOException {
             final Path tmpFilePath = Path.of(mainFile + ".tmp");
-            final boolean[] syncedBuckets = new boolean[BUCKET_COUNT];
+            final long[] syncedBucketEpochs = new long[BUCKET_COUNT];
             final long[] newPositionTable = new long[BUCKET_COUNT];
 
             // note: there is no necessary hold the write lock for this stuff
@@ -974,7 +991,8 @@ public class BufferedLinearRegionFile implements IRegionFile {
                     long dataOffset = V3_DATA_AREA_OFFSET;
 
                     for (int bucketIndex = 0; bucketIndex < BUCKET_COUNT; bucketIndex++) {
-                        final boolean isBucketDirty = BufferedLinearRegionFile.this.isBucketDirty(bucketIndex);
+                        final long bucketWriteEpoch = BufferedLinearRegionFile.this.getBucketWriteEpoch(bucketIndex);
+                        final boolean isBucketDirty = bucketWriteEpoch != BufferedLinearRegionFile.this.getBucketSyncedEpoch(bucketIndex);
 
                         if (isBucketDirty) {
                             final int baseChunk = bucketIndex << BUCKET_SHIFT;
@@ -1015,7 +1033,7 @@ public class BufferedLinearRegionFile implements IRegionFile {
                             }
                             // else: newPositionTable[bucketIndex] stays 0
 
-                            syncedBuckets[bucketIndex] = true;
+                            syncedBucketEpochs[bucketIndex] = bucketWriteEpoch;
                         } else {
                             // Not dirty: copy bytes from old file if available
                             if (oldPositionTable != null && oldPositionTable[bucketIndex] != 0) {
@@ -1076,9 +1094,10 @@ public class BufferedLinearRegionFile implements IRegionFile {
                 this.masterFileLock.writeLock().unlock();
             }
 
-            for (int i = 0; i < syncedBuckets.length; i++) {
-                if (syncedBuckets[i]) {
-                    BufferedLinearRegionFile.this.cleanBucketDirty(i);
+            for (int i = 0; i < syncedBucketEpochs.length; i++) {
+                final long syncedEpoch = syncedBucketEpochs[i];
+                if (syncedEpoch != 0L) {
+                    BufferedLinearRegionFile.this.markBucketSynced(i, syncedEpoch);
                 }
             }
         }
@@ -1234,11 +1253,9 @@ public class BufferedLinearRegionFile implements IRegionFile {
                                     byte[] chunkData = new byte[dataLen];
                                     bucketBuffer.get(chunkData);
 
-                                    // Mark bucket as loaded and dirty so it gets synced to new master format
+                                    // Mark bucket as loaded. writeChunk() bumps the bucket epoch so it gets synced to the new master format.
                                     final int blinearBucketIndex = chunkIndex >> BUCKET_SHIFT;
                                     final Bucket bucket = BufferedLinearRegionFile.this.buckets[blinearBucketIndex];
-
-                                    bucket.dirty = true;
 
                                     synchronized (bucket.lock) {
                                         bucket.loaded = true;
@@ -1296,8 +1313,6 @@ public class BufferedLinearRegionFile implements IRegionFile {
                             bucket.loaded = true;
                         }
 
-                        bucket.dirty = true;
-
                         BufferedLinearRegionFile.this.writeChunkDataRaw(index, sectorDataNioBuffer, false);
                     }
                 }
@@ -1348,8 +1363,6 @@ public class BufferedLinearRegionFile implements IRegionFile {
 
                         final int bucketIndex = i >> BUCKET_SHIFT;
                         final Bucket bucket = BufferedLinearRegionFile.this.buckets[bucketIndex];
-
-                        bucket.dirty = true;
 
                         synchronized (bucket.lock) {
                             bucket.loaded = true;

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/RegionFormatConfig.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/RegionFormatConfig.java
@@ -27,7 +27,7 @@ public class RegionFormatConfig extends ConfigModules {
     private static boolean regionFormatLoaded = false;
 
     public static boolean isReadOnlyMode() {
-        return regionFormat == EnumRegionFormat.LINEAR_V2 && LeafConstants.LINEAR_V2_READ_ONLY;
+        return LeafConstants.LINEAR_V2_READ_ONLY && regionFormat == EnumRegionFormat.LINEAR_V2;
     }
 
     @Override

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/RegionFormatConfig.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/RegionFormatConfig.java
@@ -7,6 +7,7 @@ import org.dreeam.leaf.config.ConfigModules;
 import org.dreeam.leaf.config.EnumConfigCategory;
 import org.dreeam.leaf.config.annotations.DoNotLoad;
 import org.dreeam.leaf.config.annotations.HotReloadUnsupported;
+import org.dreeam.leaf.util.LeafConstants;
 
 public class RegionFormatConfig extends ConfigModules {
 
@@ -60,8 +61,17 @@ public class RegionFormatConfig extends ConfigModules {
 
         if (regionFormat == EnumRegionFormat.LINEAR_V2) {
             checkCompressionLevel();
-            LOGGER.warn("Linear v2 region format is unstable and not recommended to use, beware of data loss and take backups.");
+            if (!LeafConstants.LINEAR_V2_ALLOW_WRITE) {
+                LOGGER.error("LINEAR_V2 is write-locked by default.");
+                LOGGER.error("This is intentional because LINEAR_V2 is unstable and may cause world data loss.");
+                LOGGER.error("If you understand the risk, have backups, and still want to write to LINEAR_V2 regions, add JVM flag: -D{}=true", LeafConstants.LINEAR_V2_ALLOW_WRITE_FLAG);
 
+                throw new IllegalStateException(
+                    "LINEAR_V2 requires explicit write unlock: -D" + LeafConstants.LINEAR_V2_ALLOW_WRITE_FLAG + "=true"
+                );
+            }
+
+            LOGGER.warn("Linear v2 region format is unstable and not recommended to use, beware of data loss and take backups.");
             LinearRegionFile.SAVE_DELAY_MS = ioFlushDelay <= 0 ? 100 : ioFlushDelay;
             LinearRegionFile.SAVE_THREAD_MAX_COUNT = ioThreadCount;
             LinearRegionFile.USE_VIRTUAL_THREAD = linearUseVirtualThread;

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/RegionFormatConfig.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/RegionFormatConfig.java
@@ -26,6 +26,10 @@ public class RegionFormatConfig extends ConfigModules {
 
     private static boolean regionFormatLoaded = false;
 
+    public static boolean isReadOnlyMode() {
+        return regionFormat == EnumRegionFormat.LINEAR_V2 && LeafConstants.LINEAR_V2_READ_ONLY;
+    }
+
     @Override
     public void onLoaded() {
         config.addCommentRegionBased(getBasePath(), """
@@ -61,17 +65,19 @@ public class RegionFormatConfig extends ConfigModules {
 
         if (regionFormat == EnumRegionFormat.LINEAR_V2) {
             checkCompressionLevel();
-            if (!LeafConstants.LINEAR_V2_ALLOW_WRITE) {
-                LOGGER.error("LINEAR_V2 is write-locked by default.");
-                LOGGER.error("This is intentional because LINEAR_V2 is unstable and may cause world data loss.");
-                LOGGER.error("If you understand the risk, have backups, and still want to write to LINEAR_V2 regions, add JVM flag: -D{}=true", LeafConstants.LINEAR_V2_ALLOW_WRITE_FLAG);
-
-                throw new IllegalStateException(
-                    "LINEAR_V2 requires explicit write unlock: -D" + LeafConstants.LINEAR_V2_ALLOW_WRITE_FLAG + "=true"
-                );
-            }
-
             LOGGER.warn("Linear v2 region format is unstable and not recommended to use, beware of data loss and take backups.");
+            if (isReadOnlyMode()) {
+                LOGGER.error("============================================================");
+                LOGGER.error("                  LINEAR_V2 READ-ONLY MODE                 ");
+                LOGGER.error("============================================================");
+                LOGGER.error("Linear v2 read-only mode is enabled.");
+                LOGGER.error("Any world changes in Linear v2 regions will NOT be saved.");
+                LOGGER.error("Chunk, entity, player data and POI changes will be discarded.");
+                LOGGER.error("This mode is intended for inspection, testing, migration, or emergency recovery.");
+                LOGGER.error("To enable LINEAR_V2 writing, stop the server, take backups,");
+                LOGGER.error("then remove the JVM flag: -D{}=true", LeafConstants.LINEAR_V2_READ_ONLY);
+                LOGGER.error("============================================================");
+            }
             LinearRegionFile.SAVE_DELAY_MS = ioFlushDelay <= 0 ? 100 : ioFlushDelay;
             LinearRegionFile.SAVE_THREAD_MAX_COUNT = ioThreadCount;
             LinearRegionFile.USE_VIRTUAL_THREAD = linearUseVirtualThread;

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/RegionFormatConfig.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/misc/RegionFormatConfig.java
@@ -75,7 +75,7 @@ public class RegionFormatConfig extends ConfigModules {
                 LOGGER.error("Chunk, entity, player data and POI changes will be discarded.");
                 LOGGER.error("This mode is intended for inspection, testing, migration, or emergency recovery.");
                 LOGGER.error("To enable LINEAR_V2 writing, stop the server, take backups,");
-                LOGGER.error("then remove the JVM flag: -D{}=true", LeafConstants.LINEAR_V2_READ_ONLY);
+                LOGGER.error("then remove the JVM flag: -D{}=true", LeafConstants.LINEAR_V2_READ_ONLY_FLAG);
                 LOGGER.error("============================================================");
             }
             LinearRegionFile.SAVE_DELAY_MS = ioFlushDelay <= 0 ? 100 : ioFlushDelay;

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
@@ -10,6 +10,8 @@ public final class LeafConstants {
     public static final boolean ENABLE_IO_URING = Boolean.getBoolean("Leaf.enable-io-uring");
     public static final boolean ENABLE_BASE64CODER_WARNING = Boolean.getBoolean("Leaf.enable-base64coder-warning");
     public static final boolean DISABLE_VANILLA_DEBUG_FEATURE = Boolean.getBoolean("Leaf.disable-vanilla-debug-feature");
+    public static final String LINEAR_V2_ALLOW_WRITE_FLAG = "Leaf.linear-v2-allow-write";
+    public static final boolean LINEAR_V2_ALLOW_WRITE = Boolean.getBoolean(LINEAR_V2_ALLOW_WRITE_FLAG);
 
     public static final String DISABLE_VANILLA_PROFILER_DOCS_URL = "https://www.leafmc.one/docs/config/system-properties#dleaf-disable-vanilla-profiler";
 }

--- a/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/LeafConstants.java
@@ -10,8 +10,8 @@ public final class LeafConstants {
     public static final boolean ENABLE_IO_URING = Boolean.getBoolean("Leaf.enable-io-uring");
     public static final boolean ENABLE_BASE64CODER_WARNING = Boolean.getBoolean("Leaf.enable-base64coder-warning");
     public static final boolean DISABLE_VANILLA_DEBUG_FEATURE = Boolean.getBoolean("Leaf.disable-vanilla-debug-feature");
-    public static final String LINEAR_V2_ALLOW_WRITE_FLAG = "Leaf.linear-v2-allow-write";
-    public static final boolean LINEAR_V2_ALLOW_WRITE = Boolean.getBoolean(LINEAR_V2_ALLOW_WRITE_FLAG);
+    public static final String LINEAR_V2_READ_ONLY_FLAG = "Leaf.linear-v2-read-only";
+    public static final boolean LINEAR_V2_READ_ONLY = Boolean.getBoolean(LINEAR_V2_READ_ONLY_FLAG);
 
     public static final String DISABLE_VANILLA_PROFILER_DOCS_URL = "https://www.leafmc.one/docs/config/system-properties#dleaf-disable-vanilla-profiler";
 }


### PR DESCRIPTION
Preparing to sync following changes from Luminol:

1. https://github.com/LuminolMC/Luminol/commit/3ca8eba57d252d1fac75fb0308199e48e146465a


Add read-only mode for Linear v2 for emergency use.