### PR TITLE
Fix rooted dirt hoe drops

### DIFF
--- a/leaf-server/minecraft-patches/features/0264-Paper-PR-Fix-cancelled-rooted-dirt-drops-being-duped.patch
+++ b/leaf-server/minecraft-patches/features/0264-Paper-PR-Fix-cancelled-rooted-dirt-drops-being-duped.patch
@@ -75,3 +75,18 @@ index e20f3e99a8f56622d86af4acbd7aecdb0fa4e8e1..14124df21792508be7c237a0d682f1e1
                      player.awardStat(Stats.ITEM_USED.get(item)); // SPIGOT-7236 - award stat
                  }
  
+@@ -539,6 +560,14 @@ public final class ItemStack implements DataComponentHolder, net.caffeinemc.mods
+                         serverLevel.playSound(player, clickedPos, soundType.getPlaceSound(), net.minecraft.sounds.SoundSource.BLOCKS, (soundType.getVolume() + 1.0F) / 2.0F, soundType.getPitch() * 0.8F);
+                     }
+ 
++                    // Paper start - Fix cancelled rooted dirt drops being duped
++                    if (capturedDrops != null) {
++                        for (ItemEntity drop : capturedDrops) {
++                            serverLevel.addFreshEntity(drop);
++                        }
++                    }
++                    // Paper end - Fix cancelled rooted dirt drops being duped
++
+                     player.awardStat(Stats.ITEM_USED.get(item));
+                 }
+             }


### PR DESCRIPTION
Fixes #773.

`ItemStack#useOn` captures hoe drops so cancelled block changes do not dupe rooted dirt drops, but the captured drops were only released in the tree-generation path.

Normal hoe tilling goes through the block-place event path, so Purpur's configured `minecraft:hanging_roots` drop was captured and then discarded. This releases captured hoe drops after the normal path succeeds, while still dropping them on cancelled placement.

Tested with:
- `./gradlew.bat :leaf-server:applyMinecraftFeaturePatches --no-configuration-cache`
- `./gradlew.bat :leaf-server:compileJava --no-configuration-cache`