### PR TITLE
Cache method calls in HopperHelper#determineComparatorUpdatePattern

### DIFF
--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/hopper/HopperHelper.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/hopper/HopperHelper.java
@@ -101,20 +101,21 @@ public class HopperHelper {
         float contentWeight = 0f;
         int numOccupiedSlots = 0;
 
-        // Leaf - cache method call results to avoid repeated interface dispatch
+        // Leaf start - cache method call results to avoid repeated interface dispatch
         int containerSize = from.getContainerSize();
         int containerMaxStackSize = from.getMaxStackSize();
 
         for (int j = 0; j < containerSize; ++j) {
+            // Leaf end - cache method call results to avoid repeated interface dispatch
             ItemStack itemStack = from.getItem(j);
             if (!itemStack.isEmpty()) {
-                int maxStackSize = Math.min(containerMaxStackSize, itemStack.getMaxStackSize());
+                int maxStackSize = Math.min(containerMaxStackSize, itemStack.getMaxStackSize()); // Leaf - cache method call results to avoid repeated interface dispatch
                 contentWeight += itemStack.getCount() / (float) maxStackSize;
                 ++numOccupiedSlots;
             }
         }
         float f = contentWeight;
-        f /= (float) containerSize;
+        f /= (float) containerSize; // Leaf - cache method call results to avoid repeated interface dispatch
         int originalSignalStrength = Mth.floor(f * 14.0F) + (numOccupiedSlots > 0 ? 1 : 0);
 
 
@@ -122,12 +123,12 @@ public class HopperHelper {
         //check the signal strength change when failing to extract from each slot
         int[] availableSlots = from instanceof WorldlyContainer ? ((WorldlyContainer) from).getSlotsForFace(Direction.DOWN) : null;
         WorldlyContainer sidedInventory = from instanceof WorldlyContainer ? (WorldlyContainer) from : null;
-        int fromSize = availableSlots != null ? availableSlots.length : containerSize;
+        int fromSize = availableSlots != null ? availableSlots.length : containerSize; // Leaf - cache method call results to avoid repeated interface dispatch
         for (int i = 0; i < fromSize; i++) {
             int fromSlot = availableSlots != null ? availableSlots[i] : i;
             ItemStack itemStack = fromStackList.get(fromSlot);
             if (!itemStack.isEmpty() && (sidedInventory == null || sidedInventory.canTakeItemThroughFace(fromSlot, itemStack, Direction.DOWN))) {
-                int newSignalStrength = calculateReducedSignalStrength(contentWeight, containerSize, containerMaxStackSize, numOccupiedSlots, itemStack.getCount(), itemStack.getMaxStackSize());
+                int newSignalStrength = calculateReducedSignalStrength(contentWeight, containerSize, containerMaxStackSize, numOccupiedSlots, itemStack.getCount(), itemStack.getMaxStackSize()); // Leaf - cache method call results to avoid repeated interface dispatch
                 if (newSignalStrength != originalSignalStrength) {
                     updatePattern = updatePattern.thenDecrementUpdateIncrementUpdate();
                 } else {

--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/hopper/HopperHelper.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/hopper/HopperHelper.java
@@ -101,16 +101,20 @@ public class HopperHelper {
         float contentWeight = 0f;
         int numOccupiedSlots = 0;
 
-        for (int j = 0; j < from.getContainerSize(); ++j) {
+        // Leaf - cache method call results to avoid repeated interface dispatch
+        int containerSize = from.getContainerSize();
+        int containerMaxStackSize = from.getMaxStackSize();
+
+        for (int j = 0; j < containerSize; ++j) {
             ItemStack itemStack = from.getItem(j);
             if (!itemStack.isEmpty()) {
-                int maxStackSize = Math.min(from.getMaxStackSize(), itemStack.getMaxStackSize());
+                int maxStackSize = Math.min(containerMaxStackSize, itemStack.getMaxStackSize());
                 contentWeight += itemStack.getCount() / (float) maxStackSize;
                 ++numOccupiedSlots;
             }
         }
         float f = contentWeight;
-        f /= (float) from.getContainerSize();
+        f /= (float) containerSize;
         int originalSignalStrength = Mth.floor(f * 14.0F) + (numOccupiedSlots > 0 ? 1 : 0);
 
 
@@ -118,12 +122,12 @@ public class HopperHelper {
         //check the signal strength change when failing to extract from each slot
         int[] availableSlots = from instanceof WorldlyContainer ? ((WorldlyContainer) from).getSlotsForFace(Direction.DOWN) : null;
         WorldlyContainer sidedInventory = from instanceof WorldlyContainer ? (WorldlyContainer) from : null;
-        int fromSize = availableSlots != null ? availableSlots.length : from.getContainerSize();
+        int fromSize = availableSlots != null ? availableSlots.length : containerSize;
         for (int i = 0; i < fromSize; i++) {
             int fromSlot = availableSlots != null ? availableSlots[i] : i;
             ItemStack itemStack = fromStackList.get(fromSlot);
             if (!itemStack.isEmpty() && (sidedInventory == null || sidedInventory.canTakeItemThroughFace(fromSlot, itemStack, Direction.DOWN))) {
-                int newSignalStrength = calculateReducedSignalStrength(contentWeight, from.getContainerSize(), from.getMaxStackSize(), numOccupiedSlots, itemStack.getCount(), itemStack.getMaxStackSize());
+                int newSignalStrength = calculateReducedSignalStrength(contentWeight, containerSize, containerMaxStackSize, numOccupiedSlots, itemStack.getCount(), itemStack.getMaxStackSize());
                 if (newSignalStrength != originalSignalStrength) {
                     updatePattern = updatePattern.thenDecrementUpdateIncrementUpdate();
                 } else {


### PR DESCRIPTION
motivation
hopperhelper.determinecomparatorupdatepattern calls getcontainersize and getmaxstacksize repeatedly inside loops since container is an interface this causes redundant virtual dispatch calls that jit can't always inline this overhead adds up on hopper heavy servers


changes
cached getcontainersize and getmaxstacksize into local variables at the start

updated all loop calls to use these cached values


impact
removes unnecessary interface method dispatching

maintains identical behavior with lower overhead per call

provides measurable performance gains in hopper heavy scenarios