### PR TITLE
Fix shulker bullet nearby equation check

### DIFF
--- a/leaf-server/minecraft-patches/features/0299-Improve-Purpur-JS-expression-evaluation.patch
+++ b/leaf-server/minecraft-patches/features/0299-Improve-Purpur-JS-expression-evaluation.patch
@@ -202,14 +202,15 @@ index 195b619d54011602ebd4b267904bb4600e19aa04..d00c412c2b649614bc1aee463109e201
      public boolean shulkerSpawnFromBulletRandomColor = false;
      public boolean shulkerChangeColorWithDye = false;
      public boolean shulkerAlwaysDropExp = false;
-@@ -3023,6 +3034,7 @@ public class PurpurWorldConfig {
+@@ -3023,7 +3034,8 @@ public class PurpurWorldConfig {
          shulkerScale = Mth.clamp(getDouble("mobs.shulker.attributes.scale", shulkerScale), 0.0625D, Shulker.MAX_SCALE);
          shulkerTakeDamageFromWater = getBoolean("mobs.shulker.takes-damage-from-water", shulkerTakeDamageFromWater);
          shulkerSpawnFromBulletBaseChance = (float) getDouble("mobs.shulker.spawn-from-bullet.base-chance", shulkerSpawnFromBulletBaseChance);
-+        shulkerSpawnFromBulletNearbyEquationEnabled = !"(nearby - 1) / 5.0".equals(shulkerSpawnFromBulletBaseChance);
          shulkerSpawnFromBulletRequireOpenLid = getBoolean("mobs.shulker.spawn-from-bullet.require-open-lid", shulkerSpawnFromBulletRequireOpenLid);
          shulkerSpawnFromBulletNearbyRange = getDouble("mobs.shulker.spawn-from-bullet.nearby-range", shulkerSpawnFromBulletNearbyRange);
          shulkerSpawnFromBulletNearbyEquation = getString("mobs.shulker.spawn-from-bullet.nearby-equation", shulkerSpawnFromBulletNearbyEquation);
++        shulkerSpawnFromBulletNearbyEquationEnabled = !"(nearby - 1) / 5.0".equals(shulkerSpawnFromBulletNearbyEquation);
+         shulkerSpawnFromBulletRandomColor = getBoolean("mobs.shulker.spawn-from-bullet.random-color", shulkerSpawnFromBulletRandomColor);
 @@ -3074,7 +3086,8 @@ public class PurpurWorldConfig {
      public double skeletonHeadVisibilityPercent = 0.5D;
      public int skeletonFeedWitherRoses = 0;


### PR DESCRIPTION
Fixes "shulkerSpawnFromBulletNearbyEquationEnabled" always being true, which causes Leaf to always use JS eval for shulker bullet nearby equation even when default config is used.

This is added this to skip JS expression evaluation when the shulker bullet nearby equation is the default value, but check compared the default equation string with "shulkerSpawnFromBulletBaseChance", which is a float value

```java
!"(nearby - 1) / 5.0".equals(shulkerSpawnFromBulletBaseChance)
```
A string can never equal to a float, so this check is always false, and after ! it becomes always true and bcs of this problem, Leaf were always using JS's eval for shulker bullet nearby equation, even when the config was using the default equation ^^ 