### PR TITLE
Use xx2Reference map instead of 2Object

### DIFF
--- a/leaf-api/paper-patches/features/0022-Replace-data-maps-with-optimized-collection.patch
+++ b/leaf-api/paper-patches/features/0022-Replace-data-maps-with-optimized-collection.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Replace data maps with optimized collection
 
 
 diff --git a/src/main/java/org/bukkit/ChatColor.java b/src/main/java/org/bukkit/ChatColor.java
-index f283bcabff7fe6eede6cf4344537e43048c35166..8fa31420e2e674f4860bc1385357eb2e2c9a6316 100644
+index f283bcabff7fe6eede6cf4344537e43048c35166..09e86b1431b30e190d9f3e152ad0231c0b70b98e 100644
 --- a/src/main/java/org/bukkit/ChatColor.java
 +++ b/src/main/java/org/bukkit/ChatColor.java
 @@ -246,8 +246,10 @@ public enum ChatColor {
@@ -15,14 +15,14 @@ index f283bcabff7fe6eede6cf4344537e43048c35166..8fa31420e2e674f4860bc1385357eb2e
 -    private static final Map<Integer, ChatColor> BY_ID = Maps.newHashMap();
 -    private static final Map<Character, ChatColor> BY_CHAR = Maps.newHashMap();
 +    // Leaf start - Replace data maps with optimized collection
-+    private static final it.unimi.dsi.fastutil.ints.Int2ObjectMap<ChatColor> BY_ID = new it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap<>();
-+    private static final it.unimi.dsi.fastutil.chars.Char2ObjectMap<ChatColor> BY_CHAR = new it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap<>();
++    private static final it.unimi.dsi.fastutil.ints.Int2ReferenceMap<ChatColor> BY_ID = new it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap<>();
++    private static final it.unimi.dsi.fastutil.chars.Char2ReferenceMap<ChatColor> BY_CHAR = new it.unimi.dsi.fastutil.chars.Char2ReferenceOpenHashMap<>();
 +    // Leaf end - Replace data maps with optimized collection
  
      private ChatColor(char code, int intCode) {
          this(code, intCode, false);
 diff --git a/src/main/java/org/bukkit/CoalType.java b/src/main/java/org/bukkit/CoalType.java
-index ede570814963a0fb93e2e5affa54439880cd685b..8884034db96dddaf8806fa122dc97adcdb8b6c1c 100644
+index ede570814963a0fb93e2e5affa54439880cd685b..8acb7e917ff68a759731eace466c14a18098f18a 100644
 --- a/src/main/java/org/bukkit/CoalType.java
 +++ b/src/main/java/org/bukkit/CoalType.java
 @@ -13,7 +13,7 @@ public enum CoalType {
@@ -30,12 +30,12 @@ index ede570814963a0fb93e2e5affa54439880cd685b..8884034db96dddaf8806fa122dc97adc
  
      private final byte data;
 -    private static final Map<Byte, CoalType> BY_DATA = Maps.newHashMap();
-+    private static final it.unimi.dsi.fastutil.bytes.Byte2ObjectMap<CoalType> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
++    private static final it.unimi.dsi.fastutil.bytes.Byte2ReferenceMap<CoalType> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ReferenceOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
  
      private CoalType(final int data) {
          this.data = (byte) data;
 diff --git a/src/main/java/org/bukkit/CropState.java b/src/main/java/org/bukkit/CropState.java
-index 9420e919088392c6aac4114356af7a2096478195..86b8cda28febde6379a322a40eb46568ec4127a2 100644
+index 9420e919088392c6aac4114356af7a2096478195..4097a1c5b9e07c60eb13be1636193e474ab05235 100644
 --- a/src/main/java/org/bukkit/CropState.java
 +++ b/src/main/java/org/bukkit/CropState.java
 @@ -44,7 +44,7 @@ public enum CropState {
@@ -43,12 +43,12 @@ index 9420e919088392c6aac4114356af7a2096478195..86b8cda28febde6379a322a40eb46568
  
      private final byte data;
 -    private static final Map<Byte, CropState> BY_DATA = Maps.newHashMap();
-+    private static final it.unimi.dsi.fastutil.bytes.Byte2ObjectMap<CropState> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
++    private static final it.unimi.dsi.fastutil.bytes.Byte2ReferenceMap<CropState> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ReferenceOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
  
      private CropState(final int data) {
          this.data = (byte) data;
 diff --git a/src/main/java/org/bukkit/Difficulty.java b/src/main/java/org/bukkit/Difficulty.java
-index 427ce8cfd6f63e5c7ec7b264b15ab4111b947729..f069fc9d49cfe0f394847a7546fb81b8fb2384c8 100644
+index 427ce8cfd6f63e5c7ec7b264b15ab4111b947729..72452d7e94fcbe53e7bf2e59786cc24deec604d8 100644
 --- a/src/main/java/org/bukkit/Difficulty.java
 +++ b/src/main/java/org/bukkit/Difficulty.java
 @@ -34,7 +34,7 @@ public enum Difficulty implements net.kyori.adventure.translation.Translatable {
@@ -56,12 +56,12 @@ index 427ce8cfd6f63e5c7ec7b264b15ab4111b947729..f069fc9d49cfe0f394847a7546fb81b8
  
      private final int value;
 -    private static final Map<Integer, Difficulty> BY_ID = Maps.newHashMap();
-+    private static final it.unimi.dsi.fastutil.ints.Int2ObjectMap<Difficulty> BY_ID = new it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
++    private static final it.unimi.dsi.fastutil.ints.Int2ReferenceMap<Difficulty> BY_ID = new it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
  
      private Difficulty(final int value) {
          this.value = value;
 diff --git a/src/main/java/org/bukkit/Effect.java b/src/main/java/org/bukkit/Effect.java
-index ed450e67fd178ebec2879718910ddd0831d04dd5..7ea7164dec068e386f533850e75d5725f2c05dc2 100644
+index ed450e67fd178ebec2879718910ddd0831d04dd5..d3c0637b44831d1ddf600e41274aff43788cbcfd 100644
 --- a/src/main/java/org/bukkit/Effect.java
 +++ b/src/main/java/org/bukkit/Effect.java
 @@ -549,7 +549,7 @@ public enum Effect {
@@ -69,12 +69,12 @@ index ed450e67fd178ebec2879718910ddd0831d04dd5..7ea7164dec068e386f533850e75d5725
      //</editor-fold>
  
 -    private static final Map<Integer, Effect> BY_ID = new HashMap<>();
-+    private static final it.unimi.dsi.fastutil.ints.Int2ObjectMap<Effect> BY_ID = new it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
++    private static final it.unimi.dsi.fastutil.ints.Int2ReferenceMap<Effect> BY_ID = new it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
  
      private final int id;
      private final Type type;
 diff --git a/src/main/java/org/bukkit/GameMode.java b/src/main/java/org/bukkit/GameMode.java
-index 796f75313255ecc8917819b28eaf12776f2e4ce3..a765121ed02516a9a1e8bf1823b978762107b14f 100644
+index 796f75313255ecc8917819b28eaf12776f2e4ce3..1a0ffcf0be29c08e43fd74766b2c74aa88ee9bcd 100644
 --- a/src/main/java/org/bukkit/GameMode.java
 +++ b/src/main/java/org/bukkit/GameMode.java
 @@ -34,7 +34,7 @@ public enum GameMode implements net.kyori.adventure.translation.Translatable { /
@@ -82,12 +82,12 @@ index 796f75313255ecc8917819b28eaf12776f2e4ce3..a765121ed02516a9a1e8bf1823b97876
  
      private final int value;
 -    private static final Map<Integer, GameMode> BY_ID = Maps.newHashMap();
-+    private static final it.unimi.dsi.fastutil.ints.Int2ObjectMap<GameMode> BY_ID = new it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
++    private static final it.unimi.dsi.fastutil.ints.Int2ReferenceMap<GameMode> BY_ID = new it.unimi.dsi.fastutil.ints.Int2ReferenceOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
      // Paper start - translation keys
      private final String translationKey;
  
 diff --git a/src/main/java/org/bukkit/GrassSpecies.java b/src/main/java/org/bukkit/GrassSpecies.java
-index 43da0eb033f7cb65e3b2cacd67946bc9dc187678..fd3d68b05ea0518077a91a57199cb98889eb1dc6 100644
+index 43da0eb033f7cb65e3b2cacd67946bc9dc187678..a4433669928516efe2ce9ce2fd914ae93c5d17b1 100644
 --- a/src/main/java/org/bukkit/GrassSpecies.java
 +++ b/src/main/java/org/bukkit/GrassSpecies.java
 @@ -25,7 +25,7 @@ public enum GrassSpecies {
@@ -95,12 +95,12 @@ index 43da0eb033f7cb65e3b2cacd67946bc9dc187678..fd3d68b05ea0518077a91a57199cb988
  
      private final byte data;
 -    private static final Map<Byte, GrassSpecies> BY_DATA = Maps.newHashMap();
-+    private static final it.unimi.dsi.fastutil.bytes.Byte2ObjectMap<GrassSpecies> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
++    private static final it.unimi.dsi.fastutil.bytes.Byte2ReferenceMap<GrassSpecies> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ReferenceOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
  
      private GrassSpecies(final int data) {
          this.data = (byte) data;
 diff --git a/src/main/java/org/bukkit/Note.java b/src/main/java/org/bukkit/Note.java
-index aff858346776386f1288b648b221404f7f412399..42d3eb5814148d1b3acd0cf88acfb62e592c9aab 100644
+index aff858346776386f1288b648b221404f7f412399..4d50fb87489f10e641a1a48f55440d912ddf9e11 100644
 --- a/src/main/java/org/bukkit/Note.java
 +++ b/src/main/java/org/bukkit/Note.java
 @@ -26,7 +26,7 @@ public class Note {
@@ -108,12 +108,12 @@ index aff858346776386f1288b648b221404f7f412399..42d3eb5814148d1b3acd0cf88acfb62e
          private final byte id;
  
 -        private static final Map<Byte, Note.Tone> BY_DATA = Maps.newHashMap();
-+        private static final it.unimi.dsi.fastutil.bytes.Byte2ObjectMap<Tone> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
++        private static final it.unimi.dsi.fastutil.bytes.Byte2ReferenceMap<Tone> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ReferenceOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
          /** The number of tones including sharped tones. */
          public static final byte TONES_COUNT = 12;
  
 diff --git a/src/main/java/org/bukkit/SandstoneType.java b/src/main/java/org/bukkit/SandstoneType.java
-index d2ea2c81f94093414399512e289cea6c12855ec2..468fa38be237b9d5777c5630bfb082d03028f57e 100644
+index d2ea2c81f94093414399512e289cea6c12855ec2..4e742de7221ebd131dd04edb019c3f9921bbbd97 100644
 --- a/src/main/java/org/bukkit/SandstoneType.java
 +++ b/src/main/java/org/bukkit/SandstoneType.java
 @@ -15,7 +15,7 @@ public enum SandstoneType {
@@ -121,12 +121,12 @@ index d2ea2c81f94093414399512e289cea6c12855ec2..468fa38be237b9d5777c5630bfb082d0
  
      private final byte data;
 -    private static final Map<Byte, SandstoneType> BY_DATA = Maps.newHashMap();
-+    private static final it.unimi.dsi.fastutil.bytes.Byte2ObjectMap<SandstoneType> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
++    private static final it.unimi.dsi.fastutil.bytes.Byte2ReferenceMap<SandstoneType> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ReferenceOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
  
      private SandstoneType(final int data) {
          this.data = (byte) data;
 diff --git a/src/main/java/org/bukkit/TreeSpecies.java b/src/main/java/org/bukkit/TreeSpecies.java
-index abbe7c3b2984dc03098780d5678553685ea78dc4..26f6950822a8a3ac8eee332425f40f2021ad54af 100644
+index abbe7c3b2984dc03098780d5678553685ea78dc4..8cecfa130b7382cdf7a2eb6f00a2600746bd72dc 100644
 --- a/src/main/java/org/bukkit/TreeSpecies.java
 +++ b/src/main/java/org/bukkit/TreeSpecies.java
 @@ -39,7 +39,7 @@ public enum TreeSpecies {
@@ -134,12 +134,12 @@ index abbe7c3b2984dc03098780d5678553685ea78dc4..26f6950822a8a3ac8eee332425f40f20
  
      private final byte data;
 -    private static final Map<Byte, TreeSpecies> BY_DATA = Maps.newHashMap();
-+    private static final it.unimi.dsi.fastutil.bytes.Byte2ObjectMap<TreeSpecies> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
++    private static final it.unimi.dsi.fastutil.bytes.Byte2ReferenceMap<TreeSpecies> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ReferenceOpenHashMap<>(); // Leaf - Replace data maps with optimized collection
  
      private TreeSpecies(final int data) {
          this.data = (byte) data;
 diff --git a/src/main/java/org/bukkit/material/types/MushroomBlockTexture.java b/src/main/java/org/bukkit/material/types/MushroomBlockTexture.java
-index ca1b5d270848aebea3fb5c87daa5dc11ff1a877c..0a4b3329c647dde77445e46f221f9123f9e581d3 100644
+index ca1b5d270848aebea3fb5c87daa5dc11ff1a877c..a9e61fc7a2b33f7f81f7d943a7a75db495f3b69b 100644
 --- a/src/main/java/org/bukkit/material/types/MushroomBlockTexture.java
 +++ b/src/main/java/org/bukkit/material/types/MushroomBlockTexture.java
 @@ -65,8 +65,10 @@ public enum MushroomBlockTexture {
@@ -149,7 +149,7 @@ index ca1b5d270848aebea3fb5c87daa5dc11ff1a877c..0a4b3329c647dde77445e46f221f9123
 -    private static final Map<Byte, MushroomBlockTexture> BY_DATA = Maps.newHashMap();
 -    private static final Map<BlockFace, MushroomBlockTexture> BY_BLOCKFACE = Maps.newHashMap();
 +    // Leaf start - Replace data maps with optimized collection
-+    private static final it.unimi.dsi.fastutil.bytes.Byte2ObjectMap<MushroomBlockTexture> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap<>();
++    private static final it.unimi.dsi.fastutil.bytes.Byte2ReferenceMap<MushroomBlockTexture> BY_DATA = new it.unimi.dsi.fastutil.bytes.Byte2ReferenceOpenHashMap<>();
 +    private static final Map<BlockFace, MushroomBlockTexture> BY_BLOCKFACE = new java.util.EnumMap<>(BlockFace.class);
 +    // Leaf end - Replace data maps with optimized collection
  


### PR DESCRIPTION
Use xx2Reference map instead of 2Object, since the value is enum.

This PR will not improve performance too much, since most of these CB classes are deprecated. This PR only makes it look more reasonable.