### PR TITLE
Optimize trivial End surface generation

### DIFF
--- a/leaf-server/minecraft-patches/features/0317-Optimize-trivial-End-surface-generation.patch
+++ b/leaf-server/minecraft-patches/features/0317-Optimize-trivial-End-surface-generation.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Optimize trivial End surface generation
+
+This patch is based on the following mixin:
+"org/codeberg/zenxarch/fastnoise/mixin/perf/surface/NoiseChunkGeneratorMixin.java"
+By: ZenXArch <zenxarch@noreply.codeberg.org>
+As part of: FastNoise (https://codeberg.org/ZenXArch/FastNoise)
+Licensed under: MPL-2.0 (https://www.mozilla.org/en-US/MPL/2.0/)
+
+diff --git a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java b/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
+index 3fb94e04dff417794bf46a7722b1b99acf377cbf..aa8109ac6e5410bf7b8b3260b3fa1e2ff5b92470 100644
+--- a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
++++ b/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
+@@ -263,6 +263,14 @@ public final class NoiseBasedChunkGenerator extends ChunkGenerator {
+     @Override
+     public void buildSurface(final WorldGenRegion region, final StructureManager structureManager, final RandomState randomState, final ChunkAccess protoChunk) {
+         if (!SharedConstants.debugVoidTerrain(protoChunk.getPos()) && !SharedConstants.DEBUG_DISABLE_SURFACE) {
++            // Leaf start - Optimize trivial End surface generation
++            final NoiseGeneratorSettings settings = this.settings.value();
++            if (this.settings.is(NoiseGeneratorSettings.END)
++                && settings.surfaceRule() instanceof SurfaceRules.BlockRuleSource block
++                && block.resultState() == settings.defaultBlock()) {
++                return;
++            }
++            // Leaf end - Optimize trivial End surface generation
+             WorldGenerationContext context = new WorldGenerationContext(this, region, region.getMinecraftWorld()); // Paper - Flat bedrock generator settings
+             Set<Holder<Biome>> possibleBiomes = collectPossibleBiomes(region, 1);
+             this.buildSurface(protoChunk, context, randomState, structureManager, region.getBiomeManager(), Blender.of(region), possibleBiomes);
+diff --git a/net/minecraft/world/level/levelgen/SurfaceRules.java b/net/minecraft/world/level/levelgen/SurfaceRules.java
+index 1fa663be2987f9c4ee59a099622f85d90123c987..738aa79be088a88f29a03a27bb45d89dd1c08a72 100644
+--- a/net/minecraft/world/level/levelgen/SurfaceRules.java
++++ b/net/minecraft/world/level/levelgen/SurfaceRules.java
+@@ -236,7 +236,7 @@ public class SurfaceRules {
+         }
+     }
+ 
+-    private record BlockRuleSource(BlockState resultState, SurfaceRules.StateRule rule) implements SurfaceRules.RuleSource {
++    record BlockRuleSource(BlockState resultState, SurfaceRules.StateRule rule) implements SurfaceRules.RuleSource { // Leaf - Optimize trivial End surface generation - private -> package-private
+         private static final MapCodec<SurfaceRules.BlockRuleSource> CODEC = BlockState.CODEC
+             .xmap(SurfaceRules.BlockRuleSource::new, SurfaceRules.BlockRuleSource::resultState)
+             .fieldOf("result_state");

--- a/leaf-server/minecraft-patches/features/0317-Optimize-trivial-End-surface-generation.patch
+++ b/leaf-server/minecraft-patches/features/0317-Optimize-trivial-End-surface-generation.patch
@@ -10,19 +10,22 @@ As part of: FastNoise (https://codeberg.org/ZenXArch/FastNoise)
 Licensed under: MPL-2.0 (https://www.mozilla.org/en-US/MPL/2.0/)
 
 diff --git a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java b/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
-index 3fb94e04dff417794bf46a7722b1b99acf377cbf..aa8109ac6e5410bf7b8b3260b3fa1e2ff5b92470 100644
+index 3fb94e04dff417794bf46a7722b1b99acf377cbf..e9855179b40cb5818ba6b3cdfa65f0c04647fad2 100644
 --- a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
 +++ b/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
-@@ -263,6 +263,14 @@ public final class NoiseBasedChunkGenerator extends ChunkGenerator {
+@@ -263,6 +263,17 @@ public final class NoiseBasedChunkGenerator extends ChunkGenerator {
      @Override
      public void buildSurface(final WorldGenRegion region, final StructureManager structureManager, final RandomState randomState, final ChunkAccess protoChunk) {
          if (!SharedConstants.debugVoidTerrain(protoChunk.getPos()) && !SharedConstants.DEBUG_DISABLE_SURFACE) {
 +            // Leaf start - Optimize trivial End surface generation
-+            final NoiseGeneratorSettings settings = this.settings.value();
-+            if (this.settings.is(NoiseGeneratorSettings.END)
-+                && settings.surfaceRule() instanceof SurfaceRules.BlockRuleSource block
-+                && block.resultState() == settings.defaultBlock()) {
-+                return;
++            if (org.dreeam.leaf.config.modules.opt.OptimizeEndSurfaceGen.enabled) {
++                final NoiseGeneratorSettings settings = this.settings.value();
++                if (this.settings.is(NoiseGeneratorSettings.END)
++                    && !protoChunk.isUpgrading()
++                    && settings.surfaceRule() instanceof SurfaceRules.BlockRuleSource block
++                    && block.resultState() == settings.defaultBlock()) {
++                    return;
++                }
 +            }
 +            // Leaf end - Optimize trivial End surface generation
              WorldGenerationContext context = new WorldGenerationContext(this, region, region.getMinecraftWorld()); // Paper - Flat bedrock generator settings

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/OptimizeEndSurfaceGen.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/opt/OptimizeEndSurfaceGen.java
@@ -1,0 +1,22 @@
+package org.dreeam.leaf.config.modules.opt;
+
+import org.dreeam.leaf.config.ConfigCategory;
+import org.dreeam.leaf.config.ConfigModule;
+
+public class OptimizeEndSurfaceGen extends ConfigModule {
+    public String basePath() {
+        return ConfigCategory.PERF.basePath() + ".optimize-end-surface-gen";
+    }
+
+    public static boolean enabled = false;
+
+    @Override
+    public void onLoaded() {
+        enabled = globalConfig.getBoolean(basePath() + ".enabled", enabled, globalConfig.pickStringRegionBased("""
+                Skip trivial End surface rule build process.
+                May be incompatible with some datapacks that modify End world generation.""",
+            """
+                跳过不必要的末地 surface rule 构建。
+                可能不兼容一些修改末地世界生成的数据包。"""));
+    }
+}


### PR DESCRIPTION
From https://codeberg.org/ZenXArch/FastNoise

Before:

<img width="1513" height="303" alt="a30f7ce4cd2d316fb3355478e82f8b30" src="https://github.com/user-attachments/assets/75aae299-aed8-4107-83f2-3511215f790b" />

After:

<img width="1511" height="324" alt="5e22e92373e8f3d40cc01fdbe6adff53" src="https://github.com/user-attachments/assets/e638205d-e08e-4ac0-a9a2-f6eaa7012438" />

Test Environment:

Windows 11 25H2, Amazon Corretto 25.0.2, Intel Core Ultra 9 275HX, `chunky start world_the_end square 0 0 2000`, and restart the system after each benchmark finished.
