### PR TITLE
Leaves Fork cache item max stack size

### DIFF
--- a/leaf-server/minecraft-patches/features/0322-Leaves-Fork-cache-item-max-stack-size.patch
+++ b/leaf-server/minecraft-patches/features/0322-Leaves-Fork-cache-item-max-stack-size.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Lumine1909 <133463833+Lumine1909@users.noreply.github.com>
+Date: Tue, 9 Nov 2077 00:00:00 +0800
+Subject: [PATCH] Leaves Fork cache item max stack size
+
+Slightly modified and cleaned up version
+
+Original license: GPL-3.0-only
+Original project: https://github.com/Lumine1909/Leaves_Fork
+
+diff --git a/net/minecraft/core/component/PatchedDataComponentMap.java b/net/minecraft/core/component/PatchedDataComponentMap.java
+index b0967af2a3f85dad242ec7475ec9d4f7d7badfc7..a41e358035655236f4539a9fb2e5e1aff99cecb8 100644
+--- a/net/minecraft/core/component/PatchedDataComponentMap.java
++++ b/net/minecraft/core/component/PatchedDataComponentMap.java
+@@ -18,6 +18,7 @@ public final class PatchedDataComponentMap implements DataComponentMap, net.caff
+     private final DataComponentMap prototype;
+     private Reference2ObjectMap<DataComponentType<?>, Optional<?>> patch;
+     private boolean copyOnWrite;
++    private int maxStackSize; // Leaves - cache item max stack size
+     private net.caffeinemc.mods.lithium.common.util.change_tracking.ChangeSubscriber<PatchedDataComponentMap> subscriber; // Leaf - Lithium - equipment tracking
+ 
+     public PatchedDataComponentMap(final DataComponentMap prototype) {
+@@ -30,6 +31,7 @@ public final class PatchedDataComponentMap implements DataComponentMap, net.caff
+         this.prototype = prototype;
+         this.patch = patch;
+         this.copyOnWrite = copyOnWrite;
++        this.detectMaxStackSizeChange(null); // Leaves - cache item max stack size
+     }
+ 
+     public static PatchedDataComponentMap fromPatch(final DataComponentMap prototype, final DataComponentPatch patch) {
+@@ -77,6 +79,7 @@ public final class PatchedDataComponentMap implements DataComponentMap, net.caff
+             lastValue = (Optional<T>)this.patch.put(type, Optional.ofNullable(value));
+         }
+ 
++        this.detectMaxStackSizeChange(type); // Leaves - cache item max stack size
+         return lastValue != null ? lastValue.orElse(defaultValue) : defaultValue;
+     }
+ 
+@@ -94,6 +97,7 @@ public final class PatchedDataComponentMap implements DataComponentMap, net.caff
+             lastValue = (Optional<? extends T>)this.patch.remove(type);
+         }
+ 
++        this.detectMaxStackSizeChange(type); // Leaves - cache item max stack size
+         return (T)(lastValue != null ? lastValue.orElse(null) : defaultValue);
+     }
+ 
+@@ -118,17 +122,20 @@ public final class PatchedDataComponentMap implements DataComponentMap, net.caff
+         } else {
+             this.patch.remove(type);
+         }
++        this.detectMaxStackSizeChange(type); // Leaves - cache item max stack size
+     }
+ 
+     public void restorePatch(final DataComponentPatch patch) {
+         this.ensureMapOwnership();
+         this.patch.clear();
+         this.patch.putAll(patch.map);
++        this.detectMaxStackSizeChange(null); // Leaves - cache item max stack size
+     }
+ 
+     public void clearPatch() {
+         this.ensureMapOwnership();
+         this.patch.clear();
++        this.detectMaxStackSizeChange(null); // Leaves - cache item max stack size
+     }
+ 
+     public void setAll(final DataComponentMap components) {
+@@ -266,4 +273,16 @@ public final class PatchedDataComponentMap implements DataComponentMap, net.caff
+     public String toString() {
+         return "{" + this.stream().map(TypedDataComponent::toString).collect(Collectors.joining(", ")) + "}";
+     }
++
++    // Leaves start - cache item max stack size
++    public int getMaxStackSize() {
++        return this.maxStackSize;
++    }
++
++    private void detectMaxStackSizeChange(final @Nullable DataComponentType<?> changedType) {
++        if (changedType == null || changedType == DataComponents.MAX_STACK_SIZE) {
++            this.maxStackSize = this.getOrDefault(DataComponents.MAX_STACK_SIZE, 1);
++        }
++    }
++    // Leaves end - cache item max stack size
+ }
+diff --git a/net/minecraft/world/item/ItemStack.java b/net/minecraft/world/item/ItemStack.java
+index 006a3c8bf13d93570e264added86a179dc90f7fb..3707037438162daec6535e7e5c5bfab6d365bd53 100644
+--- a/net/minecraft/world/item/ItemStack.java
++++ b/net/minecraft/world/item/ItemStack.java
+@@ -1372,6 +1372,13 @@ public final class ItemStack implements DataComponentHolder, ItemInstance, net.c
+         return this.getCount();
+     }
+ 
++    // Leaves start - cache item max stack size
++    @Override
++    public int getMaxStackSize() {
++        return this.components.getMaxStackSize();
++    }
++    // Leaves end - cache item max stack size
++
+     public void setCount(final int count) {
+         // Leaf start - Lithium - equipment tracking
+         if (count != this.count) {


### PR DESCRIPTION
Taken from: https://github.com/Lumine1909/Leaves_Fork

Optimizes the ItemStack hotpath in item merging, inventory moving