### PR TITLE
Fix ActivityArrayMap hashCode() using raw registry ids instead of Activity hashes

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/util/map/ActivityArrayMap.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/util/map/ActivityArrayMap.java
@@ -354,7 +354,9 @@ public final class ActivityArrayMap<V> implements Map<Activity, V> {
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(key) ^ Objects.hashCode(value);
+            // Consistent with getKey()/equals(): the entry key is the Activity, not
+            // its raw registry id, so hash the Activity per the Map.Entry contract.
+            return Objects.hashCode(RegistryTypeManager.ACTIVITY_DIRECT[key]) ^ Objects.hashCode(value);
         }
 
         @Override
@@ -383,7 +385,10 @@ public final class ActivityArrayMap<V> implements Map<Activity, V> {
     public int hashCode() {
         int hash = 0;
         for (int i = 0; i < size; i++) {
-            hash += Objects.hashCode(k[i]) ^ Objects.hashCode(v[i]);
+            // Map.hashCode sums entry hashes, and an entry's key hash is the
+            // Activity's hashCode(), not its raw registry id, so this stays
+            // consistent with equals() (which compares against arbitrary maps).
+            hash += Objects.hashCode(RegistryTypeManager.ACTIVITY_DIRECT[k[i]]) ^ Objects.hashCode(v[i]);
         }
         return hash;
     }


### PR DESCRIPTION
### Problem
`ActivityArrayMap` stores each key as its raw activity registry id (`int`), and two `hashCode()` implementations hash that raw id instead of the `Activity`:

- `MapEntry#hashCode()` returns `Objects.hashCode(key) ^ Objects.hashCode(value)` where `key` is the int id — even though the same class's `getKey()` and `equals()` use the actual `Activity` via `RegistryTypeManager.ACTIVITY_DIRECT[key]`. So an entry's `equals()` and `hashCode()` disagree.
- `ActivityArrayMap#hashCode()` sums `Objects.hashCode(k[i]) ^ ...` over the raw ids for the same reason.

The `Map`/`Map.Entry` contract defines an entry hash as `key.hashCode() ^ value.hashCode()`, and the key here is an `Activity` whose `hashCode()` is `name.hashCode()`, not its id. Since `equals()` compares against arbitrary `Activity`-keyed maps, an `ActivityArrayMap` (or its entries) can be equal to an ordinary `HashMap` holding the same contents while returning a different `hashCode()`, breaking the `Object` equals/hashCode contract.

### Fix
Hash the `Activity` (via `RegistryTypeManager.ACTIVITY_DIRECT[...]`, exactly as `getKey()`/`equals()` already do) instead of the raw id, in both `hashCode()` methods.

### Testing
`./gradlew applyAllPatches` and `./gradlew :leaf-server:compileJava` both build cleanly on a JDK 25 toolchain. Docs-level behaviour of a single map is unchanged; its hash is now correct when compared against other `Map` implementations.