### PR TITLE
optimize PoiAccess BFS seen set capacity

### DIFF
--- a/leaf-server/minecraft-patches/features/0317-optimize-PoiAccess-BFS-seen-set-capacity.patch
+++ b/leaf-server/minecraft-patches/features/0317-optimize-PoiAccess-BFS-seen-set-capacity.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrlingXD <90316914+wling-art@users.noreply.github.com>
+Date: Sun, 9 Aug 2026 00:59:10 +0800
+Subject: [PATCH] optimize PoiAccess BFS seen set capacity
+
+
+diff --git a/ca/spottedleaf/moonrise/patches/poi_lookup/PoiAccess.java b/ca/spottedleaf/moonrise/patches/poi_lookup/PoiAccess.java
+index 85d80b3952a76b0ca7f67401a659cf35dd55b082..dbd7b565d628339f69850fdf1252bdbcaed88c3e 100644
+--- a/ca/spottedleaf/moonrise/patches/poi_lookup/PoiAccess.java
++++ b/ca/spottedleaf/moonrise/patches/poi_lookup/PoiAccess.java
+@@ -117,7 +117,7 @@ public final class PoiAccess {
+         final long centerKey = CoordinateUtils.getChunkSectionKey(centerX, centerY, centerZ);
+ 
+         final LongArrayFIFOQueue queue = new LongArrayFIFOQueue();
+-        final LongOpenHashSet seen = new LongOpenHashSet();
++        final LongOpenHashSet seen = new LongOpenHashSet(Math.min(4096, (upperX - lowerX + 1) * (upperY - lowerY + 1) * (upperZ - lowerZ + 1))); // Leaf - pre-size POI BFS seen set to avoid rehashing
+         seen.add(centerKey);
+         queue.enqueue(centerKey);
+ 
+@@ -360,7 +360,7 @@ public final class PoiAccess {
+         final long centerKey = CoordinateUtils.getChunkSectionKey(centerX, centerY, centerZ);
+ 
+         final LongArrayFIFOQueue queue = new LongArrayFIFOQueue();
+-        final LongOpenHashSet seen = new LongOpenHashSet();
++        final LongOpenHashSet seen = new LongOpenHashSet(Math.min(4096, (upperX - lowerX + 1) * (upperY - lowerY + 1) * (upperZ - lowerZ + 1))); // Leaf - pre-size POI BFS seen set to avoid rehashing
+         seen.add(centerKey);
+         queue.enqueue(centerKey);
+ 


### PR DESCRIPTION
村民找工作地点（铁砧、讲台等）时会一圈圈往外搜索附近的区块，搜索过程中记录"查过的地方"用的是一个 `LongOpenHashSet`，但一开始只申请了很小的空间（fastutil 默认 16 个），搜索范围一大就要反复扩容（16→32→64→...→2048），每次搬家都要把已有数据全部复制一遍。                       
                                                                                                                        
更改后在开始搜索前算好了这次搜索的范围，只是没拿这个边界去预估要装多少数据、提前把空间租够。