### PR TITLE
Pre-size ArrayList in ChunkSectionInventoryEntityTracker and ChunkSec…

### DIFF
--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/tracking/entity/ChunkSectionInventoryEntityTracker.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/tracking/entity/ChunkSectionInventoryEntityTracker.java
@@ -49,10 +49,12 @@ public class ChunkSectionInventoryEntityTracker extends ChunkSectionEntityMoveme
             ));
         }
 
+        // Leaf start - pre-size ArrayList to avoid grow allocations
         int sizeX = worldSectionBox.chunkX2() - worldSectionBox.chunkX1() + 1;
         int sizeY = worldSectionBox.chunkY2() - worldSectionBox.chunkY1() + 1;
         int sizeZ = worldSectionBox.chunkZ2() - worldSectionBox.chunkZ1() + 1;
         List<ChunkSectionInventoryEntityTracker> trackers = new ArrayList<>(sizeX * sizeY * sizeZ);
+        // Leaf end - pre-size ArrayList to avoid grow allocations
 
         for (int x = worldSectionBox.chunkX1(); x <= worldSectionBox.chunkX2(); x++) {
             for (int y = worldSectionBox.chunkY1(); y <= worldSectionBox.chunkY2(); y++) {

--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/tracking/entity/ChunkSectionInventoryEntityTracker.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/tracking/entity/ChunkSectionInventoryEntityTracker.java
@@ -49,7 +49,10 @@ public class ChunkSectionInventoryEntityTracker extends ChunkSectionEntityMoveme
             ));
         }
 
-        List<ChunkSectionInventoryEntityTracker> trackers = new ArrayList<>();
+        int sizeX = worldSectionBox.chunkX2() - worldSectionBox.chunkX1() + 1;
+        int sizeY = worldSectionBox.chunkY2() - worldSectionBox.chunkY1() + 1;
+        int sizeZ = worldSectionBox.chunkZ2() - worldSectionBox.chunkZ1() + 1;
+        List<ChunkSectionInventoryEntityTracker> trackers = new ArrayList<>(sizeX * sizeY * sizeZ);
 
         for (int x = worldSectionBox.chunkX1(); x <= worldSectionBox.chunkX2(); x++) {
             for (int y = worldSectionBox.chunkY1(); y <= worldSectionBox.chunkY2(); y++) {

--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/tracking/entity/ChunkSectionItemEntityMovementTracker.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/tracking/entity/ChunkSectionItemEntityMovementTracker.java
@@ -49,7 +49,10 @@ public class ChunkSectionItemEntityMovementTracker extends ChunkSectionEntityMov
             ));
         }
 
-        List<ChunkSectionItemEntityMovementTracker> trackers = new ArrayList<>();
+        int sizeX = worldSectionBox.chunkX2() - worldSectionBox.chunkX1() + 1;
+        int sizeY = worldSectionBox.chunkY2() - worldSectionBox.chunkY1() + 1;
+        int sizeZ = worldSectionBox.chunkZ2() - worldSectionBox.chunkZ1() + 1;
+        List<ChunkSectionItemEntityMovementTracker> trackers = new ArrayList<>(sizeX * sizeY * sizeZ);
 
         for (int x = worldSectionBox.chunkX1(); x <= worldSectionBox.chunkX2(); x++) {
             for (int y = worldSectionBox.chunkY1(); y <= worldSectionBox.chunkY2(); y++) {

--- a/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/tracking/entity/ChunkSectionItemEntityMovementTracker.java
+++ b/leaf-server/src/main/java/net/caffeinemc/mods/lithium/common/tracking/entity/ChunkSectionItemEntityMovementTracker.java
@@ -49,10 +49,12 @@ public class ChunkSectionItemEntityMovementTracker extends ChunkSectionEntityMov
             ));
         }
 
+        // Leaf start - pre-size ArrayList to avoid grow allocations
         int sizeX = worldSectionBox.chunkX2() - worldSectionBox.chunkX1() + 1;
         int sizeY = worldSectionBox.chunkY2() - worldSectionBox.chunkY1() + 1;
         int sizeZ = worldSectionBox.chunkZ2() - worldSectionBox.chunkZ1() + 1;
         List<ChunkSectionItemEntityMovementTracker> trackers = new ArrayList<>(sizeX * sizeY * sizeZ);
+        // Leaf end - pre-size ArrayList to avoid grow allocations
 
         for (int x = worldSectionBox.chunkX1(); x <= worldSectionBox.chunkX2(); x++) {
             for (int y = worldSectionBox.chunkY1(); y <= worldSectionBox.chunkY2(); y++) {


### PR DESCRIPTION
Pre size ArrayList allocations in inventory item entity movement trackers.

Avoids array grow copy by calculating chunk dimensions before loop.
Affects ChunkSectionInventoryEntityTracker and ChunkSectionItemEntityMovementTracker
No behavior change. 2 files changed