### PR TITLE
Fix all chunks slime chunk

### DIFF
--- a/leaf-server/minecraft-patches/features/0119-Matter-Secure-Seed.patch
+++ b/leaf-server/minecraft-patches/features/0119-Matter-Secure-Seed.patch
@@ -66,9 +66,9 @@ index 1faab89a0c6febdbbb15c8f1345fbd8e71f3af6e..eac3f902df16f917d6be2b0d57f5d7ba
              ChunkPos chunkPos = ChunkPos.containing(pos);
 -            boolean slimeChunk = level.getMinecraftWorld().paperConfig().entities.spawning.allChunksAreSlimeChunks || WorldgenRandom.seedSlimeChunk(chunkPos.x(), chunkPos.z(), worldGenLevel.getSeed(), level.getMinecraftWorld().spigotConfig.slimeSeed).nextInt(10) == 0; // Paper
 +            // Leaf start - Matter - Secure Seed
-+            boolean slimeChunk = level.getMinecraftWorld().paperConfig().entities.spawning.allChunksAreSlimeChunks || org.dreeam.leaf.config.modules.misc.SecureSeed.enabled
++            boolean slimeChunk = level.getMinecraftWorld().paperConfig().entities.spawning.allChunksAreSlimeChunks || (org.dreeam.leaf.config.modules.misc.SecureSeed.enabled
 +                ? level.getChunk(chunkPos.x(), chunkPos.z()).isSlimeChunk()
-+                : WorldgenRandom.seedSlimeChunk(chunkPos.x(), chunkPos.z(), worldGenLevel.getSeed(), level.getMinecraftWorld().spigotConfig.slimeSeed).nextInt(10) == 0; // Paper
++                : WorldgenRandom.seedSlimeChunk(chunkPos.x(), chunkPos.z(), worldGenLevel.getSeed(), level.getMinecraftWorld().spigotConfig.slimeSeed).nextInt(10) == 0); // Paper
 +            // Leaf end - Matter - Secure Seed
              // Paper start - Replace rules for Height in Slime Chunks
              final double maxHeightSlimeChunk = level.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.slimeChunk.maximum;


### PR DESCRIPTION
Fixes Paper's "all-chunks-are-slime-chunks" config being ignored by Secure Seed's slime chunk check due to ternary precedence ^^

Currently, even when Secure Seed is disabled or enabled, "all-chunks-are-slime-chunks" does not work, this causes the server to use the secure slime chunk check instead of treating every chunk as a slime chunk 
