### PR TITLE
Add back missing isAlwaysTicking check

### DIFF
--- a/leaf-server/minecraft-patches/features/0223-optimize-getEntityStatus.patch
+++ b/leaf-server/minecraft-patches/features/0223-optimize-getEntityStatus.patch
@@ -5,16 +5,19 @@ Subject: [PATCH] optimize getEntityStatus
 
 
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
-index 328784ba08236553e49d62320b79f7222292412f..6d6b1a261708b88a4b706ccc51b7d397fe42ea6b 100644
+index 328784ba08236553e49d62320b79f7222292412f..cc02a276e5de57667676e5c2cdb9358f684984ec 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
-@@ -93,8 +93,14 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
+@@ -93,8 +93,17 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
          if (entity == null) {
              return null;
          }
 -        final Visibility visibility = EntityLookup.getEntityStatus(entity);
 -        return visibility.isAccessible() ? entity : null;
 +        // Leaf start - optimize getEntityStatus
++        if (entity.isAlwaysTicking()) {
++            return entity;
++        }
 +        final FullChunkStatus entityStatus = ((ChunkSystemEntity) entity).moonrise$getChunkStatus();
 +        return switch (entityStatus) {
 +            case INACCESSIBLE -> null;
@@ -25,7 +28,7 @@ index 328784ba08236553e49d62320b79f7222292412f..6d6b1a261708b88a4b706ccc51b7d397
      }
  
      @Override
-@@ -402,7 +408,14 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
+@@ -402,7 +411,14 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
              return Visibility.TICKING;
          }
          final FullChunkStatus entityStatus = ((ChunkSystemEntity)entity).moonrise$getChunkStatus();

--- a/leaf-server/minecraft-patches/features/0277-Rewrite-entity-despawn-time.patch
+++ b/leaf-server/minecraft-patches/features/0277-Rewrite-entity-despawn-time.patch
@@ -32,7 +32,7 @@ index 81e72a1cd2de1bfeb4c78999148dd2e95ed782c2..2b90941bf6824719531582c27e640514
                  PlatformHooks.get().unloadEntity(entity);
                  if (entity.isVehicle()) {
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
-index 6d6b1a261708b88a4b706ccc51b7d397fe42ea6b..f27f198e84ac668446c9d57772343ba10464428c 100644
+index cc02a276e5de57667676e5c2cdb9358f684984ec..53d85b59964fad1ebbd32e939909bb408d969705 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
 @@ -51,6 +51,7 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
@@ -43,7 +43,7 @@ index 6d6b1a261708b88a4b706ccc51b7d397fe42ea6b..f27f198e84ac668446c9d57772343ba1
  
      public EntityLookup(final Level world, final LevelCallback<Entity> worldCallback) {
          this.world = world;
-@@ -261,6 +262,21 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
+@@ -264,6 +265,21 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
          try {
              final Boolean ticketBlockBefore = this.blockTicketUpdates();
              try {
@@ -65,7 +65,7 @@ index 6d6b1a261708b88a4b706ccc51b7d397fe42ea6b..f27f198e84ac668446c9d57772343ba1
                  ((ChunkSystemEntity)entity).moonrise$setUpdatingSectionStatus(true);
                  try {
                      if (created) {
-@@ -501,6 +517,7 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
+@@ -504,6 +520,7 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
                  LOGGER.warn("Failed to remove entity " + entity + " from entity slices (" + sectionX + "," + sectionZ + ")");
              }
          }
@@ -73,7 +73,7 @@ index 6d6b1a261708b88a4b706ccc51b7d397fe42ea6b..f27f198e84ac668446c9d57772343ba1
          ((ChunkSystemEntity)entity).moonrise$setSectionX(Integer.MIN_VALUE);
          ((ChunkSystemEntity)entity).moonrise$setSectionY(Integer.MIN_VALUE);
          ((ChunkSystemEntity)entity).moonrise$setSectionZ(Integer.MIN_VALUE);
-@@ -939,6 +956,34 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
+@@ -942,6 +959,34 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
          }
      }
  

--- a/leaf-server/minecraft-patches/features/0321-optimize-entity-activation.patch
+++ b/leaf-server/minecraft-patches/features/0321-optimize-entity-activation.patch
@@ -26,10 +26,10 @@ index 2b90941bf6824719531582c27e640514742f0dd2..aaa30ab2dc639d4b84fa166cc31e5f03
          return this.entities.size() == 0;
      }
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
-index f27f198e84ac668446c9d57772343ba10464428c..9bdc69f7e5b1295c42a89eb1871747e704be79aa 100644
+index 53d85b59964fad1ebbd32e939909bb408d969705..775bea1ff010d3bdd6ea20ad47d9b8c45fbdc95f 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
-@@ -637,6 +637,48 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
+@@ -640,6 +640,48 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
          }
      }
  

--- a/leaf-server/minecraft-patches/features/0326-Limit-pushable-entity-queries.patch
+++ b/leaf-server/minecraft-patches/features/0326-Limit-pushable-entity-queries.patch
@@ -84,10 +84,10 @@ index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..498f397b53b7b21f5c95cb0550381cd4
      }
  }
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
-index 9bdc69f7e5b1295c42a89eb1871747e704be79aa..694954f812f83d6a0d43b35ddbb3c837051a0593 100644
+index 775bea1ff010d3bdd6ea20ad47d9b8c45fbdc95f..2a9032f8fe5424d3795093dfa8bd79ef4534b835 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/EntityLookup.java
-@@ -679,6 +679,47 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
+@@ -682,6 +682,47 @@ public abstract class EntityLookup implements LevelEntityGetter<Entity> {
      }
      // Leaf end - optimize entity activation
  


### PR DESCRIPTION
Add back `isAlwaysTicking` check that was unexpectedly removed in `0223-optimize-getEntityStatus.patch`.