### PR TITLE
Add explicit license description to my patches

### DIFF
--- a/leaf-server/minecraft-patches/features/0277-Rewrite-entity-despawn-time.patch
+++ b/leaf-server/minecraft-patches/features/0277-Rewrite-entity-despawn-time.patch
@@ -19,6 +19,17 @@ After: 1.5 seconds
 Brings the ability to despawn weak-loaded entities once they are ticked,
 a solution for https://github.com/PaperMC/Paper/issues/12986
 
+License: GPL-3.0-only (https://www.gnu.org/licenses/gpl-3.0.html)
+
+Additional term under GNU GPLv3 section 7(b):
+
+Any copy or modified version containing a substantial portion of the
+original contributions in this patch must preserve the following
+author attribution in the patch header, source code, or another
+prominent legal notice accompanying the corresponding source:
+
+Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 index 81e72a1cd2de1bfeb4c78999148dd2e95ed782c2..2b90941bf6824719531582c27e640514742f0dd2 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java

--- a/leaf-server/minecraft-patches/features/0278-Optimize-Vec3i-hashing.patch
+++ b/leaf-server/minecraft-patches/features/0278-Optimize-Vec3i-hashing.patch
@@ -12,6 +12,17 @@ while random or small coordinate sets are mostly unchanged. This patch is aimed
 at improving worst-case distribution rather than reducing raw hash instruction
 count.
 
+License: GPL-3.0-only (https://www.gnu.org/licenses/gpl-3.0.html)
+
+Additional term under GNU GPLv3 section 7(b):
+
+Any copy or modified version containing a substantial portion of the
+original contributions in this patch must preserve the following
+author attribution in the patch header, source code, or another
+prominent legal notice accompanying the corresponding source:
+
+Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+
 diff --git a/net/minecraft/core/Vec3i.java b/net/minecraft/core/Vec3i.java
 index b81a61a7b05e11cbd9fdfa704937abd18d32070e..cf001d7c4bd85a6c36c3be420ca5a845b366610c 100644
 --- a/net/minecraft/core/Vec3i.java

--- a/leaf-server/minecraft-patches/features/0279-Cache-world-border.patch
+++ b/leaf-server/minecraft-patches/features/0279-Cache-world-border.patch
@@ -6,6 +6,17 @@ Subject: [PATCH] Cache world border
 The world border is only initialized once when the level is created.
 Lookup from data storage map multiple time is quite unnecessary and expensive.
 
+License: GPL-3.0-only (https://www.gnu.org/licenses/gpl-3.0.html)
+
+Additional term under GNU GPLv3 section 7(b):
+
+Any copy or modified version containing a substantial portion of the
+original contributions in this patch must preserve the following
+author attribution in the patch header, source code, or another
+prominent legal notice accompanying the corresponding source:
+
+Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
 index 6bad7fa23cfd3be43f6f642ae3eeb02492b0aa2f..2fac5a4fd19a5f3d9b832e7611f005b852eec9fa 100644
 --- a/net/minecraft/server/level/ServerLevel.java

--- a/leaf-server/minecraft-patches/features/0286-Don-t-load-POI-for-competitor-scan.patch
+++ b/leaf-server/minecraft-patches/features/0286-Don-t-load-POI-for-competitor-scan.patch
@@ -3,6 +3,16 @@ From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 Date: Tue, 9 Nov 2077 00:00:00 +0800
 Subject: [PATCH] Don't load POI for competitor scan
 
+License: GPL-3.0-only (https://www.gnu.org/licenses/gpl-3.0.html)
+
+Additional term under GNU GPLv3 section 7(b):
+
+Any copy or modified version containing a substantial portion of the
+original contributions in this patch must preserve the following
+author attribution in the patch header, source code, or another
+prominent legal notice accompanying the corresponding source:
+
+Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java b/net/minecraft/world/entity/ai/behavior/PoiCompetitorScan.java
 index c507cbb1b0d89f8fe5a00e67eea510f7516fe040..4aa67879f3e78f92e51e4c32a3aa69438b30ac63 100644

--- a/leaf-server/minecraft-patches/features/0313-Cache-XP-orb-merge-parameters.patch
+++ b/leaf-server/minecraft-patches/features/0313-Cache-XP-orb-merge-parameters.patch
@@ -3,6 +3,16 @@ From: HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 Date: Tue, 9 Nov 2077 00:00:00 +0800
 Subject: [PATCH] Cache XP orb merge parameters
 
+License: GPL-3.0-only (https://www.gnu.org/licenses/gpl-3.0.html)
+
+Additional term under GNU GPLv3 section 7(b):
+
+Any copy or modified version containing a substantial portion of the
+original contributions in this patch must preserve the following
+author attribution in the patch header, source code, or another
+prominent legal notice accompanying the corresponding source:
+
+Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
 
 diff --git a/net/minecraft/world/entity/ExperienceOrb.java b/net/minecraft/world/entity/ExperienceOrb.java
 index b44467e1f9a876c696a97585c8d4a1107a8055b5..4df5d3fffb349129217042812ecb26000b84a0d1 100644

--- a/leaf-server/minecraft-patches/features/0320-Optimize-PoiAccess-visited-section-tracking.patch
+++ b/leaf-server/minecraft-patches/features/0320-Optimize-PoiAccess-visited-section-tracking.patch
@@ -6,6 +6,17 @@ Subject: [PATCH] Optimize PoiAccess visited section tracking
 Replace LongOpenHashSet used for tracking sections visited with bit set, avoid rehash overhead.
 Manually unroll the six neighbor checks, eliminate the 3x3x3 loop.
 
+License: GPL-3.0-only (https://www.gnu.org/licenses/gpl-3.0.html)
+
+Additional term under GNU GPLv3 section 7(b):
+
+Any copy or modified version containing a substantial portion of the
+original contributions in this patch must preserve the following
+author attribution in the patch header, source code, or another
+prominent legal notice accompanying the corresponding source:
+
+Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>, co-authored by MrlingXD <90316914+wling-art@users.noreply.github.com>
+
 Co-authored-by: MrlingXD <90316914+wling-art@users.noreply.github.com>
 
 diff --git a/ca/spottedleaf/moonrise/patches/poi_lookup/PoiAccess.java b/ca/spottedleaf/moonrise/patches/poi_lookup/PoiAccess.java

--- a/leaf-server/minecraft-patches/features/0326-Limit-pushable-entity-queries.patch
+++ b/leaf-server/minecraft-patches/features/0326-Limit-pushable-entity-queries.patch
@@ -6,6 +6,17 @@ Subject: [PATCH] Limit pushable entity queries
 Avoid collecting every nearby pushable entity before processing collisions, only keep entities needed by the collision limit.
 Reduces temporary allocations cost without compromising the logic parity.
 
+License: GPL-3.0-only (https://www.gnu.org/licenses/gpl-3.0.html)
+
+Additional term under GNU GPLv3 section 7(b):
+
+Any copy or modified version containing a substantial portion of the
+original contributions in this patch must preserve the following
+author attribution in the patch header, source code, or another
+prominent legal notice accompanying the corresponding source:
+
+Original patch by HaHaWTH <102713261+HaHaWTH@users.noreply.github.com>
+
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java b/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java
 index aaa30ab2dc639d4b84fa166cc31e5f033451bd5d..498f397b53b7b21f5c95cb0550381cd469cba9b1 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/level/entity/ChunkEntitySlices.java


### PR DESCRIPTION
This PR adds explicit licensing terms to my original contributions in several Leaf patches.

These contributions were previously covered by Leaf's default patch licensing (MIT) because no separate license was specified in their patch headers. This PR explicitly licenses my contributions under GPL-3.0-only and adds an additional term under GNU GPLv3 Section 7(b) requiring preservation of the specified author attribution when the covered material is copied, modified, or redistributed.

The intent is to make the attribution requirement explicit while keeping the covered contributions freely usable, modifiable, and redistributable under the applicable GPL terms, including by downstream forks.

### Co-author

`0320-Optimize-PoiAccess-visited-section-tracking.patch` also contains contributions from MrlingXD.

@wling-art, could you please explicitly confirm that if you agree to relicense your contributions to this patch under GPL-3.0-only, together with the GPLv3 Section 7(b) attribution term introduced in this PR?

For clarity, a confirmation such as the following would be appreciated:

`I agree to relicense my contributions to 0320-Optimize-PoiAccess-visited-section-tracking.patch under GPL-3.0-only with the GPLv3 Section 7(b) attribution term specified in this PR.`