### PR TITLE
Drop FishHook related part of random source reduce

### DIFF
--- a/leaf-server/minecraft-patches/features/0077-Reduce-RandomSource-instances.patch
+++ b/leaf-server/minecraft-patches/features/0077-Reduce-RandomSource-instances.patch
@@ -38,27 +38,6 @@ index 9c29b275236ad8a79beb130199113dcbda948a14..f036c4eaf68e957333bdb4b81be0010c
              this.challengeBytes = String.format(Locale.ROOT, "\t%s%d\u0000", this.ident, this.challenge).getBytes(StandardCharsets.UTF_8);
          }
  
-diff --git a/net/minecraft/world/entity/projectile/FishingHook.java b/net/minecraft/world/entity/projectile/FishingHook.java
-index c0bb1b62dfcdebbd34a8e8423fa36eb4924a55e5..2cb1bf6cb7f2f8b6b4bf7b22f4f2ca4fa256e5b0 100644
---- a/net/minecraft/world/entity/projectile/FishingHook.java
-+++ b/net/minecraft/world/entity/projectile/FishingHook.java
-@@ -52,7 +52,7 @@ import org.slf4j.Logger;
- 
- public class FishingHook extends Projectile {
-     private static final Logger LOGGER = LogUtils.getLogger();
--    private final RandomSource syncronizedRandom = RandomSource.create();
-+    private final RandomSource syncronizedRandom; // Gale - Patina - reduce RandomSource instances
-     private boolean biting;
-     public int outOfWaterTime;
-     private static final int MAX_OUT_OF_WATER_TIME = 10;
-@@ -90,6 +90,7 @@ public class FishingHook extends Projectile {
-         this.minWaitTime = level.paperConfig().fishingTimeRange.minimum;
-         this.maxWaitTime = level.paperConfig().fishingTimeRange.maximum;
-         // Paper end - Configurable fishing time ranges
-+        this.syncronizedRandom = level.getRandom(); // Gale - Patina - reduce RandomSource instances
-     }
- 
-     public FishingHook(final EntityType<? extends FishingHook> type, final Level level) {
 diff --git a/net/minecraft/world/entity/raid/Raid.java b/net/minecraft/world/entity/raid/Raid.java
 index 35b25e737e0671dc7ab366956c329ab8c90df1e6..e7a1786369d0d541de8884579b0adefeda4d2d23 100644
 --- a/net/minecraft/world/entity/raid/Raid.java


### PR DESCRIPTION
Fishing hook random cannot be shared, it will call `setSeed` on every tick and cause state corruption.

<img width="1336" height="296" alt="image" src="https://github.com/user-attachments/assets/5f6534d9-276f-4f33-87f4-121fee66a521" />
