### PR TITLE
Forge-like startup world migration

### DIFF
--- a/leaf-server/paper-patches/features/0067-Forge-like-startup-world-migration.patch
+++ b/leaf-server/paper-patches/features/0067-Forge-like-startup-world-migration.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Forge-like startup world migration
+
+
+diff --git a/src/main/java/io/papermc/paper/world/migration/WorldFolderMigration.java b/src/main/java/io/papermc/paper/world/migration/WorldFolderMigration.java
+index 77fb09a15bcefaeb5016fcda53cd6a0c9e604ef8..f847681ec9800445d6d7d981ca70f415d70d1812 100644
+--- a/src/main/java/io/papermc/paper/world/migration/WorldFolderMigration.java
++++ b/src/main/java/io/papermc/paper/world/migration/WorldFolderMigration.java
+@@ -69,19 +69,40 @@ public final class WorldFolderMigration {
+         LOGGER.warn("===================== ! ALERT ! =====================");
+         LOGGER.warn("World storage migration is required during startup.");
+         LOGGER.warn("If you do not have a backup: interrupt the server now. Use Ctrl+C, your panel kill function, etc.");
++        LOGGER.warn("Extra files in migrated legacy world folders may be moved, and migrated legacy folders may be deleted."); // Leaf - Forge-like startup world migration
+         LOGGER.warn("=====================================================");
+-        LOGGER.warn("Continuing in 30 seconds...");
++        //LOGGER.warn("Continuing in 30 seconds..."); // Leaf - Forge-like startup world migration
+         if (DISABLE_MIGRATION_DELAY) {
+-            LOGGER.warn("Migration delay disabled by system property.");
+-        } else {
+-            try {
+-                Thread.sleep(30_000L);
+-            } catch (final InterruptedException ex) {
+-                Thread.currentThread().interrupt();
+-                throw new RuntimeException("Interrupted while waiting before startup world migration", ex);
++            // Leaf start - Forge-like startup world migration
++            LOGGER.warn("Migration confirmation disabled by system property.");
++            LOGGER.info("Continuing with startup world migration.");
++            return;
++        }
++
++        LOGGER.warn("Type 'confirm' to continue with startup world migration, or 'cancel' to stop the server.");
++
++        try {
++            final java.io.BufferedReader reader = new java.io.BufferedReader(new java.io.InputStreamReader(System.in));
++            while (true) {
++                final String line = reader.readLine();
++                if (line == null) {
++                    LOGGER.warn("World migration is still waiting for confirmation. Type 'confirm' to continue, or 'cancel' to stop the server.");
++                    continue;
++                }
++
++                switch (line.trim().toLowerCase(java.util.Locale.ROOT)) {
++                    case "confirm" -> {
++                        LOGGER.info("Continuing with startup world migration.");
++                        return;
++                    }
++                    case "cancel" -> throw new RuntimeException("World migration cancelled by console input.");
++                    default -> LOGGER.warn("Invalid migration response. Type 'confirm' to continue, or 'cancel' to stop the server.");
++                }
+             }
++        } catch (final IOException ex) {
++            throw new RuntimeException("Failed to read world migration confirmation from console", ex);
+         }
+-        LOGGER.info("Continuing with startup world migration.");
++        // Leaf end - Forge-like startup world migration
+     }
+ 
+     private static MigrationMode classifyStartupMigration(final WorldMigrationContext context) {


### PR DESCRIPTION
## Changes

Added Forge-like startup world migration to force the server owner to see the migration notice and take the server backup.

In many cases, the server owner will start the server and wait for it to launch successfully, instead of watching the terminal and checking logs. So that they may miss the 30 seconds and cause unexpected data loss.