### PR TITLE
Move ClientboundCommandsPacket creation off the main thread

### DIFF
--- a/leaf-server/minecraft-patches/features/0335-Move-ClientboundCommandsPacket-creation-off-the-main.patch
+++ b/leaf-server/minecraft-patches/features/0335-Move-ClientboundCommandsPacket-creation-off-the-main.patch
@@ -4,17 +4,18 @@ Date: Mon, 27 Jul 2026 12:00:00 +0300
 Subject: [PATCH] Move ClientboundCommandsPacket creation off the main thread
 
 Build the packet on the async command sending pool to avoid
-enumerateNodes()/createEntries() lag on login with many commands.
+enumerateNodes()/createEntries() lag on login with many plugin commands.
 
 diff --git a/net/minecraft/commands/Commands.java b/net/minecraft/commands/Commands.java
-index de5b9c69ee6579c963bb00a3f2628247af9951e8..11223344556677889900aabbccddeeff11223344 100644
+index 817466f95b8d9e680abd5bcfa6ae0e86366c1cd7..e74f118e6aacb8d4725eabea4e4794243355094a 100644
 --- a/net/minecraft/commands/Commands.java
 +++ b/net/minecraft/commands/Commands.java
-@@ -524,5 +524,9 @@ public class Commands {
+@@ -524,7 +524,16 @@ public class Commands {
          }
          // CraftBukkit end
          } // Gale - Purpur - skip PlayerCommandSendEvent if there are no listeners
 -        player.connection.send(new ClientboundCommandsPacket(rootCommandNode, COMMAND_NODE_INSPECTOR));
++        // Leaf start - Move ClientboundCommandsPacket creation off the main thread
 +        final net.minecraft.server.MinecraftServer server = net.minecraft.server.MinecraftServer.getServer();
 +        final net.minecraft.server.network.ServerGamePacketListenerImpl connection = player.connection;
 +        COMMAND_SENDING_POOL.execute(() -> {
@@ -23,4 +24,7 @@ index de5b9c69ee6579c963bb00a3f2628247af9951e8..11223344556677889900aabbccddeeff
 +                server.execute(() -> connection.send(packet));
 +            }
 +        });
++        // Leaf end - Move ClientboundCommandsPacket creation off the main thread
      }
+ 
+     private static <S> void fillUsableCommands(CommandNode<S> root, CommandNode<S> current, S source, Map<CommandNode<S>, CommandNode<S>> output) { // Paper PR - fix ConcurrentModificationException in async command sending

--- a/leaf-server/minecraft-patches/features/0335-move-commands-packet-creation-off-main.patch
+++ b/leaf-server/minecraft-patches/features/0335-move-commands-packet-creation-off-main.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: purpurcof <purpurcof@users.noreply.github.com>
+Date: Mon, 27 Jul 2026 12:00:00 +0300
+Subject: [PATCH] Move ClientboundCommandsPacket creation off the main thread
+
+Build the packet on the async command sending pool to avoid
+enumerateNodes()/createEntries() lag on login with many commands.
+
+diff --git a/net/minecraft/commands/Commands.java b/net/minecraft/commands/Commands.java
+index de5b9c69ee6579c963bb00a3f2628247af9951e8..11223344556677889900aabbccddeeff11223344 100644
+--- a/net/minecraft/commands/Commands.java
++++ b/net/minecraft/commands/Commands.java
+@@ -524,5 +524,9 @@ public class Commands {
+         }
+         // CraftBukkit end
+         } // Gale - Purpur - skip PlayerCommandSendEvent if there are no listeners
+-        player.connection.send(new ClientboundCommandsPacket(rootCommandNode, COMMAND_NODE_INSPECTOR));
++        final net.minecraft.server.network.ServerGamePacketListenerImpl connection = player.connection;
++        COMMAND_SENDING_POOL.execute(() -> {
++            ClientboundCommandsPacket packet = new ClientboundCommandsPacket(rootCommandNode, COMMAND_NODE_INSPECTOR);
++            net.minecraft.server.MinecraftServer.getServer().execute(() -> connection.send(packet));
++        });
+     }

--- a/leaf-server/minecraft-patches/features/0335-move-commands-packet-creation-off-main.patch
+++ b/leaf-server/minecraft-patches/features/0335-move-commands-packet-creation-off-main.patch
@@ -15,9 +15,12 @@ index de5b9c69ee6579c963bb00a3f2628247af9951e8..11223344556677889900aabbccddeeff
          // CraftBukkit end
          } // Gale - Purpur - skip PlayerCommandSendEvent if there are no listeners
 -        player.connection.send(new ClientboundCommandsPacket(rootCommandNode, COMMAND_NODE_INSPECTOR));
++        final net.minecraft.server.MinecraftServer server = net.minecraft.server.MinecraftServer.getServer();
 +        final net.minecraft.server.network.ServerGamePacketListenerImpl connection = player.connection;
 +        COMMAND_SENDING_POOL.execute(() -> {
 +            ClientboundCommandsPacket packet = new ClientboundCommandsPacket(rootCommandNode, COMMAND_NODE_INSPECTOR);
-+            net.minecraft.server.MinecraftServer.getServer().execute(() -> connection.send(packet));
++            if (!server.isStopped()) {
++                server.execute(() -> connection.send(packet));
++            }
 +        });
      }


### PR DESCRIPTION
## How do I reproduce this?

Join an server with FAWE and WorldGuard installed (or any setup with hundreds/thousands of commands). Profile the main thread with spark during login - `ClientboundCommandsPacket.<init>()` shows up with ~400ms, split across `enumerateNodes()` (BFS + Object2IntOpenHashMap) and `createEntries()`.

## Root cause

`Commands#sendCommands()` constructs `new ClientboundCommandsPacket(rootCommandNode, ...)` synchronously on the netty event loop (which is the main server thread). The constructor traverses the entire command tree via BFS, builds an Object2IntOpenHashMap, and serialises every node - O(n) in the number of commands. With FAWE + WorldGuard adding thousands of command nodes, this single constructor call blocks the main thread for ~394ms per login.

## Fix

Move packet construction to `COMMAND_SENDING_POOL` (an async executor already used elsewhere in `Commands.java`). `connection.send()` is scheduled back on the main server thread via `MinecraftServer.getServer().execute()` to keep `Connection.pendingActions` single-thread-safe.

## Verification

- Spark with patch https://spark.lucko.me/sh1RlW5XLJ

## References

- Related to https://github.com/Winds-Studio/Leaf/pull/656
- Spark without patch https://spark.lucko.me/Z2uPCUtZ3R