### PR TITLE
Fix: Exempt fishing hooks from motion packet filtering

### DIFF
--- a/leaf-server/minecraft-patches/features/0293-Filter-ClientboundSetEntityMotionPacket.patch
+++ b/leaf-server/minecraft-patches/features/0293-Filter-ClientboundSetEntityMotionPacket.patch
@@ -20,6 +20,7 @@ The only entities needing this are:
 3. Ender Eyes, they depend on their velocity being set bc the packet sets the velocity on the client, but the client doesn't handle the
      ender eye velocity on its own bc the ender eye velocity is in relation to the stronghold structure which the client doesn't have access to
 4. Shulker bullets use random to determine where they are going, so we need to send velocity packets to ensure it remains smooth on the client
+5. Fishing hooks, filtering their motion packets breaks client-side bobbing and sinking physics, which prevents client-side auto-fishing mods from detecting bite events
 
 This filter helps keep unneeded packets reduced, but also ensures that we keep smooth visual gameplay
 
@@ -27,7 +28,7 @@ diff --git a/net/minecraft/server/level/ServerEntity.java b/net/minecraft/server
 index 5b7fe0ecf878b500cfd35ddf1349ec5545c7df69..267271c83e4c475dc39e409a9cce87f1dfc0080f 100644
 --- a/net/minecraft/server/level/ServerEntity.java
 +++ b/net/minecraft/server/level/ServerEntity.java
-@@ -226,7 +226,12 @@ public class ServerEntity {
+@@ -226,7 +226,13 @@ public class ServerEntity {
                                          )
                                      )
                                  );
@@ -36,12 +37,13 @@ index 5b7fe0ecf878b500cfd35ddf1349ec5545c7df69..267271c83e4c475dc39e409a9cce87f1
 +                            (this.entity instanceof net.minecraft.world.entity.item.ItemEntity && positionChanged) ||
 +                            this.entity instanceof net.minecraft.world.entity.projectile.EyeOfEnder ||
 +                            this.entity instanceof net.minecraft.world.entity.animal.squid.Squid ||
-+                            this.entity instanceof net.minecraft.world.entity.projectile.ShulkerBullet
++                            this.entity instanceof net.minecraft.world.entity.projectile.ShulkerBullet ||
++                            this.entity instanceof net.minecraft.world.entity.projectile.FishingHook
 +                        ) { // Leaf - Multithreaded tracker - diff on change
                              this.synchronizer.sendToTrackingPlayers(new ClientboundSetEntityMotionPacket(this.entity.getId(), this.lastSentMovement));
                          }
                      }
-@@ -563,7 +568,12 @@ public class ServerEntity {
+@@ -563,7 +568,13 @@ public class ServerEntity {
                                      new ClientboundSetEntityMotionPacket(this.entity.getId(), this.lastSentMovement),
                                      new ClientboundProjectilePowerPacket(projectile.getId(), projectile.accelerationPower)
                                  )));
@@ -50,7 +52,8 @@ index 5b7fe0ecf878b500cfd35ddf1349ec5545c7df69..267271c83e4c475dc39e409a9cce87f1
 +                                (this.entity instanceof net.minecraft.world.entity.item.ItemEntity && positionChanged) ||
 +                                this.entity instanceof net.minecraft.world.entity.projectile.EyeOfEnder ||
 +                                this.entity instanceof net.minecraft.world.entity.animal.squid.Squid ||
-+                                this.entity instanceof net.minecraft.world.entity.projectile.ShulkerBullet
++                                this.entity instanceof net.minecraft.world.entity.projectile.ShulkerBullet ||
++                                this.entity instanceof net.minecraft.world.entity.projectile.FishingHook
 +                            ) {
                                  ctx.sendToTrackingPlayers(tracker, new ClientboundSetEntityMotionPacket(this.entity.getId(), this.lastSentMovement));
                              }


### PR DESCRIPTION
When `filterClientboundSetEntityMotionPacket` is enabled, the server stops synchronizing delta movement packets for most projectiles to save bandwidth. However, this completely breaks the client-side physics simulation for fishing hooks (bobbing and sinking animation when a fish bites). 

This PR adds `FishingHook` to the exemption list, ensuring that players on the client side can correctly see the visual fish-bite events and hook animations, matching vanilla behavior.