### PR TITLE
Fix DoABarrelRollProtocol

### DIFF
--- a/leaf-server/src/main/java/org/dreeam/leaf/protocol/DoABarrelRollProtocol.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/protocol/DoABarrelRollProtocol.java
@@ -111,7 +111,7 @@ public class DoABarrelRollProtocol implements Protocol {
                 var rolling = rollSyncC2SPacket.rolling();
                 var roll = rollSyncC2SPacket.roll();
                 isRollingMap.put(player.connection, rolling);
-                if (Float.isInfinite(roll)) {
+                if (!Float.isFinite(roll)) {
                     roll = 0.0F;
                 }
                 rollMap.put(player.connection, roll);


### PR DESCRIPTION
Filter NaN values, as `NaN != NaN`, this will send sync packets to all subscribed players every tick until the sender disconnects or sends another normal packet.