### PR TITLE
Soft limit projectile list size instead of using the hard throw

### DIFF
--- a/leaf-server/minecraft-patches/features/0322-Paper-Limit-projectiles-size.patch
+++ b/leaf-server/minecraft-patches/features/0322-Paper-Limit-projectiles-size.patch
@@ -10,7 +10,7 @@ Paper commit: https://github.com/PaperMC/Paper/commit/e2c7e5cff2d81190d15b85fb37
 Backported from Paper 26.1.2
 
 diff --git a/net/minecraft/world/item/component/BundleContents.java b/net/minecraft/world/item/component/BundleContents.java
-index e513f95105b0663bd6155e69ac814bc8dbba5b76..f476334525bb3cedb920a94ac5f74b168e1ae5d5 100644
+index e513f95105b0663bd6155e69ac814bc8dbba5b76..b47a2de41bb3d2a52b4d55c541d4a5dfd9e0ffbd 100644
 --- a/net/minecraft/world/item/component/BundleContents.java
 +++ b/net/minecraft/world/item/component/BundleContents.java
 @@ -21,10 +21,10 @@ import org.jspecify.annotations.Nullable;
@@ -32,17 +32,17 @@ index e513f95105b0663bd6155e69ac814bc8dbba5b76..f476334525bb3cedb920a94ac5f74b16
      BundleContents(List<ItemStack> items, Fraction weight, int selectedItem) {
 +        // Paper start - limit size
 +        if (items.size() > 256) {
-+            throw new IllegalArgumentException("Too many items");
++            items = items.subList(0, 256);
 +        }
 +        // Paper end - limit size
          this.items = items;
          this.weight = weight;
          this.selectedItem = selectedItem;
 diff --git a/net/minecraft/world/item/component/ChargedProjectiles.java b/net/minecraft/world/item/component/ChargedProjectiles.java
-index e7a07bc38758c30183a4e4f12bc98834c51234ee..9d5590a2a8c28109ec818dd92fd9d78529ffd751 100644
+index e7a07bc38758c30183a4e4f12bc98834c51234ee..631eafbddf4288a988d18670491a368ddf273b24 100644
 --- a/net/minecraft/world/item/component/ChargedProjectiles.java
 +++ b/net/minecraft/world/item/component/ChargedProjectiles.java
-@@ -18,15 +18,20 @@ import net.minecraft.world.item.TooltipFlag;
+@@ -18,16 +18,16 @@ import net.minecraft.world.item.TooltipFlag;
  public final class ChargedProjectiles implements TooltipProvider {
      public static final ChargedProjectiles EMPTY = new ChargedProjectiles(List.of());
      public static final Codec<ChargedProjectiles> CODEC = ItemStack.CODEC
@@ -57,11 +57,8 @@ index e7a07bc38758c30183a4e4f12bc98834c51234ee..9d5590a2a8c28109ec818dd92fd9d785
      private final List<ItemStack> items;
  
      private ChargedProjectiles(List<ItemStack> items) {
-+        // Paper start - limit size
-+        if (items.size() > 64) {
-+            throw new IllegalArgumentException("Too many items");
-+        }
-+        // Paper end - limit size
-         this.items = items;
+-        this.items = items;
++        this.items = items.size() > 64 ? items.subList(0, 64) : items; // Paper - limit size
      }
  
+     public static ChargedProjectiles of(ItemStack stack) {


### PR DESCRIPTION
## Problem
Some plugins, Slimefun, or its addons, for example, provide even higher enchantment levels compared with the vanilla enchantments. And players can craft the crossbow with a higher enchat level. Thus, it can create a long projectile item list in `CrossbowItem#draw` (`EnchantmentHelper#processProjectileCount`).
Unlike the projectile size limit in CODEC, the exception throwing under these constructors will not be caught; it crashes the server instead.

example error:
<img width="2515" height="962" alt="ba1f61b2eaa97c1669851643c2b6aa9f" src="https://github.com/user-attachments/assets/eb05861c-8dfa-47cd-b4a1-f72668e27952" />

Tested without issues.