### PR TITLE
Optimize MutableBlockPos in CombinedHeightmapUpdate loop

### DIFF
--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/heightmap/CombinedHeightmapUpdate.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/world/chunk/heightmap/CombinedHeightmapUpdate.java
@@ -95,11 +95,11 @@ public final class CombinedHeightmapUpdate {
             return;
         }
 
-        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
+        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos(x, y - 1, z); // Leaf - init with x/z only Y changes in loop
         int bottomY = worldChunk.getMinY();
 
         for (int searchY = y - 1; searchY >= bottomY && heightmapsToUpdate > 0; --searchY) {
-            mutable.set(x, searchY, z);
+            mutable.setY(searchY); // Leaf - only Y changes avoid redundant x/z writes
             BlockState blockState = worldChunk.getBlockState(mutable);
             if (heightmap0 != null && blockPredicate0.test(blockState)) {
                 heightmap0.setHeight(x, z, searchY + 1);


### PR DESCRIPTION
## Summary

Small optimization in `CombinedHeightmapUpdate#updateHeightmaps` to avoid redundant field writes on the `MutableBlockPos` inside the search loop.

## Changes

- Initialize `MutableBlockPos` with `x` and `z` already set (they never change during the loop).
- Use `setY(searchY)` inside the loop instead of `set(x, searchY, z)`.

## Rationale

The loop can iterate up to the full world height (`y - 1` down to `bottomY`, so potentially hundreds of iterations for tall worlds). In each iteration, only `searchY` changes — `x` and `z` are loop-invariant.

- Before: every iteration writes 3 fields (`x`, `y`, `z`) via `set(x, searchY, z)`.
- After: every iteration writes only 1 field (`y`) via `setY(searchY)`.

This removes 2 redundant field writes per iteration. While JIT may hoist some of these, expressing the intent explicitly in the code is beneficial and avoids relying on optimizer behavior.