### PR TITLE
Optimize getLeashHolder

### DIFF
--- a/leaf-server/minecraft-patches/features/0311-Optimize-getLeashHolder.patch
+++ b/leaf-server/minecraft-patches/features/0311-Optimize-getLeashHolder.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrlingXD <90316914+wling-art@users.noreply.github.com>
+Date: Tue, 23 Jun 2026 08:40:09 +0800
+Subject: [PATCH] Optimize getLeashHolder
+
+
+diff --git a/net/minecraft/world/entity/Leashable.java b/net/minecraft/world/entity/Leashable.java
+index 90811d2f3d5a642d919b6c533668a20ede1d101c..5eac09956f29e17680c4f6649ec8e7eb0ed971f1 100644
+--- a/net/minecraft/world/entity/Leashable.java
++++ b/net/minecraft/world/entity/Leashable.java
+@@ -370,11 +370,7 @@ public interface Leashable {
+             return null;
+         }
+ 
+-        Entity ntt = entity.level().getEntity(leashData.delayedLeashHolderId);
+-        if (leashData.delayedLeashHolderId != 0 && entity.level().isClientSide() && ntt != null) {
+-            leashData.setLeashHolder(ntt);
+-        }
+-
++        // Leaf - Optimize getLeashHolder - drop client-only delayed leash resolution (isClientSide() always false on a dedicated server)
+         return leashData.leashHolder;
+     }
+ 


### PR DESCRIPTION
isClientSide 在这个环境下永远是 false，省掉了每次的 getEntity。