### PR TITLE
Configurable locator bar range

### DIFF
--- a/leaf-server/minecraft-patches/features/0327-Configurable-locator-bar-max-distance.patch
+++ b/leaf-server/minecraft-patches/features/0327-Configurable-locator-bar-max-distance.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: HyperGaming99 <130169800+HyperGaming99@users.noreply.github.com>
 Date: Fri, 14 Aug 2026 04:52:05 +0200
-Subject: [PATCH] Configurable locator bar range
+Subject: [PATCH] Configurable locator bar max distance
 
 Player waypoint range comes from the waypoint_transmit_range and
 waypoint_receive_range attributes, both of which default to 6.0E7 for
@@ -18,20 +18,22 @@ individually.
 Clamps only, never widens, so plugins or datapacks lowering the attributes
 still take precedence. Defaults to 0, which keeps vanilla behaviour.
 
+Similar Paper PR: https://github.com/PaperMC/Paper/pull/13376
+
 diff --git a/net/minecraft/world/waypoints/WaypointTransmitter.java b/net/minecraft/world/waypoints/WaypointTransmitter.java
-index 6077e1a0ae8448f4d975676f0eaf19ddbd45bd4b..7420f7d9970ff14f4228d79e472188aca10d5d4a 100644
+index 6077e1a0ae8448f4d975676f0eaf19ddbd45bd4b..a249f2ea782dd82c6ddd5fcf22da2a3bb56e9d8b 100644
 --- a/net/minecraft/world/waypoints/WaypointTransmitter.java
 +++ b/net/minecraft/world/waypoints/WaypointTransmitter.java
 @@ -27,6 +27,12 @@ public interface WaypointTransmitter extends Waypoint {
              double broadcastRange = Math.min(
                  source.getAttributeValue(Attributes.WAYPOINT_TRANSMIT_RANGE), receiver.getAttributeValue(Attributes.WAYPOINT_RECEIVE_RANGE)
              );
-+            // Leaf start - Configurable locator bar range - clamp only, never widen what the attributes allow
++            // Leaf start - Configurable locator bar max distance
 +            final double configuredRange = org.dreeam.leaf.config.modules.gameplay.LocatorBarRange.maxDistance;
 +            if (configuredRange > 0.0D && configuredRange < broadcastRange) {
 +                broadcastRange = configuredRange;
 +            }
-+            // Leaf end - Configurable locator bar range
++            // Leaf end - Configurable locator bar max distance
              return source.distanceToSqr(receiver) >= Mth.square(broadcastRange); // Paper - optimize waypoint distance check by using squared distance
          } else {
              return true;

--- a/leaf-server/minecraft-patches/features/0327-Configurable-locator-bar-range.patch
+++ b/leaf-server/minecraft-patches/features/0327-Configurable-locator-bar-range.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HyperGaming99 <130169800+HyperGaming99@users.noreply.github.com>
+Date: Fri, 14 Aug 2026 04:52:05 +0200
+Subject: [PATCH] Configurable locator bar range
+
+Player waypoint range comes from the waypoint_transmit_range and
+waypoint_receive_range attributes, both of which default to 6.0E7 for
+players, so every player in a dimension ends up transmitted to every other
+one and the connection table grows quadratically.
+
+Clamp the effective range in WaypointTransmitter#doesSourceIgnoreReceiver.
+That is the choke point: ServerWaypointManager reaches it once through
+LivingEntity#makeWaypointConnectionWith when a connection is created, and
+again through isBroken() on all three connection types, so both new and
+existing connections respect the limit without touching any of them
+individually.
+
+Clamps only, never widens, so plugins or datapacks lowering the attributes
+still take precedence. Defaults to 0, which keeps vanilla behaviour.
+
+diff --git a/net/minecraft/world/waypoints/WaypointTransmitter.java b/net/minecraft/world/waypoints/WaypointTransmitter.java
+index 6077e1a0ae8448f4d975676f0eaf19ddbd45bd4b..7420f7d9970ff14f4228d79e472188aca10d5d4a 100644
+--- a/net/minecraft/world/waypoints/WaypointTransmitter.java
++++ b/net/minecraft/world/waypoints/WaypointTransmitter.java
+@@ -27,6 +27,12 @@ public interface WaypointTransmitter extends Waypoint {
+             double broadcastRange = Math.min(
+                 source.getAttributeValue(Attributes.WAYPOINT_TRANSMIT_RANGE), receiver.getAttributeValue(Attributes.WAYPOINT_RECEIVE_RANGE)
+             );
++            // Leaf start - Configurable locator bar range - clamp only, never widen what the attributes allow
++            final double configuredRange = org.dreeam.leaf.config.modules.gameplay.LocatorBarRange.maxDistance;
++            if (configuredRange > 0.0D && configuredRange < broadcastRange) {
++                broadcastRange = configuredRange;
++            }
++            // Leaf end - Configurable locator bar range
+             return source.distanceToSqr(receiver) >= Mth.square(broadcastRange); // Paper - optimize waypoint distance check by using squared distance
+         } else {
+             return true;

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/LocatorBarRange.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/LocatorBarRange.java
@@ -1,0 +1,39 @@
+package org.dreeam.leaf.config.modules.gameplay;
+
+import org.dreeam.leaf.config.ConfigModule;
+import org.dreeam.leaf.config.ConfigCategory;
+
+public class LocatorBarRange extends ConfigModule {
+
+    public String basePath() {
+        return ConfigCategory.GAMEPLAY.basePath();
+    }
+
+    public static double maxDistance = 0.0D;
+
+    @Override
+    public void onLoaded() {
+        maxDistance = globalConfig.getDouble(basePath() + ".locator-bar-max-distance", maxDistance, globalConfig.pickStringRegionBased("""
+                Maximum distance in blocks at which players show up on each other's
+                locator bar. Vanilla derives this from the waypoint_transmit_range and
+                waypoint_receive_range attributes, which default to 6.0E7 blocks, so
+                effectively every player in the dimension is transmitted.
+
+                Lowering this cuts the number of waypoint connections and the packets
+                they produce, which matters most on servers with many players in one
+                dimension. 100 is a reasonable starting point.
+
+                Set to 0 to keep vanilla behaviour. This never raises the range beyond
+                what the attributes allow, so plugins lowering those still win.""",
+            """
+                玩家在彼此定位栏上显示的最大距离 (单位: 方块).
+                原版通过 waypoint_transmit_range 和 waypoint_receive_range 属性决定该值,
+                其默认值为 6.0E7 方块, 因此实际上同维度内的所有玩家都会被传输.
+
+                降低此值可减少路径点连接数量及其产生的数据包,
+                在单一维度内玩家较多时效果最明显. 100 是一个合理的起点.
+
+                设置为 0 保持原版行为. 此选项不会超出属性允许的范围,
+                因此插件调低属性时仍以插件为准."""));
+    }
+}

--- a/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/LocatorBarRange.java
+++ b/leaf-server/src/main/java/org/dreeam/leaf/config/modules/gameplay/LocatorBarRange.java
@@ -15,25 +15,10 @@ public class LocatorBarRange extends ConfigModule {
     public void onLoaded() {
         maxDistance = globalConfig.getDouble(basePath() + ".locator-bar-max-distance", maxDistance, globalConfig.pickStringRegionBased("""
                 Maximum distance in blocks at which players show up on each other's
-                locator bar. Vanilla derives this from the waypoint_transmit_range and
-                waypoint_receive_range attributes, which default to 6.0E7 blocks, so
-                effectively every player in the dimension is transmitted.
-
-                Lowering this cuts the number of waypoint connections and the packets
-                they produce, which matters most on servers with many players in one
-                dimension. 100 is a reasonable starting point.
-
-                Set to 0 to keep vanilla behaviour. This never raises the range beyond
-                what the attributes allow, so plugins lowering those still win.""",
+                locator bar.
+                Set to 0 to keep vanilla behaviour.""",
             """
                 玩家在彼此定位栏上显示的最大距离 (单位: 方块).
-                原版通过 waypoint_transmit_range 和 waypoint_receive_range 属性决定该值,
-                其默认值为 6.0E7 方块, 因此实际上同维度内的所有玩家都会被传输.
-
-                降低此值可减少路径点连接数量及其产生的数据包,
-                在单一维度内玩家较多时效果最明显. 100 是一个合理的起点.
-
-                设置为 0 保持原版行为. 此选项不会超出属性允许的范围,
-                因此插件调低属性时仍以插件为准."""));
+                设置为 0 保持原版行为."""));
     }
 }


### PR DESCRIPTION
Adds `gameplay-mechanisms.locator-bar-max-distance`, a cap on how far away players show up on each other's locator bar. Defaults to `0`, which keeps vanilla behaviour.

### Why

Vanilla already derives the range from the `waypoint_transmit_range` and `waypoint_receive_range` attributes, but for players both default to `6.0E7` (`Player.java`):

```java
.add(Attributes.WAYPOINT_TRANSMIT_RANGE, 6.0E7)
.add(Attributes.WAYPOINT_RECEIVE_RANGE, 6.0E7);
```

So in practice every player in a dimension is transmitted to every other one, and the connection table in `ServerWaypointManager` grows quadratically. At 100 players that is roughly 9900 waypoint connections being updated and sent.

Servers that want the locator bar as a local awareness feature rather than a dimension-wide radar currently have no way to say so short of editing the attributes through a datapack or per-player modifiers.

### Implementation

One clamp in `WaypointTransmitter#doesSourceIgnoreReceiver`:

```java
double broadcastRange = Math.min(
    source.getAttributeValue(Attributes.WAYPOINT_TRANSMIT_RANGE), receiver.getAttributeValue(Attributes.WAYPOINT_RECEIVE_RANGE)
);
// Leaf start - Configurable locator bar range - clamp only, never widen what the attributes allow
final double configuredRange = org.dreeam.leaf.config.modules.gameplay.LocatorBarRange.maxDistance;
if (configuredRange > 0.0D && configuredRange < broadcastRange) {
    broadcastRange = configuredRange;
}
// Leaf end - Configurable locator bar range
return source.distanceToSqr(receiver) >= Mth.square(broadcastRange);
```

That method is the choke point both paths already route through, so one hook covers everything:

- connection creation, via `LivingEntity#makeWaypointConnectionWith`
- `isBroken()` on all three connection types (azimuth, block, chunk)

New connections stop forming beyond the limit, and existing ones report broken so `ServerWaypointManager#updateConnection` disconnects them. Neither call site needed changing.

The value **clamps only, it never widens**. If a plugin or datapack lowers the attributes below the configured value, the attributes still win.

### What this does not do

The pair scan itself is unchanged. `ServerWaypointManager#updatePlayer` and `#updateWaypoint` still walk every player/waypoint combination; what the cap removes is the connection objects and the packets, not the distance checks. Narrowing the scan would need a spatial pre-filter and is a separate change, and I have not profiled whether it is worth the complexity.

### Testing

Built and booted against `ver/26.2`. Verified that the config entry is generated, that the compiled `WaypointTransmitter` reads `LocatorBarRange.maxDistance` before the `Mth.square` call, and that the server starts cleanly with the option set.
