### PR TITLE
Fix only tick items double ticking offhand

### DIFF
--- a/leaf-server/minecraft-patches/features/0217-Only-tick-items-at-hand.patch
+++ b/leaf-server/minecraft-patches/features/0217-Only-tick-items-at-hand.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Only tick items at hand
 
 
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index e1b2022e7e063bc1e30a7139f8d452e0810771ac..e59cbde71d74630dfcfa1ba79600f82496c86a00 100644
+index dc1f4fcbd284735f8c98cd2f60095a892a875ce5..b7c83473cde3df58f966e183af92160e9fde0b51 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -851,12 +851,19 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -29,17 +29,16 @@ index e1b2022e7e063bc1e30a7139f8d452e0810771ac..e59cbde71d74630dfcfa1ba79600f824
              if (this.getHealth() != this.lastSentHealth
                  || this.lastSentFood != this.foodData.getFoodLevel()
 diff --git a/net/minecraft/world/entity/player/Player.java b/net/minecraft/world/entity/player/Player.java
-index 04d88c162a854c8bd48cbac5bce787654bf31545..2a0ae51cb0450f80abeaf3d858206512e9c6a4f3 100644
+index da86654718388f70e752627ade08db930e2278e4..013ccfa032723a78c99871f88252347a7c34c5d7 100644
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
-@@ -527,7 +527,14 @@ public abstract class Player extends Avatar implements ContainerUser {
+@@ -527,7 +527,13 @@ public abstract class Player extends Avatar implements ContainerUser {
          }
  
          this.tickRegeneration();
 +        // Leaf start - Only tick items at hand
 +        if (org.dreeam.leaf.config.modules.opt.OptimizeItemTicking.onlyTickItemsInHand) {
 +            this.getMainHandItem().inventoryTick(this.level(), this, EquipmentSlot.MAINHAND);
-+            this.getOffhandItem().inventoryTick(this.level(), this, EquipmentSlot.OFFHAND);
 +        } else {
          this.inventory.tick();
 +        }

--- a/leaf-server/minecraft-patches/features/0298-Improve-Purpur-JS-expression-evaluation.patch
+++ b/leaf-server/minecraft-patches/features/0298-Improve-Purpur-JS-expression-evaluation.patch
@@ -129,10 +129,10 @@ index 8f30f9f0f12e5fd6ddcb1809195f0823ea3ebd51..1cf50c7f3d32270f3cbfa36eb2ac79f4
          return ProjectileUtil.getMobArrow(this, projectile, power, firingWeapon);
      }
 diff --git a/net/minecraft/world/entity/player/Player.java b/net/minecraft/world/entity/player/Player.java
-index 2a0ae51cb0450f80abeaf3d858206512e9c6a4f3..0b4689abdc02251b5aa79f4e15331821a5cc67c3 100644
+index 013ccfa032723a78c99871f88252347a7c34c5d7..3043c073856ff64b4e7c2194c4c6883f5eeab7cb 100644
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
-@@ -1837,7 +1837,10 @@ public abstract class Player extends Avatar implements ContainerUser {
+@@ -1836,7 +1836,10 @@ public abstract class Player extends Avatar implements ContainerUser {
      protected int getBaseExperienceReward(final ServerLevel level) {
          // Purpur start - Add player death exp control options
          if (!level.getGameRules().get(GameRules.KEEP_INVENTORY) && !this.isSpectator()) {
@@ -144,7 +144,7 @@ index 2a0ae51cb0450f80abeaf3d858206512e9c6a4f3..0b4689abdc02251b5aa79f4e15331821
              try {
                  toDrop = Math.round(((Number) scriptEngine.eval("let expLevel = " + experienceLevel + "; " +
                      "let expTotal = " + totalExperience + "; " +
-@@ -1847,6 +1850,7 @@ public abstract class Player extends Avatar implements ContainerUser {
+@@ -1846,6 +1849,7 @@ public abstract class Player extends Avatar implements ContainerUser {
                  e.printStackTrace();
                  toDrop = experienceLevel * 7;
              }


### PR DESCRIPTION
Offhand item has already been ticked in `LivingEntity#aiStep`.

Callstack

```text
Player.aiStep()
  main.inventoryTick()
  off.inventoryTick() first time
  super.aiStep()
    LivingEntity.aiStep()
      this.equipment.tick(this)
         off.inventoryTick() second time
```