### PR TITLE
Use hit location for piercing arrow sorting order

### DIFF
--- a/leaf-server/minecraft-patches/features/0336-Use-hit-location-for-piercing-arrow-sorting-order.patch
+++ b/leaf-server/minecraft-patches/features/0336-Use-hit-location-for-piercing-arrow-sorting-order.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Use hit location for piercing arrow sorting order
+
+Vanilla bug found during reviewing MC-214546.
+Bug: AbstractArrow sorted multiple entity hits by the target entity position.
+This is incorrect for large entities:
+An entity with a farther origin pos can have a bounding box that is intersected earlier by the projectile.
+
+diff --git a/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java b/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java
+index d4c6a68c59b710cd3d158c674df03cbc2f2f307b..a683251c08ba8bb4e06299d2aa9228bd984151f4 100644
+--- a/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java
++++ b/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java
+@@ -281,7 +281,7 @@ public abstract class AbstractArrow extends Projectile {
+         while (this.isAlive()) {
+             Vec3 vec3 = this.position();
+             ArrayList<EntityHitResult> list = new ArrayList<>(this.findHitEntities(vec3, hitResult.getLocation()));
+-            list.sort(Comparator.comparingDouble(entityHitResult1 -> vec3.distanceToSqr(entityHitResult1.getEntity().position())));
++            list.sort(Comparator.comparingDouble(entityHitResult1 -> vec3.distanceToSqr(entityHitResult1.getLocation()))); // Leaf - Use hit location for piercing arrow sorting order
+             EntityHitResult entityHitResult = list.isEmpty() ? null : list.getFirst();
+             Vec3 location = Objects.requireNonNullElse(entityHitResult, hitResult).getLocation();
+             this.setPos(location);


### PR DESCRIPTION
Vanilla bug found during reviewing MC-214546.

### Description
AbstractArrow sorted multiple entity hits by the target entity position.

This is definitely incorrect and unexpected behavior for large entities:
An entity with a farther origin pos can have a bounding box that is intersected earlier by the projectile.

### Reproduce

```java
    private UUID testArrow;
    private final List<String> order = new ArrayList<>();
    @Override
    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
        if (!(sender instanceof Player player)) {
            sender.sendMessage("Player only.");
            return true;
        }
        World world = player.getWorld();
        order.clear();
        testArrow = null;
        Location p = player.getLocation();
        double startX = p.getX();
        double y = p.getY();
        double z = p.getZ() + 3.0;
        Location start = new Location(world, startX, y + 1.1, z);
        Location zombieLoc = new Location(world, startX + 4.0, y, z);
        Location slimeLoc = new Location(world, startX + 5.0, y, z);
        for (Entity entity : world.getNearbyEntities(start, 12, 8, 12)) {
            if (entity.getScoreboardTags().contains("pierce-order-test")
                    || entity.getScoreboardTags().contains("pierce-order-arrow")) {
                entity.remove();
            }
        }
        world.spawn(slimeLoc, Slime.class, slime -> {
            slime.setSize(8);
            slime.setAI(false);
            slime.setSilent(true);
            slime.setCustomName("A_SLIME");
            slime.setCustomNameVisible(true);
            slime.addScoreboardTag("pierce-order-test");
        });
        world.spawn(zombieLoc, Zombie.class, zombie -> {
            zombie.setAI(false);
            zombie.setSilent(true);
            zombie.setCustomName("B_ZOMBIE");
            zombie.setCustomNameVisible(true);
            zombie.addScoreboardTag("pierce-order-test");
        });
        player.sendMessage("Expected correct order: A_SLIME -> B_ZOMBIE");
        Bukkit.getScheduler().runTaskLater(this, () -> {
            Arrow arrow = world.spawnArrow(
                    start,
                    new Vector(1.0, 0.0, 0.0),
                    8.0f,
                    0.0f
            );
            arrow.setGravity(false);
            arrow.setDamage(0.5);
            arrow.setCritical(false);
            arrow.setPierceLevel(4);
            arrow.setPickupStatus(AbstractArrow.PickupStatus.DISALLOWED);
            arrow.addScoreboardTag("pierce-order-arrow");
            testArrow = arrow.getUniqueId();
        }, 2L);
        Bukkit.getScheduler().runTaskLater(this, () -> {
            player.sendMessage("Observed order: " + String.join(" -> ", order));
            if (order.size() >= 2
                    && order.get(0).equals("A_SLIME")
                    && order.get(1).equals("B_ZOMBIE")) {
                player.sendMessage("PASS");
            } else {
                player.sendMessage("FAIL");
            }
        }, 40L);
        return true;
    }
    @EventHandler
    public void onProjectileHit(ProjectileHitEvent event) {
        if (testArrow == null || !event.getEntity().getUniqueId().equals(testArrow)) {
            return;
        }
        if (event.getHitBlock() != null) {
            Bukkit.broadcastMessage("ProjectileHitEvent block: " + event.getHitBlock().getType());
            return;
        }
        Entity hit = event.getHitEntity();
        if (hit == null) {
            Bukkit.broadcastMessage("ProjectileHitEvent with no hit entity");
            return;
        }
        String name = hit.getCustomName();
        if (name == null) {
            name = hit.getType().name();
        }
        order.add(name);
        Bukkit.broadcastMessage("ProjectileHitEvent entity: " + name);
    }
```

Run the test code snippet, should see:

Before:
B_ZOMBIE -> A_SLIME

After:
A_SLIME -> B_ZOMBIE