### PR TITLE
Fix skeleton bow accuracy reload

### DIFF
--- a/leaf-server/minecraft-patches/features/0299-Improve-Purpur-JS-expression-evaluation.patch
+++ b/leaf-server/minecraft-patches/features/0299-Improve-Purpur-JS-expression-evaluation.patch
@@ -224,7 +224,7 @@ index 195b619d54011602ebd4b267904bb4600e19aa04..d00c412c2b649614bc1aee463109e201
          skeletonFeedWitherRoses = getInt("mobs.skeleton.feed-wither-roses", skeletonFeedWitherRoses);
          final String defaultSkeletonBowAccuracy = skeletonBowAccuracy;
          skeletonBowAccuracy = getString("mobs.skeleton.bow-accuracy", skeletonBowAccuracy);
-+        skeletonBowAccuracyEnabled = !defaultSkeletonBowAccuracy.equals(skeletonBowAccuracy); // Leaf - Improve Purpur JS expression evaluation
++        skeletonBowAccuracyEnabled = !"14 - difficulty * 4".equals(skeletonBowAccuracy); // Leaf - Improve Purpur JS expression evaluation
          for (int i = 1; i < 4; i++) {
              final float divergence;
              try {


### PR DESCRIPTION
Fixes skeleton "mobs.skeleton.bow-accuracy" being reset after "/purpur reload".

Leaf is adding an optimization to skip Purpur JS expression evaluation when the value is default, but it was checking the previous loaded value instead of checking the real default value

Because of this, if the same custom value was loaded twice, Leaf thought it was default and stopped using the custom accuracy.

Steps to reproduce:

1. Set "mobs.skeleton.bow-accuracy" to  an obvious value, such as 0
2. Start the server
3. Spawn a skeleton and see that it shoots very accurately
4. Change "mobs.skeleton.bow-accuracy" to another obvious value such as 100
5. Run "/purpur reload" command
6. Skeleton now misses almost every shot
7. Run "/purpur reload" command again without changing the configuration we set on step 4
8. Skeleton will start shooting accurately again, like the custom value was completely ignored

This patch checks against Purpur's real default value instead, so custom bow accuracy keeps working after reload ^^ 