### PR TITLE
Filter control chars in console input to prevent crash

### DIFF
--- a/leaf-server/minecraft-patches/features/0235-Fix-crash-during-parsing-unknown-command-message.patch
+++ b/leaf-server/minecraft-patches/features/0235-Fix-crash-during-parsing-unknown-command-message.patch
@@ -4,9 +4,10 @@ Date: Sun, 15 Jun 2025 02:20:26 +0800
 Subject: [PATCH] Fix crash during parsing unknown command message
 
 Use direct impl for unknown commands message parse to prevent crash
+Filter control chars to prevent crash
 
 diff --git a/net/minecraft/commands/Commands.java b/net/minecraft/commands/Commands.java
-index f5cf9f7e382be977866f5783cad9bfb70178f61c..797758fea530800da5cb449d0eff27090f8e98d8 100644
+index f5cf9f7e382be977866f5783cad9bfb70178f61c..b2076e535244b5e566d453bf0019401edc978711 100644
 --- a/net/minecraft/commands/Commands.java
 +++ b/net/minecraft/commands/Commands.java
 @@ -680,7 +680,7 @@ public class Commands {
@@ -18,7 +19,28 @@ index f5cf9f7e382be977866f5783cad9bfb70178f61c..797758fea530800da5cb449d0eff2709
          }
  
          final String input = e.getInput();
-@@ -723,7 +723,7 @@ public class Commands {
+@@ -692,7 +692,7 @@ public class Commands {
+             final net.kyori.adventure.text.Component context = net.kyori.adventure.text.Component.translatable("command.context.here")
+                 .color(net.kyori.adventure.text.format.NamedTextColor.RED)
+                 .decorate(net.kyori.adventure.text.format.TextDecoration.ITALIC);
+-            final net.kyori.adventure.text.event.ClickEvent event = net.kyori.adventure.text.event.ClickEvent.suggestCommand("/" + commandString);
++            final net.kyori.adventure.text.event.ClickEvent event = net.kyori.adventure.text.event.ClickEvent.suggestCommand("/" + net.minecraft.util.StringUtil.filterText(commandString)); // Leaf - Fix crash during parsing unknown command message
+ 
+             detail.color(net.kyori.adventure.text.format.NamedTextColor.GRAY);
+ 
+@@ -700,9 +700,9 @@ public class Commands {
+                 detail.append(net.kyori.adventure.text.Component.text("..."));
+             }
+ 
+-            detail.append(net.kyori.adventure.text.Component.text(input.substring(Math.max(0, min - 10), min)));
++            detail.append(net.kyori.adventure.text.Component.text(net.minecraft.util.StringUtil.filterText(input.substring(Math.max(0, min - 10), min)))); // Leaf - Fix crash during parsing unknown command message
+             if (min < input.length()) {
+-                net.kyori.adventure.text.Component commandInput = net.kyori.adventure.text.Component.text(input.substring(min))
++                net.kyori.adventure.text.Component commandInput = net.kyori.adventure.text.Component.text(net.minecraft.util.StringUtil.filterText(input.substring(min))) // Leaf - Fix crash during parsing unknown command message
+                     .color(net.kyori.adventure.text.format.NamedTextColor.RED)
+                     .decorate(net.kyori.adventure.text.format.TextDecoration.UNDERLINED);
+ 
+@@ -723,20 +723,20 @@ public class Commands {
      private static net.kyori.adventure.text.Component getVanillaUnknownCommandMessage(
          final net.kyori.adventure.text.TextComponent.Builder builder, final CommandSyntaxException e, final String commandString
      ) {
@@ -27,3 +49,19 @@ index f5cf9f7e382be977866f5783cad9bfb70178f61c..797758fea530800da5cb449d0eff2709
  
          if (e.getInput() != null && e.getCursor() >= 0) {
              int cursor = Math.min(e.getInput().length(), e.getCursor());
+             MutableComponent context = Component.empty()
+                 .withStyle(ChatFormatting.GRAY)
+-                .withStyle(s -> s.withClickEvent(new ClickEvent.SuggestCommand("/" + commandString)));
++                .withStyle(s -> s.withClickEvent(new ClickEvent.SuggestCommand("/" + net.minecraft.util.StringUtil.filterText(commandString)))); // Leaf - Fix crash during parsing unknown command message
+             if (cursor > 10) {
+                 context.append(CommonComponents.ELLIPSIS);
+             }
+ 
+-            context.append(e.getInput().substring(Math.max(0, cursor - 10), cursor));
++            context.append(net.minecraft.util.StringUtil.filterText(e.getInput().substring(Math.max(0, cursor - 10), cursor))); // Leaf - Fix crash during parsing unknown command message
+             if (cursor < e.getInput().length()) {
+-                Component remaining = Component.literal(e.getInput().substring(cursor)).withStyle(ChatFormatting.RED, ChatFormatting.UNDERLINE);
++                Component remaining = Component.literal(net.minecraft.util.StringUtil.filterText(e.getInput().substring(cursor))).withStyle(ChatFormatting.RED, ChatFormatting.UNDERLINE); // Leaf - Fix crash during parsing unknown command message
+                 context.append(remaining);
+             }
+ 


### PR DESCRIPTION
Closes #808.

Will port to 1.21.11 later.