### PR TITLE
Update 0194-SparklyPaper-Parallel-world-ticking.patch

### DIFF
--- a/leaf-server/minecraft-patches/features/0194-SparklyPaper-Parallel-world-ticking.patch
+++ b/leaf-server/minecraft-patches/features/0194-SparklyPaper-Parallel-world-ticking.patch
@@ -235,13 +235,15 @@ index 9077a799f5113ce598d1f5c6c72bfec8cfb8f747..0bd82f3e378f7408ae029ae3b68a6273
 +                tickLevel(level, haveTime);
              }
  
-             profiler.pop();
-             profiler.pop();
-             level.explosionDensityCache.clear(); // Paper - Optimize explosions
-         }
-+            while (!tasks.isEmpty()) {
-+                tasks.pop().get();
-+            }
+            profiler.pop();
+            profiler.pop();
+-            level.explosionDensityCache.clear(); // Paper - Optimize explosions
+        }
+            while (!tasks.isEmpty()) {
+-                tasks.pop().get();
++                ServerLevel tickedLevel = tasks.pop().get();
++                tickedLevel.explosionDensityCache.clear();
+            }
 +        } catch (java.lang.InterruptedException | java.util.concurrent.ExecutionException e) {
 +            throw new RuntimeException(e); // Propagate exception
 +        }


### PR DESCRIPTION
Title: Fix explosionDensityCache concurrent access crash with PWT

Description:

When PWT (Parallel World Ticking) is enabled, every explosion (creeper, TNT, bed, respawn anchor) can crash the server or corrupt the explosionDensityCache, causing explosions to deal wrong damage or destroy wrong blocks.

Root cause: In MinecraftServer.tickChildren(), after submitting the world tick to the executor, the main thread immediately called level.explosionDensityCache.clear(). The world thread was still reading/writing the same HashMap at the same time, causing a data race.

Fix: Moved the clear() call to after all worlds finish ticking, so there is no concurrent access to the HashMap.