### PR TITLE
optimize PathNavigation#shouldRecomputePath

### DIFF
--- a/leaf-server/minecraft-patches/features/0317-optimize-PathNavigation-shouldRecomputePath.patch
+++ b/leaf-server/minecraft-patches/features/0317-optimize-PathNavigation-shouldRecomputePath.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrlingXD <90316914+wling-art@users.noreply.github.com>
+Date: Sat, 8 Aug 2026 17:09:43 +0800
+Subject: [PATCH] optimize PathNavigation#shouldRecomputePath
+
+
+diff --git a/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/net/minecraft/world/entity/ai/navigation/PathNavigation.java
+index 0336742e0886eb06beacaa2d8b1975d77b383142..bf47b60064d5253748cc94798c3d6032d4af5bc3 100644
+--- a/net/minecraft/world/entity/ai/navigation/PathNavigation.java
++++ b/net/minecraft/world/entity/ai/navigation/PathNavigation.java
+@@ -487,8 +487,10 @@ public abstract class PathNavigation {
+             return false;
+         } else if (this.path != null && this.path.isProcessed() && !this.path.isDone() && this.path.getNodeCount() != 0) { // Kaiiju - petal - async path processing - Skip if not processed
+             Node target = this.path.getEndNode();
+-            Vec3 middlePos = new Vec3((target.x + this.mob.getX()) / 2.0, (target.y + this.mob.getY()) / 2.0, (target.z + this.mob.getZ()) / 2.0);
+-            return pos.closerToCenterThan(middlePos, this.path.getNodeCount() - this.path.getNextNodeIndex());
++            // Leaf start - optimize PathNavigation#shouldRecomputePath - avoid Vec3 alloc on this hot path
++            return pos.distToCenterSqr((target.x + this.mob.getX()) / 2.0, (target.y + this.mob.getY()) / 2.0, (target.z + this.mob.getZ()) / 2.0)
++                < Mth.square(this.path.getNodeCount() - this.path.getNextNodeIndex());
++            // Leaf end - optimize PathNavigation#shouldRecomputePath
+         } else {
+             return false;
+         }


### PR DESCRIPTION
在活塞/红石机器高频刷新方块的服务器上，该函数会被每个正在寻路的生物 × 每次方块变化反复调用，实测 profile 中自耗时达 11.88%

改用 `distToCenterSqr(double, double, double)` 直接算距离平方，跳过对象分配和接口虚调用，行为不变。

BenchMark:
```
  correctness: OK (100000 random cases, old == new)                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                            
  === MONO (Vec3 only, best case for old JIT) ===                                                                                                                                                                                                                                                                           
  old (Vec3 alloc + interface):   3.73 ns/op                                                                                                                                                                                                                                                                                
  new (primitive overload):       3.10 ns/op                                                                                                                                                                                                                                                                                
  speedup: 1.20x                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                            
  === POLY (Vec3/BlockPos/Entity interleaved, matches real game) ===                                                                                                                                                                                                                                                        
  old (Vec3 alloc + interface):  22.07 ns/op                                                                                                                                                                                                                                                                                
  new (primitive overload):       2.27 ns/op                                                                                                                                                                                                                                                                                
  speedup: 9.70x
```