### PR TITLE
Fix InsideBrownianWalk shuffle logic

### DIFF
--- a/leaf-server/minecraft-patches/features/0196-rewrite-InsideBrownianWalk.patch
+++ b/leaf-server/minecraft-patches/features/0196-rewrite-InsideBrownianWalk.patch
@@ -8,7 +8,7 @@ License: LGPL-3.0-only (https://www.gnu.org/licenses/lgpl-3.0.html)
 This method is mainly visible when ton of villagers suddenly wants to sleep.
 
 diff --git a/net/minecraft/world/entity/ai/behavior/InsideBrownianWalk.java b/net/minecraft/world/entity/ai/behavior/InsideBrownianWalk.java
-index b57a48842e31f678de4dcef689a4c9dcf9dd66af..9f1cc376866bb8f6915b5b99ac0200df546bf517 100644
+index b57a48842e31f678de4dcef689a4c9dcf9dd66af..04c5afb2805ec1b5b382432cafccbc6d45be6fb1 100644
 --- a/net/minecraft/world/entity/ai/behavior/InsideBrownianWalk.java
 +++ b/net/minecraft/world/entity/ai/behavior/InsideBrownianWalk.java
 @@ -21,16 +21,29 @@ public class InsideBrownianWalk {
@@ -36,7 +36,7 @@ index b57a48842e31f678de4dcef689a4c9dcf9dd66af..9f1cc376866bb8f6915b5b99ac0200df
 +                            int j = body.getRandom().nextInt(index + 1);
 +                            BlockPos temp = poses[index];
 +                            poses[index] = poses[j];
-+                            poses[index] = temp;
++                            poses[j] = temp;
 +                        }
 +
 +                        for (BlockPos pos : poses) {


### PR DESCRIPTION
InsideBrownianWalk rewrite is assigning original value back to the array, shuffle actually does nothing.