### PR TITLE
Replace DiscardPolicy with CallerRunsPolicy in AsyncPlayerDataSaving

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/async/AsyncPlayerDataSaving.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/async/AsyncPlayerDataSaving.java
@@ -29,7 +29,7 @@ public class AsyncPlayerDataSaving {
                     .setNameFormat("Leaf IO Thread")
                     .setUncaughtExceptionHandler(Util::onThreadException)
                     .build(),
-                new ThreadPoolExecutor.DiscardPolicy()
+                new ThreadPoolExecutor.CallerRunsPolicy()
             );
         } else {
             // Temp no-op


### PR DESCRIPTION
DiscardPolicy silently drops player data save tasks when the pool is overloaded. This can cause player inventory/XP/location loss.

Replaced with CallerRunsPolicy so rejected tasks execute on the submitting thread instead of being silently discarded.