### PR TITLE
Add configurable shield blocking delay

### DIFF
--- a/leaf-server/minecraft-patches/features/0336-configurable-shield-blocking-delay.patch
+++ b/leaf-server/minecraft-patches/features/0336-configurable-shield-blocking-delay.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: vhs03 <vhs03.vhs03@outlook.de>
+Date: Wed, 10 Jun 2026 23:46:16 +0200
+Subject: [PATCH] configurable shield blocking delay
+
+
+diff --git a/net/minecraft/world/item/Items.java b/net/minecraft/world/item/Items.java
+index 310e61a9bbece157d81095130ecb3131deef9288..6942bd422dc1941fe0a2689e0673a407e1fb46fe 100644
+--- a/net/minecraft/world/item/Items.java
++++ b/net/minecraft/world/item/Items.java
+@@ -1958,7 +1958,7 @@ public class Items {
+             .component(
+                 DataComponents.BLOCKS_ATTACKS,
+                 new BlocksAttacks(
+-                    0.25F,
++                    org.dreeam.leaf.config.modules.gameplay.ShieldBlockingDelay.shieldBlockingDelay / 20.0F,
+                     1.0F,
+                     List.of(new BlocksAttacks.DamageReduction(90.0F, Optional.empty(), 0.0F, 1.0F)),
+                     new BlocksAttacks.ItemDamageFunction(3.0F, 1.0F, 1.0F),

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/ShieldBlockingDelay.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/ShieldBlockingDelay.java
@@ -1,0 +1,25 @@
+package org.dreeam.leaf.config.modules.gameplay;
+
+import org.dreeam.leaf.config.ConfigModules;
+import org.dreeam.leaf.config.EnumConfigCategory;
+
+public class ShieldBlockingDelay extends ConfigModules {
+
+    public String getBasePath() {
+        return EnumConfigCategory.GAMEPLAY.getBaseKeyName() + ".shield-blocking-delay";
+    }
+
+    public static int shieldBlockingDelay = 5;
+
+    @Override
+    public void onLoaded() {
+        shieldBlockingDelay = config.getInt(getBasePath(), shieldBlockingDelay,
+            config.pickStringRegionBased(
+                "The delay in ticks before a raised shield blocks attacks.",
+                "盾牌举起后可格挡攻击前的延迟（以刻为单位）。"
+            ));
+        if (shieldBlockingDelay < 0) {
+            shieldBlockingDelay = 5;
+        }
+    }
+}


### PR DESCRIPTION
Adds a new shield blocking delay option to leaf-global.yml

Shields normally take 5 ticks before they start blocking after being raised and there was no easy way to change that anymore after Paper removed their option for it in the 1.21.5 update

This adds the setting back in Leaf so you can control the delay again

Lower values make shields feel more responsive which is useful for pvp servers where even a few ms can make a difference